### PR TITLE
Closure-handler grammar: annotate trailing closures with @lint.context

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/Visitors/NonIdempotentInRetryContextVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/Visitors/NonIdempotentInRetryContextVisitor.swift
@@ -107,6 +107,38 @@ final class NonIdempotentInRetryContextVisitor: BasePatternVisitor, CrossFilePat
         return .visitChildren
     }
 
+    /// Trailing-closure annotation (round-11 grammar extension). An
+    /// un-bound closure passed to a call — the Vapor / Hummingbird /
+    /// Lambda idiom `app.on(.POST, "login") { req in ... }` — is its
+    /// own analysis site when the call expression carries a
+    /// `/// @lint.context` annotation in its leading trivia.
+    ///
+    /// Round 6 flagged closure-based handlers as unannotatable under the
+    /// original grammar, which blocked >50% of Vapor's routes surface.
+    /// Round 10 re-surfaced it on Vapor's `Sources/Development/routes.swift`.
+    /// This visit method closes the gap for the common
+    /// "doc-comment-above-the-call" shape.
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        guard let context = EffectAnnotationParser.parseContext(
+                leadingTrivia: node.leadingTrivia
+              ),
+              let closure = node.trailingClosure else {
+            return .visitChildren
+        }
+        let converter = currentLocationConverter
+            ?? SourceLocationConverter(fileName: currentFilePath, tree: node.root)
+        analysisSites.append(
+            AnalysisSite(
+                callerName: "closure",
+                body: Syntax(closure.statements),
+                context: context,
+                filePath: currentFilePath,
+                locationConverter: converter
+            )
+        )
+        return .visitChildren
+    }
+
     func finalizeAnalysis() {
         // Phase-2.3 upward inference — see IdempotencyViolationVisitor for
         // rationale. Runs before the body walk so every lookup in
@@ -141,6 +173,15 @@ final class NonIdempotentInRetryContextVisitor: BasePatternVisitor, CrossFilePat
         if let varDecl = syntax.as(VariableDeclSyntax.self),
            varDecl.closureInitializer != nil,
            EffectAnnotationParser.parseContext(declaration: varDecl) != nil {
+            return
+        }
+        // Same rule for annotated trailing-closure sites: the outer walk
+        // must not descend into a call whose closure is its own analysis
+        // site, or the inner calls would be attributed to the outer
+        // context twice.
+        if let call = syntax.as(FunctionCallExprSyntax.self),
+           call.trailingClosure != nil,
+           EffectAnnotationParser.parseContext(leadingTrivia: call.leadingTrivia) != nil {
             return
         }
         if let closure = syntax.as(ClosureExprSyntax.self), isEscapingClosure(closure) {

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/Visitors/UnannotatedInStrictReplayableContextVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/Visitors/UnannotatedInStrictReplayableContextVisitor.swift
@@ -118,6 +118,31 @@ final class UnannotatedInStrictReplayableContextVisitor:
         return .visitChildren
     }
 
+    /// Trailing-closure annotation (round-11 grammar extension). An
+    /// un-bound closure passed to a call with `/// @lint.context
+    /// strict_replayable` above it becomes an analysis site. Matches the
+    /// pattern in `NonIdempotentInRetryContextVisitor.visit(_:)`; see
+    /// that visitor's doc comment for the shape rationale.
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        guard EffectAnnotationParser.parseContext(
+                leadingTrivia: node.leadingTrivia
+              ) == .strictReplayable,
+              let closure = node.trailingClosure else {
+            return .visitChildren
+        }
+        let converter = currentLocationConverter
+            ?? SourceLocationConverter(fileName: currentFilePath, tree: node.root)
+        analysisSites.append(
+            AnalysisSite(
+                callerName: "closure",
+                body: Syntax(closure.statements),
+                filePath: currentFilePath,
+                locationConverter: converter
+            )
+        )
+        return .visitChildren
+    }
+
     func finalizeAnalysis() {
         let allSources = Array(fileCache.values)
         symbolTable.applyUpwardInference(
@@ -143,6 +168,12 @@ final class UnannotatedInStrictReplayableContextVisitor:
         if let varDecl = syntax.as(VariableDeclSyntax.self),
            varDecl.closureInitializer != nil,
            EffectAnnotationParser.parseContext(declaration: varDecl) != nil {
+            return
+        }
+        // Same rule for annotated trailing-closure sites (round-11).
+        if let call = syntax.as(FunctionCallExprSyntax.self),
+           call.trailingClosure != nil,
+           EffectAnnotationParser.parseContext(leadingTrivia: call.leadingTrivia) != nil {
             return
         }
         if let closure = syntax.as(ClosureExprSyntax.self), isEscapingClosure(closure) {

--- a/Tests/CoreTests/Idempotency/NonIdempotentInRetryContextVisitorTests.swift
+++ b/Tests/CoreTests/Idempotency/NonIdempotentInRetryContextVisitorTests.swift
@@ -121,6 +121,145 @@ struct NonIdempotentInRetryContextVisitorTests {
 
         #expect(visitor.detectedIssues.isEmpty)
     }
+
+    // MARK: - Trailing-closure annotation (round-11 grammar extension)
+    //
+    // Closure-based handlers (the Vapor / Hummingbird / Lambda idiom
+    // `app.on(...) { req in ... }`) become annotatable: a doc comment
+    // on the enclosing call statement attaches to the trailing closure.
+
+    @Test
+    func trailingClosureAnnotatedReplayable_firesOnNonIdempotent() throws {
+        let source = """
+        /// @lint.effect non_idempotent
+        func insert(_ id: Int) async throws {}
+
+        func routes(_ app: App) throws {
+            /// @lint.context replayable
+            app.post("orders") { req in
+                try await insert(req.id)
+            }
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.count == 1)
+        let issue = try #require(visitor.detectedIssues.first)
+        #expect(issue.message.contains("insert"))
+        #expect(issue.message.contains("replayable"))
+        #expect(issue.message.contains("closure"))
+    }
+
+    @Test
+    func trailingClosureAnnotatedRetrySafe_firesOnNonIdempotent() throws {
+        let source = """
+        /// @lint.effect non_idempotent
+        func publishEvent(_ payload: String) async throws {}
+
+        func configure(_ app: App) throws {
+            /// @lint.context retry_safe
+            app.scheduled("nightly") { ctx in
+                try await publishEvent("tick")
+            }
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.count == 1)
+        #expect(visitor.detectedIssues.first?.message.contains("retry_safe") == true)
+    }
+
+    @Test
+    func trailingClosureUnannotated_staysSilent() {
+        // No `@lint.context` above the call → the closure isn't an
+        // analysis site, and its non-idempotent callee produces no
+        // diagnostic. Preserves the round-6 precision profile.
+        let source = """
+        /// @lint.effect non_idempotent
+        func insert(_ id: Int) async throws {}
+
+        func routes(_ app: App) throws {
+            app.post("orders") { req in
+                try await insert(req.id)
+            }
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    @Test
+    func trailingClosureAnnotationOnCallWithoutClosure_staysSilent() {
+        // Doc comment above a call that has NO trailing closure — the
+        // annotation has no closure to attach to. Silent; no crash, no
+        // diagnostic.
+        let source = """
+        /// @lint.effect non_idempotent
+        func insert(_ id: Int) async throws {}
+
+        func routes(_ app: App) throws {
+            /// @lint.context replayable
+            app.configure()
+            try await insert(1)
+        }
+        """
+
+        let visitor = run(source: source)
+
+        // `insert(1)` is outside any annotated site, so no diagnostic.
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    @Test
+    func trailingClosureWithAnnotatedCalleeInside_firesOnceNotTwice() throws {
+        // Regression: the annotated trailing closure is its own site.
+        // If the OUTER enclosing function is ALSO annotated, we must not
+        // double-count the inner non-idempotent call.
+        let source = """
+        /// @lint.effect non_idempotent
+        func insert(_ id: Int) async throws {}
+
+        /// @lint.context replayable
+        func routes(_ app: App) throws {
+            /// @lint.context replayable
+            app.post("orders") { req in
+                try await insert(req.id)
+            }
+        }
+        """
+
+        let visitor = run(source: source)
+
+        // Expected: the inner `insert` call fires exactly once, from
+        // the inner analysis site (the trailing closure), not from both
+        // the outer function site AND the inner closure.
+        #expect(visitor.detectedIssues.count == 1)
+    }
+
+    @Test
+    func trailingClosureIdempotentCallee_staysSilent() {
+        // Confirms the positive path: an idempotent callee in an annotated
+        // trailing closure produces no diagnostic.
+        let source = """
+        /// @lint.effect idempotent
+        func upsert(_ id: Int) async throws {}
+
+        func routes(_ app: App) throws {
+            /// @lint.context replayable
+            app.post("orders") { req in
+                try await upsert(req.id)
+            }
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
 }
 
 /// Cross-rule fixture: a function annotated with both an effect and a context.

--- a/Tests/CoreTests/Idempotency/UnannotatedInStrictReplayableContextVisitorTests.swift
+++ b/Tests/CoreTests/Idempotency/UnannotatedInStrictReplayableContextVisitorTests.swift
@@ -364,6 +364,69 @@ struct UnannotatedInStrictReplayableContextVisitorTests {
 
     // MARK: - Nested context-annotated declarations don't leak
 
+    // MARK: - Trailing-closure annotation (round-11 grammar extension)
+
+    @Test
+    func strictReplayable_onTrailingClosure_flagsUnannotated() throws {
+        let source = """
+        func mystery() {}
+
+        func routes(_ app: App) throws {
+            /// @lint.context strict_replayable
+            app.post("x") { req in
+                mystery()
+            }
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.count == 1)
+        let issue = try #require(visitor.detectedIssues.first)
+        #expect(issue.message.contains("closure"))
+        #expect(issue.message.contains("mystery"))
+        #expect(issue.message.contains("strict_replayable"))
+    }
+
+    @Test
+    func strictReplayable_onTrailingClosure_silentOnIdempotentCallee() {
+        let source = """
+        /// @lint.effect idempotent
+        func upsert(_ id: Int) {}
+
+        func routes(_ app: App) throws {
+            /// @lint.context strict_replayable
+            app.post("x") { req in
+                upsert(1)
+            }
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    @Test
+    func replayableOnTrailingClosure_doesNotFireStrictRule() {
+        // `@lint.context replayable` on a closure — existing retry-context
+        // rule applies, but the new strict rule stays silent.
+        let source = """
+        func mystery() {}
+
+        func routes(_ app: App) throws {
+            /// @lint.context replayable
+            app.post("x") { req in
+                mystery()
+            }
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
     @Test
     func strictReplayable_nestedReplayableBinding_doesNotFireOnInnerCallees() {
         // Nested `@lint.context replayable` closure binding is its own


### PR DESCRIPTION
## Summary

Closes the closure-handler grammar gap flagged in round 6 and re-surfaced in round 10. A doc comment above a call with a trailing closure — the Vapor / Hummingbird / Lambda idiom `app.on(...) { req in ... }` — now makes the closure body an analysis site.

## Change

`NonIdempotentInRetryContextVisitor` and `UnannotatedInStrictReplayableContextVisitor` each gain a `visit(_: FunctionCallExprSyntax)` that checks the call's leading trivia for `/// @lint.context <tier>` and emits an analysis site on the trailing-closure body if present. Both visitors' `analyzeBody` also skips descent into annotated trailing-closure calls to avoid double-firing.

## Scope decision — OnceContractViolationVisitor deferred

That visitor stores `FunctionDeclSyntax` directly in its `AnalysisSite` (different architecture from the other two). Extending it to trailing closures is structurally larger. `@lint.context once` callees are also rare in retry-context web-handler surfaces — the adoption value for this slice is low. Deferred as a follow-on.

## Test plan

- [x] Full linter suite: 2136/274 → **2145/274 green** (+9 trailing-closure tests)
- [x] Unit tests cover: replayable/retry_safe/strict_replayable firing on trailing closures; silence on unannotated; silence on calls without trailing closures; no-double-fire when both outer function and inner closure are annotated
- [x] Integration on Vapor 4.118.0: `/// @lint.context replayable` above `app.post("login") { ... }` fires correctly on the inner `req.content.decode(...)` via the 5-hop upward inference chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)