### PR TITLE
Framework whitelist: type constructors + codec + metric patterns

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
@@ -72,6 +72,41 @@ public enum HeuristicEffectInferrer {
             return .observational
         }
 
+        // Metric primitives (swift-metrics + observational-by-convention
+        // siblings). Receiver names containing `counter`, `gauge`, `meter`,
+        // `timer`, `recorder` + a metric-observation method classify
+        // observational. Matches round-12's `activeRequestMeter.increment()`
+        // and `Metrics.Timer(...).recordNanoseconds(...)` shapes.
+        if let receiverName,
+           isMetricReceiver(receiverName),
+           metricObservationMethods.contains(calleeName) {
+            return .observational
+        }
+
+        // Type-constructor whitelist — known pure/value-type constructors
+        // from Foundation, SwiftNIO, etc. `JSONDecoder()`, `Data(...)`,
+        // `ByteBuffer(bytes:)`. A constructor with no receiver (bare
+        // identifier that happens to match a known type) classifies
+        // idempotent. Deliberately excludes `UUID()` (violates this
+        // project's own `missingIdempotencyKey` rule) and `Date()`
+        // (reads current time).
+        if receiverName == nil,
+           idempotentFrameworkTypes.contains(calleeName) {
+            return .idempotent
+        }
+
+        // Codec-pattern method whitelist. Receivers whose names end in
+        // `Decoder` / `Encoder` or contain `decoder` / `encoder` plus the
+        // paired verb → idempotent. Silences `decoder.decode(...)` and
+        // `encoder.encode(...)` on codec instances without requiring a
+        // type-resolver. Round-9 Lambda MultiSourceAPI had 4 fires of
+        // this exact shape.
+        if let receiverName,
+           isCodecReceiver(receiverName),
+           codecMethods.contains(calleeName) {
+            return .idempotent
+        }
+
         // Bare-name whitelists — now receiver-type gated. If the receiver
         // resolves to a stdlib collection whose (type, method) pair is in
         // the exclusion table, the bare-name match is suppressed. Named
