### PR TITLE
Framework whitelist: Fluent save/update/delete as non-idempotent verbs

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
@@ -27,12 +27,13 @@ public enum FrameworkWhitelist {
     public static let logging = "Logging"
     public static let osLog = "os"
     public static let metrics = "Metrics"
+    public static let fluent = "FluentKit"
 
     /// Every framework this project recognises. Order-insensitive.
     /// Used as the default `enabledFrameworks` set when a project
     /// hasn't opted out of any framework's classifications.
     public static let knownFrameworks: Set<String> = [
-        foundation, nio, awsLambdaEvents, logging, osLog, metrics
+        foundation, nio, awsLambdaEvents, logging, osLog, metrics, fluent
     ]
 
     // MARK: - Idempotent type constructors (bare-identifier call)
@@ -64,6 +65,31 @@ public enum FrameworkWhitelist {
     /// constructor, or nil when the name isn't on any framework's list.
     public static func framework(forIdempotentTypeConstructor name: String) -> String? {
         idempotentTypesByFramework[name]
+    }
+
+    // MARK: - Non-idempotent methods (receiver-based call)
+
+    /// Maps a method name (as it appears in source on the receiver side)
+    /// to the framework it comes from. `save` → `"FluentKit"`. Lookup
+    /// returns nil for names not on any framework's list.
+    ///
+    /// Used for verbs that are *universally* non-idempotent inside a
+    /// framework but ambiguous enough elsewhere that we don't want them
+    /// in the global bare-name whitelist. Fluent's `save`/`update`/`delete`
+    /// are the motivating case — called on any `Model`-conforming type
+    /// they always hit the database, but `Set.update(with:)` in stdlib
+    /// or `cache.save()` on an in-memory store have different semantics.
+    /// Gating on `import FluentKit` resolves the ambiguity.
+    private static let nonIdempotentMethodsByFramework: [String: String] = [
+        "save": fluent,
+        "update": fluent,
+        "delete": fluent,
+    ]
+
+    /// Returns the framework that owns a given non-idempotent method
+    /// name, or nil when the name isn't on any framework's list.
+    public static func framework(forNonIdempotentMethod name: String) -> String? {
+        nonIdempotentMethodsByFramework[name]
     }
 }
 

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
@@ -28,11 +28,17 @@ import SwiftSyntax
 ///
 /// - Non-idempotent bare-name triggers: names that are ~universally
 ///   non-idempotent in Swift/database/messaging codebases: `create`,
-///   `insert`, `append`, `publish`, `enqueue`, `post`, `send`. Names like
-///   `save`, `store`, `put`, `update`, `write` are deliberately **not** in
-///   the list — they have too many idempotent interpretations (`save`
-///   often means "set current value to this," `put` is idempotent in
-///   REST semantics, `write` could mean atomic file write).
+///   `insert`, `append`, `publish`, `enqueue`, `post`, `send`, `stop`,
+///   `destroy`. Names like `store`, `put`, `write` remain deliberately
+///   **not** in this list — they have too many idempotent interpretations
+///   (`put` is idempotent in REST semantics, `write` could mean atomic
+///   file write).
+///
+/// - Framework-gated non-idempotent triggers: `save`, `update`, `delete`
+///   fire only when the file imports `FluentKit`. These are canonical
+///   Fluent ORM verbs on `Model`-conforming types, but have idempotent
+///   senses elsewhere (`Set.update(with:)`, a cache's `save(key:value:)`).
+///   See `FrameworkWhitelist.framework(forNonIdempotentMethod:)`.
 ///
 /// - Idempotent bare-name triggers: `upsert`, `setIfAbsent`, `replace`.
 ///   These are explicit declarations of intent in the name itself.
@@ -154,6 +160,18 @@ public enum HeuristicEffectInferrer {
             return .nonIdempotent
         }
 
+        // Framework-gated non-idempotent methods (Fluent's save/update/delete).
+        // Receiver-only: `model.save()` is the adopter shape; a bare
+        // `save()` in a module that imports FluentKit is structurally
+        // unrelated (top-level free function), so we keep it out.
+        if receiverName != nil,
+           let framework = FrameworkWhitelist.framework(
+               forNonIdempotentMethod: calleeName
+           ),
+           context.isFrameworkActive(framework) {
+            return .nonIdempotent
+        }
+
         // Camel-case-gated prefix match for non-idempotent verbs.
         // `sendEmail`, `createUser`, `publishEvent`, etc. Ruled out:
         //   - `sending`, `sender`, `publisher`, `appending` (lowercase next)
@@ -221,6 +239,13 @@ public enum HeuristicEffectInferrer {
                 return nil
             }
             return "from the callee name `\(calleeName)`"
+        }
+        if receiverName != nil,
+           let framework = FrameworkWhitelist.framework(
+               forNonIdempotentMethod: calleeName
+           ),
+           context.isFrameworkActive(framework) {
+            return "from the \(framework) ORM verb `\(calleeName)`"
         }
         // Prefix-matched calls credit the matched verb explicitly so the
         // user can see which heuristic fired and why.

--- a/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
+++ b/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
@@ -176,6 +176,92 @@ struct FrameworkWhitelistGatingTests {
         ) == nil)
     }
 
