### PR TITLE
feat: Add deprecated animation analyzer

### DIFF
--- a/Sources/SwiftProjectLintCore/Animation/AnimationVisitor.swift
+++ b/Sources/SwiftProjectLintCore/Animation/AnimationVisitor.swift
@@ -3,6 +3,12 @@ import SwiftSyntax
 /// A SwiftSyntax visitor that detects the use of the deprecated `.animation()` modifier in SwiftUI.
 class AnimationVisitor: BasePatternVisitor {
 
+    private var currentFilePath: String = ""
+
+    override func setFilePath(_ filePath: String) {
+        self.currentFilePath = filePath
+    }
+
     override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
         // We are looking for `.animation(...)`
         guard let calledExpression = node.calledExpression.as(MemberAccessExprSyntax.self),


### PR DESCRIPTION
Adds a new linter check to detect the use of the deprecated .animation() modifier in SwiftUI.

This change introduces a new 'Animation' category and a new rule to identify the use of the deprecated '.animation()' modifier. The linter will now suggest replacing it with the modern, value-based animation modifier to improve performance and prevent unexpected behavior.