### PR TITLE
Heuristic: add stop + destroy to non-idempotent whitelist

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
@@ -199,7 +199,9 @@ public enum HeuristicEffectInferrer {
         "publish",
         "enqueue",
         "post",
-        "send"
+        "send",
+        "stop",
+        "destroy"
     ]
 
     private static let idempotentNames: Set<String> = [

--- a/Tests/CoreTests/Idempotency/HeuristicInferenceTests.swift
+++ b/Tests/CoreTests/Idempotency/HeuristicInferenceTests.swift
@@ -76,6 +76,65 @@ struct HeuristicInferenceUnitTests {
         #expect(HeuristicEffectInferrer.infer(call: call) == .nonIdempotent)
     }
 
+    // MARK: - Destructive-verb whitelist (round-11 follow-on)
+    //
+    // Round 11 on Vapor surfaced `running.stop()` and `req.session.destroy()`
+    // as missed catches — both short, unambiguous destructive verbs that
+    // the existing whitelist didn't cover. Added to `nonIdempotentNames`.
+
+    @Test
+    func bareStop_infersNonIdempotent() throws {
+        let call = try firstCall(in: "func f() { stop() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .nonIdempotent)
+    }
+
+    @Test
+    func memberStop_infersNonIdempotent() throws {
+        let call = try firstCall(in: "func f() { running.stop() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .nonIdempotent)
+    }
+
+    @Test
+    func stopContainer_infersNonIdempotent_viaPrefix() throws {
+        // Prefix match extends `stop` to camelCase-composed destructive
+        // verbs like `stopContainer`, `stopService`, `stopTimer`.
+        let call = try firstCall(in: "func f() { stopContainer() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .nonIdempotent)
+    }
+
+    @Test
+    func bareDestroy_infersNonIdempotent() throws {
+        let call = try firstCall(in: "func f() { destroy() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .nonIdempotent)
+    }
+
+    @Test
+    func memberDestroy_infersNonIdempotent() throws {
+        let call = try firstCall(in: "func f() { session.destroy() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .nonIdempotent)
+    }
+
+    @Test
+    func destroyResource_infersNonIdempotent_viaPrefix() throws {
+        let call = try firstCall(in: "func f() { destroyResource(id) }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .nonIdempotent)
+    }
+
+    @Test
+    func stopped_doesNotMatch_lowercaseNextCharacter() throws {
+        // `stopped` is a past participle, not a mutation verb — camelCase
+        // gate should block it (next character after `stop` is lowercase).
+        let call = try firstCall(in: "func f() { stopped(task) }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == nil)
+    }
+
+    @Test
+    func destroyer_doesNotMatch_lowercaseNextCharacter() throws {
+        // `destroyer` is a noun form; should not classify as non-idempotent.
+        let call = try firstCall(in: "func f() { destroyer() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == nil)
+    }
+
     // MARK: - Idempotent name triggers
 
     @Test


### PR DESCRIPTION
## Summary

Round-11 follow-on. Two missed catches on the Vapor corpus (`running.stop()`, `req.session.destroy()`) pointed at unambiguous destructive verbs the heuristic whitelist didn't cover.

## Change

Added `stop` and `destroy` to `HeuristicEffectInferrer.nonIdempotentNames`. Both the bare-name path and the camelCase-gated prefix path benefit:

- bare `stop()` / `destroy()` → classified directly
- `stopContainer()` / `destroyResource(id)` → classified via prefix + camelCase gate
- `stopped()` / `destroyer()` → correctly stay silent (camelCase gate blocks participle/noun forms)

## Effect on round-11 corpus

Vapor yield: **0.33 → 0.67** catches per annotation. The two missed catches from round 11's audit (`running.stop()` at `app.get("shutdown")`, `req.session.destroy()` at `sessions.get("del")`) now fire.

## Test plan

- [x] Full linter suite: 2145/274 → **2153/274 green** (+8 tests)
- [x] Unit tests cover bare, member-access, prefix-matched, and gated-out forms
- [x] Integration on Vapor: re-scanned the round-11 6-annotation setup; yield rose from 2 → 4 diagnostics as predicted

🤖 Generated with [Claude Code](https://claude.com/claude-code)