+    // MARK: - Fluent non-idempotent verbs (framework-gated, receiver-only)
+
+    @Test
+    func importGated_fluentPresent_modelSaveFires() throws {
+        let call = try firstCall(in: "func f() { todo.save() }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["FluentKit"], enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func importGated_fluentPresent_modelUpdateFires() throws {
+        let call = try firstCall(in: "func f() { todo.update() }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["FluentKit"], enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func importGated_fluentPresent_modelDeleteFires() throws {
+        let call = try firstCall(in: "func f() { todo.delete() }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["FluentKit"], enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func importGated_fluentAbsent_modelSaveDoesNotFire() throws {
+        // The classic false-positive the gate prevents: a cache with a
+        // `save(key:value:)` method shouldn't classify as non-idempotent
+        // just because the verb matches Fluent.
+        let call = try firstCall(in: "func f() { cache.save() }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["MyApp"], enabledFrameworks: nil
+        ) == nil)
+    }
+
+    @Test
+    func importGated_fluentAbsent_setUpdateDoesNotFire() throws {
+        // stdlib `Set.update(with:)` must not classify as Fluent's
+        // non-idempotent `update` on an adopter that doesn't import FluentKit.
+        let call = try firstCall(in: "func f() { var s: Set<Int> = []; s.update(with: 1) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["MyApp"], enabledFrameworks: nil
+        ) == nil)
+    }
+
+    @Test
+    func fluent_bareSaveCall_doesNotFire() throws {
+        // No receiver = top-level free function, structurally unrelated
+        // to Fluent. Fluent's verbs are always called on a Model-conforming
+        // instance.
+        let call = try firstCall(in: "func f() { save() }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["FluentKit"], enabledFrameworks: nil
+        ) == nil)
+    }
+
+    @Test
+    func backwardCompat_importsNil_modelSaveFires() throws {
+        // nil imports = backward-compat mode where every framework is active.
+        let call = try firstCall(in: "func f() { todo.save() }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: nil, enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func configGated_fluentDisabled_modelSaveDoesNotFire() throws {
+        // Adopter has FluentKit imported but opted out of Fluent
+        // classifications in their .swiftprojectlint.yml.
+        let call = try firstCall(in: "func f() { todo.save() }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["FluentKit"], enabledFrameworks: ["Foundation"]
+        ) == nil)
+    }
+
+    @Test
+    func fluent_inferenceReason_namesFramework() throws {
+        let call = try firstCall(in: "func f() { todo.save() }")
+        let reason = HeuristicEffectInferrer.inferenceReason(
+            for: call, imports: ["FluentKit"], enabledFrameworks: nil
+        )
+        #expect(reason == "from the FluentKit ORM verb `save`")
+    }
+
     // MARK: - ImportCollector
 
     @Test

--- a/Tests/CoreTests/Idempotency/HeuristicInferenceTests.swift
+++ b/Tests/CoreTests/Idempotency/HeuristicInferenceTests.swift
@@ -403,9 +403,15 @@ struct HeuristicInferenceUnitTests {
     }
 
     @Test
-    func update_isNotInferred() throws {
+    func update_notInferred_withoutFluentImport() throws {
+        // `update` is framework-gated: fires on `model.update()` when
+        // FluentKit is imported (see `FrameworkWhitelistGatingTests`),
+        // stays silent otherwise. A user-defined `db.update(row)` in
+        // a module without `import FluentKit` does not trigger inference.
         let call = try firstCall(in: "func f() { db.update(row) }")
-        #expect(HeuristicEffectInferrer.infer(call: call) == nil)
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["MyApp"], enabledFrameworks: nil
+        ) == nil)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Closes round-13's Fluent adoption blocker: `save` / `update` / `delete` on `Model`-conforming types now infer `non_idempotent` when the file imports `FluentKit`.
- Shape follows PR #9 / PR #10 (import-gated framework whitelist), **not** the round-13 retrospective's literal "add to `nonIdempotentNames`" suggestion — that predates round-14 and would have fired on `Set.update(with:)`, cache `save(...)`, etc. in non-Fluent modules.
- New `FrameworkWhitelist.nonIdempotentMethodsByFramework` + `framework(forNonIdempotentMethod:)` lookup. `HeuristicEffectInferrer` fires only when the call has a receiver AND the Fluent framework is active (import + config gates both apply).
- Doc comment at the top of `HeuristicEffectInferrer.swift` updated — the old "deliberately not in the list" caveat for `save`/`update` now points at the framework gate.

## Test plan
- [x] Nine new tests in `FrameworkWhitelistGatingTests` — positive (`import FluentKit` → fires on save/update/delete), negative (`import MyApp` → silent on cache.save / Set.update), bare-call negative (no receiver → silent even with Fluent imported), backward-compat (`imports: nil` → fires), config-gated (FluentKit imported but disabled in enabledFrameworks → silent), inference-reason check.
- [x] One existing test rewritten: `update_isNotInferred` → `update_notInferred_withoutFluentImport` (asserts the framework gate's negative case under the new API).
- [x] `swift test` — 2196 tests / 275 suites, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)