@@ -119,6 +154,20 @@ public enum HeuristicEffectInferrer {
            isLoggerReceiver(receiverName),
            loggerLevelMethods.contains(calleeName) {
             return "from logger-shaped receiver `\(receiverName).\(calleeName)`"
+        }
+        if let receiverName,
+           isMetricReceiver(receiverName),
+           metricObservationMethods.contains(calleeName) {
+            return "from metric-primitive receiver `\(receiverName).\(calleeName)`"
+        }
+        if receiverName == nil,
+           idempotentFrameworkTypes.contains(calleeName) {
+            return "from the known-idempotent framework type `\(calleeName)`"
+        }
+        if let receiverName,
+           isCodecReceiver(receiverName),
+           codecMethods.contains(calleeName) {
+            return "from codec-pattern receiver `\(receiverName).\(calleeName)`"
         }
         if idempotentNames.contains(calleeName) || nonIdempotentNames.contains(calleeName) {
             // Receiver-type-excluded pairs produce no reason, mirroring
@@ -185,6 +234,65 @@ public enum HeuristicEffectInferrer {
         let lowered = name.lowercased()
         return lowered.contains("log")
     }
+
+    /// Matches swift-metrics primitive receivers and conventional siblings.
+    /// `counter`, `Counter`, `gauge`, `meter`, `timer`, `recorder`, plus
+    /// suffixed variants (`activeRequestMeter`, `requestCounter`, etc.).
+    /// Round-12 follow-on — observationally absorbs metric mutations the
+    /// same way the logger path absorbs log emissions.
+    private static func isMetricReceiver(_ name: String) -> Bool {
+        let lowered = name.lowercased()
+        return lowered.contains("counter")
+            || lowered.contains("gauge")
+            || lowered.contains("meter")
+            || lowered.contains("timer")
+            || lowered.contains("recorder")
+    }
+
+    private static let metricObservationMethods: Set<String> = [
+        "increment", "decrement",
+        "record", "recordNanoseconds",
+        "observe",
+        "startTimer"
+    ]
+
+    /// Matches Foundation/SwiftNIO codec receivers. Conservative: receiver
+    /// name must end with or contain `Decoder` / `Encoder` (case-insensitive
+    /// via lowercasing the whole name). Silences codec instances like
+    /// `decoder.decode(...)` without needing a full type resolver.
+    private static func isCodecReceiver(_ name: String) -> Bool {
+        let lowered = name.lowercased()
+        return lowered.contains("decoder") || lowered.contains("encoder")
+    }
+
+    private static let codecMethods: Set<String> = [
+        "decode", "encode"
+    ]
+
+    /// Known-idempotent framework type constructors. When called as a
+    /// bare identifier (no receiver, capitalised callee = type
+    /// constructor), classify `.idempotent` so strict_replayable and
+    /// related rules defer.
+    ///
+    /// Scope: pure value-type constructors whose result is a function of
+    /// inputs alone. Deliberately excluded: `UUID()` (fresh per-call
+    /// identity — the very violation the `missingIdempotencyKey` rule
+    /// guards against), `Date()` (reads current time — not idempotent).
+    private static let idempotentFrameworkTypes: Set<String> = [
+        // Foundation — pure codec containers (configurable but no shared mutable state)
+        "JSONDecoder", "JSONEncoder",
+        "PropertyListDecoder", "PropertyListEncoder",
+        // Foundation — pure byte containers
+        "Data",
+        // SwiftNIO — pure byte buffers and views
+        "ByteBuffer",
+        "ByteBufferAllocator",
+        // AWS Lambda events — response constructors (build a response
+        // value from inputs; no side effects beyond allocation)
+        "ALBTargetGroupResponse",
+        "APIGatewayResponse",
+        "APIGatewayV2Response"
+    ]
 
     private static let loggerLevelMethods: Set<String> = [
         "trace", "debug", "info", "notice",

--- a/Tests/CoreTests/Idempotency/HeuristicInferenceTests.swift
+++ b/Tests/CoreTests/Idempotency/HeuristicInferenceTests.swift
@@ -250,6 +250,140 @@ struct HeuristicInferenceUnitTests {
         #expect(HeuristicEffectInferrer.infer(call: call) == nil)
     }
 
+    // MARK: - Framework whitelist — idempotent type constructors
+    //
+    // Round-12 follow-on. Known-pure framework type constructors classify
+    // idempotent when called as bare identifiers.
+
+    @Test
+    func jsonDecoderConstructor_infersIdempotent() throws {
+        let call = try firstCall(in: "func f() { _ = JSONDecoder() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .idempotent)
+    }
+
+    @Test
+    func jsonEncoderConstructor_infersIdempotent() throws {
+        let call = try firstCall(in: "func f() { _ = JSONEncoder() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .idempotent)
+    }
+
+    @Test
+    func dataConstructor_infersIdempotent() throws {
+        let call = try firstCall(in: "func f() { _ = Data(bytes) }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .idempotent)
+    }
+
+    @Test
+    func byteBufferConstructor_infersIdempotent() throws {
+        let call = try firstCall(in: "func f() { _ = ByteBuffer(bytes: data) }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .idempotent)
+    }
+
+    @Test
+    func albResponseConstructor_infersIdempotent() throws {
+        let call = try firstCall(
+            in: "func f() { _ = ALBTargetGroupResponse(statusCode: .ok) }"
+        )
+        #expect(HeuristicEffectInferrer.infer(call: call) == .idempotent)
+    }
+
+    @Test
+    func uuidConstructor_staysUnclassified() throws {
+        // DELIBERATELY EXCLUDED: UUID() produces a fresh-per-call identity.
+        // Classifying it as idempotent would contradict the
+        // `missingIdempotencyKey` rule this project specifically catches.
+        let call = try firstCall(in: "func f() { _ = UUID() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == nil)
+    }
+
+    @Test
+    func dateConstructor_staysUnclassified() throws {
+        // DELIBERATELY EXCLUDED: Date() reads current time. Same call
+        // produces different values across retries.
+        let call = try firstCall(in: "func f() { _ = Date() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == nil)
+    }
+
+    @Test
+    func userTypeConstructor_staysUnclassified() throws {
+        // Project-local types aren't on the whitelist. Unclassified by
+        // name alone; upward inference may still classify via body.
+        let call = try firstCall(in: "func f() { _ = OrderService() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == nil)
+    }
+
+    // MARK: - Framework whitelist — codec-pattern methods
+
+    @Test
+    func decoderDotDecode_infersIdempotent() throws {
+        let call = try firstCall(in: "func f() { decoder.decode(T.self, from: data) }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .idempotent)
+    }
+
+    @Test
+    func encoderDotEncode_infersIdempotent() throws {
+        let call = try firstCall(in: "func f() { encoder.encode(value) }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .idempotent)
+    }
+
+    @Test
+    func jsonDecoderStyleReceiver_infersIdempotent() throws {
+        let call = try firstCall(in: "func f() { jsonDecoder.decode(T.self, from: data) }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .idempotent)
+    }
+
+    @Test
+    func decodeOnNonCodecReceiver_staysUnclassified() throws {
+        // Vapor's `req.content.decode(...)` — receiver `content` doesn't
+        // contain `decoder`/`encoder`. The codec-pattern heuristic doesn't
+        // fire here; the 5-hop upward inference round-11 observed still
+        // applies.
+        let call = try firstCall(in: "func f() { content.decode(Creds.self) }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == nil)
+    }
+
+    // MARK: - Framework whitelist — metric-pattern methods
+
+    @Test
+    func counterIncrement_infersObservational() throws {
+        let call = try firstCall(in: "func f() { counter.increment() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .observational)
+    }
+
+    @Test
+    func meterDecrement_infersObservational() throws {
+        let call = try firstCall(in: "func f() { activeRequestMeter.decrement() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .observational)
+    }
+
+    @Test
+    func timerRecordNanoseconds_infersObservational() throws {
+        let call = try firstCall(in: "func f() { timer.recordNanoseconds(100) }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .observational)
+    }
+
+    @Test
+    func gaugeRecord_infersObservational() throws {
+        let call = try firstCall(in: "func f() { gauge.record(42.0) }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .observational)
+    }
+
+    @Test
+    func metricMethodOnNonMetricReceiver_staysUnclassified() throws {
+        // `view.record()` — the method is a metric-observation verb but the
+        // receiver isn't metric-shaped. Don't fire.
+        let call = try firstCall(in: "func f() { view.record() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == nil)
+    }
+
+    @Test
+    func chainedMetricReceiver_infersObservational() throws {
+        // `context.metrics.counter.increment()` — immediate-parent segment
+        // is `counter`, which matches the metric-receiver shape.
+        let call = try firstCall(in: "func f() { context.metrics.counter.increment() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .observational)
+    }
+
     // MARK: - Names deliberately left out of the whitelist
 
     @Test


### PR DESCRIPTION
## Summary

Round-9's 16-diagnostic Lambda-MultiSourceAPI noise floor (the "library-heavy adoption problem") addressed via three coordinated heuristic whitelists, all added to `HeuristicEffectInferrer`:

1. **Idempotent type constructors** — `JSONDecoder`, `JSONEncoder`, `Data`, `ByteBuffer`, AWS Lambda response types, etc. Bare-identifier constructor calls classify `.idempotent`. Excludes `UUID()` and `Date()`.
2. **Codec-pattern methods** — receivers containing `decoder`/`encoder` + `{decode, encode}` methods classify `.idempotent`. Silences codec instances without needing a type resolver.
3. **Metric-pattern methods** — receivers containing `counter`/`gauge`/`meter`/`timer`/`recorder` + observation methods classify `.observational`. Extends the logger pattern to swift-metrics.

## Effect on round-9 corpus

`swift-aws-lambda-runtime/Examples/MultiSourceAPI` strict_replayable: **16 → 4 diagnostics**. 12 silenced (2×JSONDecoder, 2×JSONEncoder, Data, 2×ByteBuffer, ALBTargetGroupResponse, APIGatewayV2Response, 2×decoder.decode, 2×encoder.encode). Remaining 4 are `responseWriter.write`/`.finish` — legitimate framework I/O calls the adopter annotates per-case.

## Test plan

- [x] Full linter suite: 2153/274 → **2171/274 green** (+18 tests)
- [x] Unit tests cover all three whitelists with positives and critical negatives (`UUID`/`Date` excluded; `content.decode` non-codec receiver unchanged; non-metric receiver unchanged)
- [x] Integration on Lambda: 16 → 4 diagnostics on the round-9 target

🤖 Generated with [Claude Code](https://claude.com/claude-code)