### PR TITLE
Round 9: strict_replayable context tier + cross-file suppression fixes

### DIFF
--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Suppression/InlineSuppressionFilter.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Suppression/InlineSuppressionFilter.swift
@@ -3,9 +3,15 @@ import Foundation
 
 /// Filters lint issues according to inline suppression comments in the source file.
 ///
-/// Inline suppression only applies to per-file issues. Cross-file issues (e.g. duplicate
-/// state across view hierarchies) are not affected, as their line numbers span multiple
-/// files and a single-file comment cannot unambiguously reference them.
+/// Works per-file: callers supply issues *for a single file* plus that file's source
+/// text. Per-file rules go through `analyzeFile`; cross-file rules are grouped by
+/// their primary file (first `LintIssue.locations` entry) and filtered via
+/// `ProjectLinter.applyInlineSuppression(to:files:)`.
+///
+/// Multi-location issues (a single diagnostic pointing at several files — rare for
+/// idempotency rules, more common for duplicate-state rules) are filtered against
+/// the primary file only. If you want suppression to respect every location, place a
+/// `swiftprojectlint:disable`-shaped comment at the primary file's site.
 public struct InlineSuppressionFilter {
 
     /// Returns `issues` with any suppressed violations removed.

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
@@ -172,7 +172,10 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
                 preBuiltCache: astCache
             )
         }
-        issues.append(contentsOf: crossFilePatternIssues)
+        issues.append(contentsOf: Self.applyInlineSuppression(
+            to: crossFilePatternIssues,
+            files: projectFiles
+        ))
 
         // Apply per-rule overrides (severity changes, per-rule path exclusions)
         return effectiveConfiguration.applyOverrides(to: issues, projectRoot: path)
@@ -293,5 +296,45 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
 
         let issues = InlineSuppressionFilter.filter(rawIssues, fileContent: content)
         return (file: file, issues: issues, parsedAST: parsedAST)
+    }
+
+    /// Applies inline-suppression filtering to cross-file issues. Grouped
+    /// by the issue's primary file (`LintIssue.filePath` — the first
+    /// location) and filtered against that file's content. Issues whose
+    /// primary file is not in the project-files set (defensive — shouldn't
+    /// normally happen) pass through unfiltered so no diagnostic goes
+    /// missing.
+    ///
+    /// Per-file issues are already filtered inside `analyzeFile`. Cross-
+    /// file issues are emitted by `CrossFileAnalysisEngine` and
+    /// previously bypassed suppression entirely; this method closes that
+    /// gap so `// swiftprojectlint:disable*` comments work equivalently
+    /// for both rule kinds.
+    private static func applyInlineSuppression(
+        to crossFileIssues: [LintIssue],
+        files: [ProjectFile]
+    ) -> [LintIssue] {
+        guard !crossFileIssues.isEmpty else { return crossFileIssues }
+
+        let contentByRelativePath = Dictionary(
+            uniqueKeysWithValues: files.map { ($0.relativePath, $0.content) }
+        )
+
+        let grouped = Dictionary(grouping: crossFileIssues) { $0.filePath }
+        var filtered: [LintIssue] = []
+        filtered.reserveCapacity(crossFileIssues.count)
+
+        for (filePath, issuesInFile) in grouped {
+            guard let content = contentByRelativePath[filePath] else {
+                filtered.append(contentsOf: issuesInFile)
+                continue
+            }
+            filtered.append(contentsOf: InlineSuppressionFilter.filter(
+                issuesInFile,
+                fileContent: content
+            ))
+        }
+
+        return filtered
     }
 }

