### PR TITLE
Extend observational heuristic for chained logger receivers

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
@@ -144,18 +144,32 @@ public enum HeuristicEffectInferrer {
 
     // MARK: - Private
 
-    /// Extracts (calleeName, receiverName?) from a call's called-expression.
-    /// `foo()` → ("foo", nil). `x.foo()` → ("foo", "x"). Anything more
-    /// complex (subscripts, casts, chained member access) → nil.
+    /// Extracts `(calleeName, receiverName?)` from a call's called-expression.
+    ///
+    /// - `foo()` → `("foo", nil)`
+    /// - `x.foo()` → `("foo", "x")`
+    /// - `a.b.foo()` → `("foo", "b")` — the *immediate-parent* segment of
+    ///   a chained member access, matching the semantic "the thing that
+    ///   exposes `.foo`." Enables the observational heuristic to match
+    ///   `context.logger.info(...)` where `logger` is the logger-shaped
+    ///   segment even though it isn't the outermost base.
+    /// - `a.b.c.foo()` → `("foo", "c")` — same rule extends to any depth.
+    /// - Anything structurally more complex (subscripts, casts, function-
+    ///   call bases, tuple projections) → `nil`.
     private static func callParts(of expr: ExprSyntax) -> (String, String?)? {
         if let ref = expr.as(DeclReferenceExprSyntax.self) {
             return (ref.baseName.text, nil)
         }
         if let member = expr.as(MemberAccessExprSyntax.self) {
             let callee = member.declName.baseName.text
-            if let base = member.base,
-               let baseRef = base.as(DeclReferenceExprSyntax.self) {
+            guard let base = member.base else {
+                return (callee, nil)
+            }
+            if let baseRef = base.as(DeclReferenceExprSyntax.self) {
                 return (callee, baseRef.baseName.text)
+            }
+            if let innerMember = base.as(MemberAccessExprSyntax.self) {
+                return (callee, innerMember.declName.baseName.text)
             }
             return (callee, nil)
         }

--- a/Tests/CoreTests/Idempotency/HeuristicInferenceTests.swift
+++ b/Tests/CoreTests/Idempotency/HeuristicInferenceTests.swift
@@ -129,6 +129,68 @@ struct HeuristicInferenceUnitTests {
         #expect(HeuristicEffectInferrer.infer(call: call) == nil)
     }
 
+    // MARK: - Chained receiver (context.logger.method — round-9 follow-on)
+    //
+    // Round-9 validation on swift-aws-lambda-runtime surfaced a gap:
+    // `context.logger.info(...)` didn't match the observational heuristic
+    // because `callParts` only extracted the immediate base identifier
+    // (`context`), which isn't logger-shaped. The fix walks one level
+    // deeper on chained member access and tests the segment immediately
+    // before the callee — the segment that actually exposes the method.
+
+    @Test
+    func contextLoggerInfo_infersObservational_chainedReceiver() throws {
+        let call = try firstCall(in: "func f() { context.logger.info(\"x\") }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .observational)
+    }
+
+    @Test
+    func contextLoggerError_infersObservational_chainedReceiver() throws {
+        let call = try firstCall(in: "func f() { context.logger.error(\"x\") }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .observational)
+    }
+
+    @Test
+    func selfLoggerDebug_infersObservational_chainedReceiver() throws {
+        // Mirrors the same pattern but with `self` — a common shape for
+        // instance methods that carry their own logger.
+        let call = try firstCall(in: "func f() { self.logger.debug(\"x\") }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .observational)
+    }
+
+    @Test
+    func requestLoggerFromContext_infersObservational_chainedReceiver() throws {
+        // `context.requestLogger.warning(...)` — immediate-parent segment
+        // is `requestLogger`, which pattern-matches the suffixed-logger rule.
+        let call = try firstCall(in: "func f() { context.requestLogger.warning(\"x\") }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .observational)
+    }
+
+    @Test
+    func deeplyChainedLogger_infersObservational() throws {
+        // Three-level chain: `app.context.logger.info(...)` — still finds
+        // the logger-shaped segment as the immediate parent of `info`.
+        let call = try firstCall(in: "func f() { app.context.logger.info(\"x\") }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .observational)
+    }
+
+    @Test
+    func chainedNonLoggerReceiver_doesNotInferObservational() throws {
+        // Chained call where no segment looks like a logger. Stay silent.
+        // `view.debug()` already tests single-level; this covers the
+        // two-level variant to confirm the extension doesn't go too loose.
+        let call = try firstCall(in: "func f() { app.view.debug() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == nil)
+    }
+
+    @Test
+    func chainedLoggerNonLevelMethod_doesNotInferObservational() throws {
+        // `context.logger.flush()` — logger-shaped receiver but a non-level
+        // method. Observational heuristic still requires both signals.
+        let call = try firstCall(in: "func f() { context.logger.flush() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == nil)
+    }
+
     // MARK: - Names deliberately left out of the whitelist
 
     @Test


### PR DESCRIPTION
## Summary

Round-9 follow-on. Extends `HeuristicEffectInferrer.callParts` to walk one level deeper into chained member access so `context.logger.info(...)` matches the observational heuristic (previously, only the outermost base was extracted, so `context` was tested instead of `logger`).

- `a.b.foo()` now returns `("foo", "b")` instead of `("foo", nil)` — picks the immediate-parent segment, matching the semantic "the thing that exposes `.foo`."
- The observational heuristic still requires both logger-shaped receiver AND log-level method, so no loosening of false-positive behaviour.

## Effect on round-9 corpus

`swift-aws-lambda-runtime/Examples/MultiSourceAPI` with `@lint.context strict_replayable`: **19 → 16 diagnostics**. Matches the "3/19 silenceable via chained-logger heuristic" prediction from `docs/phase2-round-9/trial-retrospective.md`.

## Test plan

- [x] Full linter suite: 2129/274 → **2136/274 green** (+7 tests)
- [x] Heuristic unit tests cover positives (`context.logger.info/error`, `self.logger.debug`, suffix-matched `requestLogger`, three-level chain) and negatives (`app.view.debug`, `context.logger.flush`)
- [x] Verified on the Lambda corpus end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)