--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
@@ -190,6 +190,7 @@ public enum RuleIdentifier: String, CaseIterable, Codable, Sendable {
     case nonIdempotentInRetryContext = "Non-Idempotent In Retry Context"
     case missingIdempotencyKey = "Missing Idempotency Key"
     case onceContractViolation = "Once Contract Violation"
+    case unannotatedInStrictReplayableContext = "Unannotated In Strict Replayable Context"
 
     // Other/System Rules
     case fileParsingError = "File Parsing Error"
@@ -304,7 +305,7 @@ public enum RuleIdentifier: String, CaseIterable, Codable, Sendable {
 
             // Idempotency Rules
         case .idempotencyViolation, .nonIdempotentInRetryContext, .missingIdempotencyKey,
-             .onceContractViolation:
+             .onceContractViolation, .unannotatedInStrictReplayableContext:
             return .idempotency
 
             // Other/System Rules

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/BuiltInRuleRegistration.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/BuiltInRuleRegistration.swift
@@ -11,10 +11,19 @@ public enum BuiltInRules {
     nonisolated(unsafe) private static var registered = false
 
     public static func registerAll() {
-        lock.withLock {
-            guard !registered else { return }
+        // Guard against double-registration. The `withLock` closure returns
+        // `true` when this call should become a no-op (another call already
+        // registered the factories). The previous form — `guard else { return }`
+        // inside the closure — only returned from the closure, so factories
+        // got appended on every call; the resulting per-call pattern growth
+        // bloated `SourcePatternRegistry` iteration under test workloads
+        // where `createConfiguredSystem()` is invoked repeatedly.
+        let alreadyRegistered: Bool = lock.withLock {
+            if registered { return true }
             registered = true
+            return false
         }
+        if alreadyRegistered { return }
 
         SourcePatternRegistry.registerFactory { registry, visitorRegistry in
             StateManagement(registry: registry, visitorRegistry: visitorRegistry)

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/PatternRegistrars/Idempotency.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/PatternRegistrars/Idempotency.swift
@@ -14,7 +14,8 @@ class Idempotency: BasePatternRegistrar {
             IdempotencyViolation(),
             NonIdempotentInRetryContext(),
             MissingIdempotencyKey(),
-            OnceContractViolation()
+            OnceContractViolation(),
+            UnannotatedInStrictReplayableContext()
         ])
     }
 }

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/PatternRegistrars/UnannotatedInStrictReplayableContext.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/PatternRegistrars/UnannotatedInStrictReplayableContext.swift
@@ -1,0 +1,30 @@
+import SwiftProjectLintModels
+import SwiftProjectLintRegistry
+import SwiftProjectLintVisitors
+import Foundation
+
+/// A registrar for the `unannotatedInStrictReplayableContext` rule.
+///
+/// Flags calls inside `/// @lint.context strict_replayable` functions to
+/// callees whose effect is not declared, upward-inferred, or
+/// heuristically classified. Opt-in strict-mode variant of
+/// `replayable` — see the round-9 trial retrospective.
+struct UnannotatedInStrictReplayableContext: PatternRegistrarProtocol {
+
+    var pattern: SyntaxPattern {
+        SyntaxPattern(
+            name: .unannotatedInStrictReplayableContext,
+            visitor: UnannotatedInStrictReplayableContextVisitor.self,
+            severity: .error,
+            category: .idempotency,
+            messageTemplate: "Unannotated call inside a strict_replayable context.",
+            suggestion: "Annotate the callee with `/// @lint.effect idempotent` / "
+                + "`observational` / `externally_idempotent(by:)`, or use the "
+                + "`SwiftIdempotency` attribute forms.",
+            description: "Detects functions declared `/// @lint.context strict_replayable` "
+                + "whose body calls a function whose effect cannot be proven through "
+                + "declaration, upward inference, or heuristic classification. The "
+                + "opt-in strict variant of the `replayable` rule's precision profile."
+        )
+    }
+}

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/Visitors/OnceContractViolationVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/Visitors/OnceContractViolationVisitor.swift
@@ -159,7 +159,9 @@ final class OnceContractViolationVisitor: BasePatternVisitor, CrossFilePatternVi
     ) {
         let inLoop = isInsideLoopBody(call: call, withinFunctionBody: site.function.body)
         let callerContext = site.callerContext
-        let isReplayableCaller = callerContext == .replayable || callerContext == .retrySafe
+        let isReplayableCaller = callerContext == .replayable
+            || callerContext == .retrySafe
+            || callerContext == .strictReplayable
 
         guard inLoop || isReplayableCaller else { return }
 
@@ -180,7 +182,12 @@ final class OnceContractViolationVisitor: BasePatternVisitor, CrossFilePatternVi
         let trigger: String
         let detail: String
         if inLoop && isReplayableCaller {
-            let contextLabel = callerContext == .replayable ? "replayable" : "retry_safe"
+            let contextLabel: String
+            switch callerContext {
+            case .replayable: contextLabel = "replayable"
+            case .strictReplayable: contextLabel = "strict_replayable"
+            default: contextLabel = "retry_safe"
+            }
             trigger = "inside a loop within a `\(contextLabel)` body"
             detail = "the loop will re-invoke '\(calleeName)' on every iteration, and "
                 + "every replay/retry of '\(callerName)' compounds that re-invocation."
@@ -188,7 +195,12 @@ final class OnceContractViolationVisitor: BasePatternVisitor, CrossFilePatternVi
             trigger = "inside a loop"
             detail = "the loop will re-invoke '\(calleeName)' on every iteration."
         } else {
-            let contextLabel = callerContext == .replayable ? "replayable" : "retry_safe"
+            let contextLabel: String
+            switch callerContext {
+            case .replayable: contextLabel = "replayable"
+            case .strictReplayable: contextLabel = "strict_replayable"
+            default: contextLabel = "retry_safe"
+            }
             trigger = "from a `\(contextLabel)` body"
             detail = "every replay/retry of '\(callerName)' will re-invoke '\(calleeName)'."
         }

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/Visitors/UnannotatedInStrictReplayableContextVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/Visitors/UnannotatedInStrictReplayableContextVisitor.swift
@@ -3,33 +3,52 @@ import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors
 import SwiftSyntax
 
-/// Detects functions declared `/// @lint.context replayable` or `/// @lint.context retry_safe`
-/// whose body calls a function declared `/// @lint.effect non_idempotent` anywhere in
-/// the project. Resolution is cross-file via the shared `EffectSymbolTable`, subject
-/// to the table's collision policy.
+/// Detects functions declared `/// @lint.context strict_replayable` whose
+/// body calls a function whose effect cannot be proven. The "strict" in
+/// `strict_replayable` flips the default for unannotated callees — under
+/// `replayable`, unannotated callees are silent; under
+/// `strict_replayable`, they fire this rule.
 ///
-/// ## Cross-file dispatch
-/// Conforms to `CrossFilePatternVisitorProtocol`. Walk phase accumulates the symbol
-/// table and analysis sites; emission happens in `finalizeAnalysis()` so the per-file
-/// dispatcher produces no double-emits.
+/// ## Firing condition
 ///
-/// Closure-traversal policy mirrors `IdempotencyViolationVisitor` — non-escaping only.
-final class NonIdempotentInRetryContextVisitor: BasePatternVisitor, CrossFilePatternVisitorProtocol {
+/// A callee fires the rule iff **none** of the following hold:
+///
+///   - Declared effect via the symbol table (any tier — even
+///     `non_idempotent` defers, because `nonIdempotentInRetryContext`
+///     already fires on that).
+///   - Upward-inferred effect (any tier, same rationale).
+///   - Heuristic effect inference returned a classification — either
+///     `nonIdempotent` (existing rule handles) or a positive tier
+///     (trusted as a prove-enough signal for strict mode, matching the
+///     round-5/6 precision profile).
+///   - Symbol-table collision (annotated with conflicting effects; no
+///     inference runs; no double-diagnostic).
+///
+/// Only callees that reach the fall-through "no evidence" branch fire
+/// this rule. That's the whole gap strict mode closes.
+///
+/// ## Relationship to `nonIdempotentInRetryContext`
+///
+/// This rule does not replicate the existing rule's diagnostic on
+/// `non_idempotent` callees in a strict_replayable body — that firing
+/// comes from the existing rule, which already treats
+/// `strict_replayable` as a retry-context caller (identical label
+/// plumbing). Strict mode only *adds* the unannotated-callee case.
+///
+/// Round-9 / phase-2 strict-replayable slice. See
+/// `docs/claude_phase_2_strict_replayable_plan.md`.
+final class UnannotatedInStrictReplayableContextVisitor:
+    BasePatternVisitor, CrossFilePatternVisitorProtocol
+{
 
     let fileCache: [String: SourceFileSyntax]
 
     private var symbolTable = EffectSymbolTable()
     private var analysisSites: [AnalysisSite] = []
 
-    /// A location in source that carries a `@lint.context` annotation and
-    /// whose body the rule will walk. Uniformly represents both function
-    /// declarations and closure-initialised variable bindings — the rule
-    /// only needs the name (for prose), the body (for traversal), the
-    /// context, and file/location info.
     private struct AnalysisSite {
         let callerName: String
         let body: Syntax
-        let context: ContextEffect
         let filePath: String
         let locationConverter: SourceLocationConverter
     }
@@ -63,7 +82,7 @@ final class NonIdempotentInRetryContextVisitor: BasePatternVisitor, CrossFilePat
     }
 
     override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
-        guard let context = EffectAnnotationParser.parseContext(declaration: node),
+        guard EffectAnnotationParser.parseContext(declaration: node) == .strictReplayable,
               let body = node.body else {
             return .visitChildren
         }
@@ -73,7 +92,6 @@ final class NonIdempotentInRetryContextVisitor: BasePatternVisitor, CrossFilePat
             AnalysisSite(
                 callerName: node.name.text,
                 body: Syntax(body),
-                context: context,
                 filePath: currentFilePath,
                 locationConverter: converter
             )
@@ -81,14 +99,8 @@ final class NonIdempotentInRetryContextVisitor: BasePatternVisitor, CrossFilePat
         return .visitChildren
     }
 
-    /// Closure-binding annotation (Phase 2 third slice). A `let`/`var` with
-    /// a closure-literal initialiser and a `@lint.context` annotation is
-    /// treated analogously to an annotated function: the closure's body is
-    /// walked under the declared context, and non-idempotent calls inside
-    /// it produce diagnostics. Multi-binding decls and non-closure
-    /// initialisers are silently skipped.
     override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
-        guard let context = EffectAnnotationParser.parseContext(declaration: node),
+        guard EffectAnnotationParser.parseContext(declaration: node) == .strictReplayable,
               let closure = node.closureInitializer,
               let name = node.firstBindingName else {
             return .visitChildren
@@ -99,7 +111,6 @@ final class NonIdempotentInRetryContextVisitor: BasePatternVisitor, CrossFilePat
             AnalysisSite(
                 callerName: name,
                 body: Syntax(closure.statements),
-                context: context,
                 filePath: currentFilePath,
                 locationConverter: converter
             )
@@ -108,12 +119,6 @@ final class NonIdempotentInRetryContextVisitor: BasePatternVisitor, CrossFilePat
     }
 
     func finalizeAnalysis() {
-        // Phase-2.3 upward inference — see IdempotencyViolationVisitor for
-        // rationale. Runs before the body walk so every lookup in
-        // analyzeCall can consult upward-inferred entries. `multiHop: true`
-        // enables fixed-point propagation across chains of un-annotated
-        // helpers between the `@context replayable` boundary and the
-        // non-idempotent leaf.
         let allSources = Array(fileCache.values)
         symbolTable.applyUpwardInference(
             to: allSources,
@@ -133,11 +138,8 @@ final class NonIdempotentInRetryContextVisitor: BasePatternVisitor, CrossFilePat
     private func analyzeBody(_ syntax: Syntax, site: AnalysisSite) {
         if syntax.is(FunctionDeclSyntax.self) { return }
         // Nested closure-initialised variable bindings that carry their
-        // own `@lint.context` annotation are independent analysis sites.
-        // Don't descend — calls inside would otherwise be attributed to
-        // the outer context. Unannotated closure-bound bindings keep the
-        // old behaviour: they inherit the outer site's context and are
-        // walked through.
+        // own `@lint.context` annotation are independent analysis sites;
+        // don't descend.
         if let varDecl = syntax.as(VariableDeclSyntax.self),
            varDecl.closureInitializer != nil,
            EffectAnnotationParser.parseContext(declaration: varDecl) != nil {
@@ -156,52 +158,38 @@ final class NonIdempotentInRetryContextVisitor: BasePatternVisitor, CrossFilePat
         }
     }
 
-    /// Resolves the callee's effect via the symbol table, falling back to
-    /// Phase-2 heuristic inference for un-annotated callees. Declared effects
-    /// always win. Only `non_idempotent` (declared or inferred) fires this
-    /// rule; `idempotent`, `observational`, and `externally_idempotent`
-    /// callees pass silently in a retry context.
     private func analyzeCall(_ call: FunctionCallExprSyntax, site: AnalysisSite) {
         guard let calleeSignature = FunctionSignature.from(call: call) else { return }
 
-        let calleeEffect: DeclaredEffect
-        let calleeClaim: String
-        let overrideHint: String
-
-        if let declared = symbolTable.effect(for: calleeSignature) {
-            calleeEffect = declared
-            calleeClaim = "which is declared `@lint.effect non_idempotent`"
-            overrideHint = ""
-        } else if symbolTable.isCollision(signature: calleeSignature) {
-            // Collision-withdrawn: annotated with conflicting effects. Neither
-            // upward nor downward inference runs.
-            return
-        } else if let upward = symbolTable.upwardInference(for: calleeSignature) {
-            calleeEffect = upward.effect
-            let chainHint = upward.depth > 1
-                ? " via \(upward.depth)-hop chain of un-annotated callees"
-                : ""
-            calleeClaim = "whose effect is inferred `non_idempotent` from its body\(chainHint)"
-            overrideHint = " If the inference is wrong, annotate '\(calleeSignature.name)' "
-                + "explicitly with `/// @lint.effect <tier>` to override the body-based inference."
-        } else if let inferred = HeuristicEffectInferrer.infer(call: call) {
-            calleeEffect = inferred
-            let reason = HeuristicEffectInferrer.inferenceReason(for: call) ?? ""
-            calleeClaim = "whose effect is inferred `non_idempotent` \(reason)"
-            overrideHint = " If the inference is wrong, annotate '\(calleeSignature.name)' "
-                + "explicitly with `/// @lint.effect <tier>` to override."
-        } else {
+        // Structural-concurrency and SwiftUI task primitives — `Task { ... }`,
+        // `Task.detached { ... }`, `withTaskGroup`, `.task { }`, etc. These
+        // aren't effect-bearing calls; they're scoping primitives. The
+        // existing rule filters them implicitly because it only fires on
+        // declared/inferred `non_idempotent`; strict mode needs an
+        // explicit exclusion or it fires on every `Task { }` in a
+        // strict-replayable body.
+        if let bareName = directCalleeName(from: call.calledExpression),
+           escapingCalleeNames.contains(bareName) {
             return
         }
 
-        guard calleeEffect == .nonIdempotent else { return }
+        // Any declared effect — even non_idempotent — means the callee is
+        // classified. `nonIdempotentInRetryContext` handles the negative
+        // case; positive tiers pass silently.
+        if symbolTable.effect(for: calleeSignature) != nil { return }
 
-        let contextLabel: String
-        switch site.context {
-        case .replayable: contextLabel = "replayable"
-        case .strictReplayable: contextLabel = "strict_replayable"
-        case .retrySafe, .once: contextLabel = "retry_safe"
-        }
+        // Collision-withdrawn: do not double-fire.
+        if symbolTable.isCollision(signature: calleeSignature) { return }
+
+        // Upward-inferred classification (from sub-graph analysis) also
+        // counts as "proven" for strict-mode purposes.
+        if symbolTable.upwardInference(for: calleeSignature) != nil { return }
+
+        // Heuristic inferrer returning any classification counts — either
+        // the existing rule handles it, or it's a positive signal.
+        if HeuristicEffectInferrer.infer(call: call) != nil { return }
+
+        // Fall through: no evidence of the callee's effect. Fire.
         let callerName = site.callerName
         let calleeName = calleeSignature.name
         let line = site.locationConverter.location(
@@ -210,14 +198,20 @@ final class NonIdempotentInRetryContextVisitor: BasePatternVisitor, CrossFilePat
 
         addIssue(
             severity: pattern.severity,
-            message: "Non-idempotent call in \(contextLabel) context: '\(callerName)' is declared "
-                + "`@lint.context \(contextLabel)` but calls '\(calleeName)', \(calleeClaim)."
-                + overrideHint,
+            message: "Unannotated call in strict_replayable context: '\(callerName)' is "
+                + "declared `@lint.context strict_replayable` but calls '\(calleeName)', "
+                + "whose effect is not declared and cannot be inferred from its body. "
+                + "Under strict mode, every callee must be provably idempotent, "
+                + "observational, or externally-keyed.",
             filePath: site.filePath,
             lineNumber: line,
-            suggestion: "Replace '\(calleeName)' with an idempotent alternative, or route the call "
-                + "through a deduplication guard or idempotency-key mechanism.",
-            ruleName: .nonIdempotentInRetryContext
+            suggestion: "Annotate '\(calleeName)' with `/// @lint.effect idempotent` if "
+                + "re-invocation produces no additional observable effects; `observational` "
+                + "for logging/metrics/tracing primitives; `externally_idempotent(by: <param>)` "
+                + "for calls routed through a caller-supplied deduplication key. Or use the "
+                + "attribute forms (`@Idempotent`, `@Observational`, "
+                + "`@ExternallyIdempotent(by:)`) from the `SwiftIdempotency` macros package.",
+            ruleName: .unannotatedInStrictReplayableContext
         )
     }
 

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/EffectAnnotationParser.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/EffectAnnotationParser.swift
@@ -31,17 +31,25 @@ public enum DeclaredEffect: Sendable, Equatable {
 ///
 /// - `replayable` / `retry_safe` are semantically equivalent to the linter:
 ///   both impose "callees must be idempotent" on the body. Only the
-///   documentation intent differs.
+///   documentation intent differs. The `nonIdempotentInRetryContext` rule
+///   fires on callees declared/inferred `non_idempotent`; unannotated
+///   callees stay silent (precision-preserving default).
+/// - `strictReplayable` is the opt-in strict variant of `replayable`. The
+///   additional `unannotatedInStrictReplayableContext` rule fires on
+///   callees whose effect can't be proven idempotent/observational —
+///   "flag unless you know for sure." Adopters promote critical
+///   handlers to this tier and leave less-critical ones on `replayable`.
 /// - `once` is the inverse contract: the function asserts that it must run
 ///   at most once across all replays, retries, or iterations. The
 ///   `onceContractViolation` rule fires when a `@context once` callee
 ///   appears in a position where it could be re-invoked (loop body,
-///   `replayable` / `retry_safe` caller).
+///   `replayable` / `retry_safe` / `strict_replayable` caller).
 /// - `dedup_guarded` remains out of scope.
 public enum ContextEffect: Sendable, Equatable {
     case replayable
     case retrySafe
     case once
+    case strictReplayable
 }
 
 /// Parses `/// @lint.effect <tier>` and `/// @lint.context <kind>` from the doc-comment
@@ -336,6 +344,8 @@ public enum EffectAnnotationParser {
             return .retrySafe
         case "once":
             return .once
+        case "strict_replayable":
+            return .strictReplayable
         default:
             return nil
         }

--- a/Tests/CoreTests/Idempotency/StrictReplayableContextParsingTests.swift
+++ b/Tests/CoreTests/Idempotency/StrictReplayableContextParsingTests.swift
@@ -1,0 +1,118 @@
+import Testing
+@testable import SwiftProjectLintVisitors
+import SwiftSyntax
+import SwiftParser
+
+/// Parsing-level coverage for `/// @lint.context strict_replayable`. The
+/// visitor-level behaviour (new diagnostic firing on unannotated callees)
+/// is covered by `UnannotatedInStrictReplayableContextVisitorTests`.
+///
+/// Round-9 / phase-2 strict-replayable slice. See
+/// `docs/claude_phase_2_strict_replayable_plan.md`.
+@Suite
+struct StrictReplayableContextParsingTests {
+
+    private func firstFunctionDecl(in source: String) throws -> FunctionDeclSyntax {
+        final class Finder: SyntaxVisitor {
+            var decl: FunctionDeclSyntax?
+            init() { super.init(viewMode: .sourceAccurate) }
+            override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+                if decl == nil { decl = node }
+                return .skipChildren
+            }
+        }
+        let finder = Finder()
+        finder.walk(Parser.parse(source: source))
+        return try #require(finder.decl)
+    }
+
+    private func allFunctionDecls(in source: String) -> [FunctionDeclSyntax] {
+        final class Finder: SyntaxVisitor {
+            var decls: [FunctionDeclSyntax] = []
+            init() { super.init(viewMode: .sourceAccurate) }
+            override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+                decls.append(node)
+                return .skipChildren
+            }
+        }
+        let finder = Finder()
+        finder.walk(Parser.parse(source: source))
+        return finder.decls
+    }
+
+    private func firstVariableDecl(in source: String) throws -> VariableDeclSyntax {
+        final class Finder: SyntaxVisitor {
+            var decl: VariableDeclSyntax?
+            init() { super.init(viewMode: .sourceAccurate) }
+            override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+                if decl == nil { decl = node }
+                return .skipChildren
+            }
+        }
+        let finder = Finder()
+        finder.walk(Parser.parse(source: source))
+        return try #require(finder.decl)
+    }
+
+    @Test
+    func contextAnnotation_strictReplayable_parses_onFunction() throws {
+        let decl = try firstFunctionDecl(
+            in: """
+            /// @lint.context strict_replayable
+            func handle(_ event: String) async throws {}
+            """
+        )
+        #expect(EffectAnnotationParser.parseContext(declaration: decl) == .strictReplayable)
+    }
+
+    @Test
+    func contextAnnotation_strictReplayable_parses_onClosureBinding() throws {
+        let decl = try firstVariableDecl(
+            in: """
+            /// @lint.context strict_replayable
+            let handler = { event in print(event) }
+            """
+        )
+        #expect(EffectAnnotationParser.parseContext(declaration: decl) == .strictReplayable)
+    }
+
+    @Test
+    func contextAnnotation_strictReplayable_distinctFromReplayable() {
+        let decls = allFunctionDecls(
+            in: """
+            /// @lint.context replayable
+            func relaxed() {}
+            /// @lint.context strict_replayable
+            func strict() {}
+            """
+        )
+        #expect(decls.count == 2)
+        #expect(EffectAnnotationParser.parseContext(declaration: decls[0]) == .replayable)
+        #expect(EffectAnnotationParser.parseContext(declaration: decls[1]) == .strictReplayable)
+    }
+
+    @Test
+    func contextAnnotation_unknownVariant_returnsNil() throws {
+        let decl = try firstFunctionDecl(
+            in: """
+            /// @lint.context ultra_strict_replayable
+            func handle() {}
+            """
+        )
+        #expect(EffectAnnotationParser.parseContext(declaration: decl) == nil)
+    }
+
+    @Test
+    func contextAnnotation_strictReplayable_withTrailingContent_stillParses() throws {
+        // The parser reads only the first whitespace-separated token after
+        // `@lint.context`, so trailing content is tolerated. Documents
+        // present behaviour rather than enforcing a specific policy.
+        let decl = try firstFunctionDecl(
+            in: """
+            /// @lint.context strict_replayable reason: "SQS at-least-once"
+            func handle() {}
+            """
+        )
+        #expect(EffectAnnotationParser.parseContext(declaration: decl) == .strictReplayable)
+    }
+}

--- a/Tests/CoreTests/Idempotency/UnannotatedInStrictReplayableContextVisitorTests.swift
+++ b/Tests/CoreTests/Idempotency/UnannotatedInStrictReplayableContextVisitorTests.swift
@@ -1,0 +1,462 @@
+import Testing
+@testable import Core
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import SwiftParser
+
+/// Unit tests for the `unannotatedInStrictReplayableContext` rule —
+/// round-9 strict-replayable slice. See
+/// `docs/claude_phase_2_strict_replayable_plan.md`.
+@Suite
+struct UnannotatedInStrictReplayableContextVisitorTests {
+
+    private func makeVisitor() -> UnannotatedInStrictReplayableContextVisitor {
+        let pattern = UnannotatedInStrictReplayableContext().pattern
+        return UnannotatedInStrictReplayableContextVisitor(pattern: pattern)
+    }
+
+    private func run(source: String) -> UnannotatedInStrictReplayableContextVisitor {
+        let visitor = makeVisitor()
+        let sourceFile = Parser.parse(source: source)
+        visitor.walk(sourceFile)
+        visitor.analyze()
+        return visitor
+    }
+
+    /// File-cache variant for tests that depend on upward inference. The
+    /// symbol table's `applyUpwardInference` only traverses files passed
+    /// via the cache; the bare-visitor `init(pattern:)` path leaves the
+    /// cache empty and upward inference is a no-op.
+    private func runWithCache(
+        _ files: [String: String]
+    ) -> UnannotatedInStrictReplayableContextVisitor {
+        let cache: [String: SourceFileSyntax] = files.mapValues { Parser.parse(source: $0) }
+        let visitor = UnannotatedInStrictReplayableContextVisitor(fileCache: cache)
+        visitor.setPattern(UnannotatedInStrictReplayableContext().pattern)
+        for (path, source) in cache {
+            visitor.setFilePath(path)
+            visitor.setSourceLocationConverter(
+                SourceLocationConverter(fileName: path, tree: source)
+            )
+            visitor.walk(source)
+        }
+        visitor.finalizeAnalysis()
+        return visitor
+    }
+
+    // MARK: - Core positive cases — rule fires on unclassified callees
+
+    @Test
+    func strictReplayable_unannotatedCallee_flags() throws {
+        let source = """
+        func mystery(_ id: Int) async throws {}
+
+        /// @lint.context strict_replayable
+        func handle(_ id: Int) async throws {
+            try await mystery(id)
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.count == 1)
+        let issue = try #require(visitor.detectedIssues.first)
+        #expect(issue.ruleName == .unannotatedInStrictReplayableContext)
+        #expect(issue.message.contains("mystery"))
+        #expect(issue.message.contains("strict_replayable"))
+    }
+
+    @Test
+    func strictReplayable_multipleUnannotatedCallees_eachFlagged() throws {
+        let source = """
+        func alpha() {}
+        func beta() {}
+        func gamma() {}
+
+        /// @lint.context strict_replayable
+        func handle() async throws {
+            alpha()
+            beta()
+            gamma()
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.count == 3)
+    }
+
+    // MARK: - Core negative cases — proven classifications pass silently
+
+    @Test
+    func strictReplayable_declaredIdempotentCallee_silent() {
+        let source = """
+        /// @lint.effect idempotent
+        func upsert(_ id: Int) async throws {}
+
+        /// @lint.context strict_replayable
+        func handle(_ id: Int) async throws {
+            try await upsert(id)
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    @Test
+    func strictReplayable_declaredObservationalCallee_silent() {
+        let source = """
+        /// @lint.effect observational
+        func audit(_ message: String) {}
+
+        /// @lint.context strict_replayable
+        func handle() async throws {
+            audit("hello")
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    @Test
+    func strictReplayable_externallyIdempotentCallee_silent() {
+        let source = """
+        /// @lint.effect externally_idempotent(by: "key")
+        func sendEmail(idempotencyKey: String) async throws {}
+
+        /// @lint.context strict_replayable
+        func handle() async throws {
+            try await sendEmail(idempotencyKey: "evt_1")
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    @Test
+    func strictReplayable_declaredNonIdempotentCallee_silent_existingRuleHandles() {
+        // A declared non_idempotent callee is classified — the EXISTING
+        // `nonIdempotentInRetryContext` rule fires. This visitor must
+        // defer to avoid double-firing.
+        let source = """
+        /// @lint.effect non_idempotent
+        func insert(_ id: Int) async throws {}
+
+        /// @lint.context strict_replayable
+        func handle(_ id: Int) async throws {
+            try await insert(id)
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    // MARK: - Heuristic classification defers
+
+    @Test
+    func strictReplayable_heuristicNonIdempotentCallee_silent() {
+        // `sendNotification` matches the prefix heuristic → nonIdempotent.
+        // Existing rule handles; this visitor defers.
+        let source = """
+        func sendNotification(to: String) async throws {}
+
+        /// @lint.context strict_replayable
+        func handle() async throws {
+            try await sendNotification(to: "alice")
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    @Test
+    func strictReplayable_heuristicObservationalCallee_silent() {
+        // A logger-shaped receiver plus a log-level method matches the
+        // observational heuristic. `logger` comes in as a parameter so
+        // the test doesn't first trip over the `Logger(label:)`
+        // constructor call (which would itself be unclassified).
+        struct LoggerStub { func info(_ message: String) {} }
+        _ = LoggerStub.self  // suppress unused-type warning in release builds
+
+        let source = """
+        struct LoggerStub { func info(_ message: String) {} }
+
+        /// @lint.context strict_replayable
+        func handle(logger: LoggerStub) async throws {
+            logger.info("event received")
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    // MARK: - Upward inference defers
+
+    @Test
+    func strictReplayable_upwardInferredCallee_silent() {
+        // `wrapper` is unannotated but its body only calls idempotent
+        // primitives. Multi-hop upward inference classifies it.
+        // Upward inference needs the fileCache pathway.
+        let visitor = runWithCache([
+            "Chain.swift": """
+            /// @lint.effect idempotent
+            func leaf(_ id: Int) async throws {}
+
+            func wrapper(_ id: Int) async throws {
+                try await leaf(id)
+            }
+
+            /// @lint.context strict_replayable
+            func handle(_ id: Int) async throws {
+                try await wrapper(id)
+            }
+            """
+        ])
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    // MARK: - Collision-withdrawn silences
+
+    @Test
+    func strictReplayable_collidingAnnotationsOnCallee_silent() {
+        // Callee has two conflicting effect annotations → collision,
+        // neither inference runs. Visitor must not double-fire.
+        let source = """
+        /// @lint.effect idempotent
+        /// @lint.effect non_idempotent
+        func conflicted() async throws {}
+
+        /// @lint.context strict_replayable
+        func handle() async throws {
+            try await conflicted()
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    // MARK: - Context scope
+
+    @Test
+    func replayableCaller_unannotatedCallee_silent() {
+        // Regular `replayable` must keep its round-6 precision profile.
+        // The new rule only fires on strict_replayable sites.
+        let source = """
+        func mystery(_ id: Int) async throws {}
+
+        /// @lint.context replayable
+        func handle(_ id: Int) async throws {
+            try await mystery(id)
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    @Test
+    func retrySafeCaller_unannotatedCallee_silent() {
+        let source = """
+        func mystery(_ id: Int) async throws {}
+
+        /// @lint.context retry_safe
+        func handle(_ id: Int) async throws {
+            try await mystery(id)
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    @Test
+    func onceCaller_unannotatedCallee_silent() {
+        // @context once is an inverse contract; strict_replayable's rule
+        // doesn't apply.
+        let source = """
+        func migrate() async throws {}
+
+        /// @lint.context once
+        func handle() async throws {
+            try await migrate()
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    @Test
+    func unannotatedCaller_anything_silent() {
+        // No context annotation → rule not engaged at all.
+        let source = """
+        func mystery() async throws {}
+
+        func handle() async throws {
+            try await mystery()
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    // MARK: - Escape hatches
+
+    @Test
+    func strictReplayable_insideEscapingTaskClosure_silent() {
+        // Same escaping-closure policy as existing retry-context rule.
+        let source = """
+        func mystery() async throws {}
+
+        /// @lint.context strict_replayable
+        func handle() async throws {
+            Task {
+                try await mystery()
+            }
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    // MARK: - Closure-bound strict_replayable sites
+
+    @Test
+    func strictReplayable_onClosureBinding_flagsUnannotated() throws {
+        let source = """
+        func mystery() async throws {}
+
+        /// @lint.context strict_replayable
+        let handler: @Sendable () async throws -> Void = {
+            try await mystery()
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.count == 1)
+        let issue = try #require(visitor.detectedIssues.first)
+        #expect(issue.message.contains("handler"))
+        #expect(issue.message.contains("mystery"))
+    }
+
+    // MARK: - Nested context-annotated declarations don't leak
+
+    @Test
+    func strictReplayable_nestedReplayableBinding_doesNotFireOnInnerCallees() {
+        // Nested `@lint.context replayable` closure binding is its own
+        // analysis site under the existing rule — the outer strict
+        // rule must not descend into it.
+        let source = """
+        func outer() async throws {}
+        func inner() async throws {}
+
+        /// @lint.context strict_replayable
+        func handle() async throws {
+            try await outer()
+            /// @lint.context replayable
+            let nested: @Sendable () async throws -> Void = {
+                try await inner()
+            }
+            _ = nested
+        }
+        """
+
+        let visitor = run(source: source)
+
+        // Only `outer` fires (direct strict callee). `inner` is inside
+        // the nested replayable binding and is silent.
+        #expect(visitor.detectedIssues.count == 1)
+        #expect(visitor.detectedIssues.first?.message.contains("outer") == true)
+    }
+}
+
+/// Cross-rule interaction: strict_replayable + declared non-idempotent callee
+/// should fire ONLY the existing rule (never double-fire).
+@Suite
+struct StrictReplayableRuleInteractionTests {
+
+    @Test
+    func strictCallsDeclaredNonIdempotent_onlyExistingRuleFires() throws {
+        let source = """
+        /// @lint.effect non_idempotent
+        func insert(_ id: Int) async throws {}
+
+        /// @lint.context strict_replayable
+        func handle(_ id: Int) async throws {
+            try await insert(id)
+        }
+        """
+
+        let sourceFile = Parser.parse(source: source)
+
+        let existingVisitor = NonIdempotentInRetryContextVisitor(
+            pattern: NonIdempotentInRetryContext().pattern
+        )
+        existingVisitor.walk(sourceFile)
+        existingVisitor.analyze()
+
+        let newVisitor = UnannotatedInStrictReplayableContextVisitor(
+            pattern: UnannotatedInStrictReplayableContext().pattern
+        )
+        newVisitor.walk(sourceFile)
+        newVisitor.analyze()
+
+        #expect(existingVisitor.detectedIssues.count == 1)
+        #expect(existingVisitor.detectedIssues.first?.ruleName == .nonIdempotentInRetryContext)
+        #expect(existingVisitor.detectedIssues.first?.message.contains("strict_replayable") == true)
+        #expect(newVisitor.detectedIssues.isEmpty)
+    }
+
+    @Test
+    func strictCallsUnannotated_onlyNewRuleFires() throws {
+        let source = """
+        func mystery() async throws {}
+
+        /// @lint.context strict_replayable
+        func handle() async throws {
+            try await mystery()
+        }
+        """
+
+        let sourceFile = Parser.parse(source: source)
+
+        let existingVisitor = NonIdempotentInRetryContextVisitor(
+            pattern: NonIdempotentInRetryContext().pattern
+        )
+        existingVisitor.walk(sourceFile)
+        existingVisitor.analyze()
+
+        let newVisitor = UnannotatedInStrictReplayableContextVisitor(
+            pattern: UnannotatedInStrictReplayableContext().pattern
+        )
+        newVisitor.walk(sourceFile)
+        newVisitor.analyze()
+
+        #expect(existingVisitor.detectedIssues.isEmpty)
+        #expect(newVisitor.detectedIssues.count == 1)
+        #expect(newVisitor.detectedIssues.first?.ruleName == .unannotatedInStrictReplayableContext)
+    }
+}

--- a/Tests/CoreTests/Suppression/CrossFileInlineSuppressionTests.swift
+++ b/Tests/CoreTests/Suppression/CrossFileInlineSuppressionTests.swift
@@ -1,0 +1,217 @@
+import Testing
+import Foundation
+@testable import Core
+@testable import SwiftProjectLintRules
+
+/// Regression tests for the cross-file-rule inline-suppression bug
+/// surfaced during round-9 validation. Prior to the fix,
+/// `InlineSuppressionFilter` only applied to per-file rule issues;
+/// cross-file rules (the four shipped pre-round-9 idempotency rules plus
+/// the new `unannotatedInStrictReplayableContext`) bypassed the filter
+/// entirely, so `// swiftprojectlint:disable:next <rule-name>` silently
+/// did nothing.
+///
+/// Fix: `ProjectLinter.applyInlineSuppression(to:files:)` groups cross-
+/// file issues by their primary file and runs the existing filter on
+/// each group. Affected rules: `idempotencyViolation`,
+/// `nonIdempotentInRetryContext`, `missingIdempotencyKey`,
+/// `onceContractViolation`, `unannotatedInStrictReplayableContext`.
+@Suite(.serialized)
+struct CrossFileInlineSuppressionTests {
+
+    private func makeTempProject(
+        _ files: [(name: String, content: String)]
+    ) -> String {
+        let tempDir = FileManager.default.temporaryDirectory.path
+        let path = (tempDir as NSString).appendingPathComponent(
+            "CrossFileSuppressionProject-\(UUID().uuidString)"
+        )
+        try? FileManager.default.createDirectory(
+            atPath: path,
+            withIntermediateDirectories: true
+        )
+        for (name, content) in files {
+            let filePath = (path as NSString).appendingPathComponent(name)
+            try? content.write(toFile: filePath, atomically: true, encoding: .utf8)
+        }
+        return path
+    }
+
+    // MARK: - Baseline (no suppression, expects firing)
+
+    @Test
+    func baseline_strictReplayableUnannotatedCallee_fires_withoutSuppression() async throws {
+        let source = """
+        func mystery() {}
+
+        /// @lint.context strict_replayable
+        func handle() async throws {
+            mystery()
+        }
+        """
+        let projectPath = makeTempProject([("main.swift", source)])
+        defer { try? FileManager.default.removeItem(atPath: projectPath) }
+
+        let linter = ProjectLinter()
+        let system = PatternRegistryFactory.createConfiguredSystem()
+        let issues = await linter.analyzeProject(
+            at: projectPath,
+            categories: [.idempotency],
+            detector: system.detector
+        )
+
+        let strictIssues = issues.filter {
+            $0.ruleName == .unannotatedInStrictReplayableContext
+        }
+        #expect(strictIssues.count == 1)
+    }
+
+    // MARK: - strict_replayable (the round-9 rule)
+
+    @Test
+    func disableNext_silences_unannotatedInStrictReplayableContext() async throws {
+        let source = """
+        func mystery() {}
+
+        /// @lint.context strict_replayable
+        func handle() async throws {
+            // swiftprojectlint:disable:next unannotated-in-strict-replayable-context
+            mystery()
+        }
+        """
+        let projectPath = makeTempProject([("main.swift", source)])
+        defer { try? FileManager.default.removeItem(atPath: projectPath) }
+
+        let linter = ProjectLinter()
+        let system = PatternRegistryFactory.createConfiguredSystem()
+        let issues = await linter.analyzeProject(
+            at: projectPath,
+            categories: [.idempotency],
+            detector: system.detector
+        )
+
+        let strictIssues = issues.filter {
+            $0.ruleName == .unannotatedInStrictReplayableContext
+        }
+        #expect(strictIssues.isEmpty)
+    }
+
+    @Test
+    func disableNext_onlySilencesTargetedLine() async throws {
+        let source = """
+        func mysteryA() {}
+        func mysteryB() {}
+
+        /// @lint.context strict_replayable
+        func handle() async throws {
+            // swiftprojectlint:disable:next unannotated-in-strict-replayable-context
+            mysteryA()
+            mysteryB()
+        }
+        """
+        let projectPath = makeTempProject([("main.swift", source)])
+        defer { try? FileManager.default.removeItem(atPath: projectPath) }
+
+        let linter = ProjectLinter()
+        let system = PatternRegistryFactory.createConfiguredSystem()
+        let issues = await linter.analyzeProject(
+            at: projectPath,
+            categories: [.idempotency],
+            detector: system.detector
+        )
+
+        let strictIssues = issues.filter {
+            $0.ruleName == .unannotatedInStrictReplayableContext
+        }
+        #expect(strictIssues.count == 1)
+        #expect(strictIssues.first?.message.contains("mysteryB") == true)
+    }
+
+    // MARK: - nonIdempotentInRetryContext (pre-existing rule, also cross-file)
+
+    @Test
+    func disableNext_silences_nonIdempotentInRetryContext() async throws {
+        let source = """
+        /// @lint.effect non_idempotent
+        func sendEmail() async throws {}
+
+        /// @lint.context replayable
+        func handle() async throws {
+            // swiftprojectlint:disable:next non-idempotent-in-retry-context
+            try await sendEmail()
+        }
+        """
+        let projectPath = makeTempProject([("main.swift", source)])
+        defer { try? FileManager.default.removeItem(atPath: projectPath) }
+
+        let linter = ProjectLinter()
+        let system = PatternRegistryFactory.createConfiguredSystem()
+        let issues = await linter.analyzeProject(
+            at: projectPath,
+            categories: [.idempotency],
+            detector: system.detector
+        )
+
+        let retryIssues = issues.filter {
+            $0.ruleName == .nonIdempotentInRetryContext
+        }
+        #expect(retryIssues.isEmpty)
+    }
+
+    // MARK: - Full-rule disable (no explicit rule list)
+
+    @Test
+    func disableNextWithoutRuleName_silencesAllRulesOnNextLine() async throws {
+        let source = """
+        func mystery() {}
+
+        /// @lint.context strict_replayable
+        func handle() async throws {
+            // swiftprojectlint:disable:next
+            mystery()
+        }
+        """
+        let projectPath = makeTempProject([("main.swift", source)])
+        defer { try? FileManager.default.removeItem(atPath: projectPath) }
+
+        let linter = ProjectLinter()
+        let system = PatternRegistryFactory.createConfiguredSystem()
+        let issues = await linter.analyzeProject(
+            at: projectPath,
+            categories: [.idempotency],
+            detector: system.detector
+        )
+
+        #expect(issues.isEmpty)
+    }
+
+    // MARK: - Wrong rule name does not silence
+
+    @Test
+    func disableNext_wrongRuleName_doesNotSilence() async throws {
+        let source = """
+        func mystery() {}
+
+        /// @lint.context strict_replayable
+        func handle() async throws {
+            // swiftprojectlint:disable:next force-try
+            mystery()
+        }
+        """
+        let projectPath = makeTempProject([("main.swift", source)])
+        defer { try? FileManager.default.removeItem(atPath: projectPath) }
+
+        let linter = ProjectLinter()
+        let system = PatternRegistryFactory.createConfiguredSystem()
+        let issues = await linter.analyzeProject(
+            at: projectPath,
+            categories: [.idempotency],
+            detector: system.detector
+        )
+
+        let strictIssues = issues.filter {
+            $0.ruleName == .unannotatedInStrictReplayableContext
+        }
+        #expect(strictIssues.count == 1)
+    }
+}


### PR DESCRIPTION
## Summary

- New opt-in `/// @lint.context strict_replayable` context tier — flags unannotated callees that can't be proven idempotent/observational. Adopters promote critical handlers; leave less-critical ones on `replayable`.
- New rule `unannotatedInStrictReplayableContext` with its own visitor + registrar; existing retry-context and once-contract visitors updated to recognise the new tier.
- **Bug fix 1**: cross-file rules (`idempotencyViolation`, `nonIdempotentInRetryContext`, `missingIdempotencyKey`, `onceContractViolation`, `unannotatedInStrictReplayableContext`) now honor `// swiftprojectlint:disable*` comments. Pre-existing; `ProjectLinter` previously appended cross-file issues without running them through `InlineSuppressionFilter`.
- **Bug fix 2**: `BuiltInRules.registerAll()` guard now returns from the outer function, not just the `withLock` closure. Previously, repeat `createConfiguredSystem()` invocations (common in test suites) appended duplicate factories, inflating pattern counts multiplicatively.

## Test plan

- [x] Full linter suite: 2099/270 → **2129/274 green** (+30 tests, +4 suites)
- [x] Round-9 validation on `swift-aws-lambda-runtime/Examples/MultiSourceAPI` with one handler promoted to `strict_replayable` — 19 diagnostics, decomposed + documented in `docs/phase2-round-9/trial-findings.md` (swiftIdempotency repo)
- [x] Suppression fix verified end-to-end: adding one `disable:next` comment on the sample drops the count from 19 → 18

Plan + scope + findings + retrospective in the swiftIdempotency docs repo:
- `docs/claude_phase_2_strict_replayable_plan.md`
- `docs/phase2-round-9/trial-scope.md`
- `docs/phase2-round-9/trial-findings.md`
- `docs/phase2-round-9/trial-retrospective.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)