### PR TITLE
Drop nil-imports backward-compat from heuristic inference API

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/Visitors/IdempotencyViolationVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/Visitors/IdempotencyViolationVisitor.swift
@@ -436,9 +436,9 @@ final class IdempotencyViolationVisitor: BasePatternVisitor, CrossFilePatternVis
     ]
 
     /// Per-file imports cache. See `NonIdempotentInRetryContextVisitor.imports(forSiteFile:)`.
-    private func imports(forSiteFile path: String) -> Set<String>? {
+    private func imports(forSiteFile path: String) -> Set<String> {
         if let cached = importCache[path] { return cached }
-        guard let source = fileCache[path] else { return nil }
+        guard let source = fileCache[path] else { return [] }
         let set = ImportCollector.imports(in: source)
         importCache[path] = set
         return set

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/Visitors/NonIdempotentInRetryContextVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/Visitors/NonIdempotentInRetryContextVisitor.swift
@@ -320,12 +320,12 @@ final class NonIdempotentInRetryContextVisitor: BasePatternVisitor, CrossFilePat
 
     /// Returns the base module imports for the file that hosts a site.
     /// Memoised off `fileCache` for the lifetime of a single analysis
-    /// run. Falls back to `nil` (no gating) when the path isn't in the
-    /// cache — preserves the old "heuristic applies always" behaviour
-    /// for call sites the visitor hasn't seen.
-    private func imports(forSiteFile path: String) -> Set<String>? {
+    /// run. Falls back to the empty set when the path isn't in the cache
+    /// (no source = no framework-gated whitelists fire for that site,
+    /// since we can't make import claims about a file we haven't seen).
+    private func imports(forSiteFile path: String) -> Set<String> {
         if let cached = importCache[path] { return cached }
-        guard let source = fileCache[path] else { return nil }
+        guard let source = fileCache[path] else { return [] }
         let set = ImportCollector.imports(in: source)
         importCache[path] = set
         return set

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/Visitors/UnannotatedInStrictReplayableContextVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/Visitors/UnannotatedInStrictReplayableContextVisitor.swift
@@ -294,9 +294,9 @@ final class UnannotatedInStrictReplayableContextVisitor:
     ]
 
     /// Per-file imports cache. See `NonIdempotentInRetryContextVisitor.imports(forSiteFile:)`.
-    private func imports(forSiteFile path: String) -> Set<String>? {
+    private func imports(forSiteFile path: String) -> Set<String> {
         if let cached = importCache[path] { return cached }
-        guard let source = fileCache[path] else { return nil }
+        guard let source = fileCache[path] else { return [] }
         let set = ImportCollector.imports(in: source)
         importCache[path] = set
         return set

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
@@ -97,40 +97,33 @@ public enum FrameworkWhitelist {
 /// "is this framework's whitelist active right now?" predicate. Used by
 /// `HeuristicEffectInferrer` to gate per-framework classifications.
 ///
-/// ## Backward-compat semantics
+/// ## Semantics
 ///
-/// When `imports` is `nil`, treat every framework as imported — this is
-/// the fallback used by call sites that haven't been updated to thread
-/// imports through yet.
-///
-/// When `imports` is an **empty** set, treat the source as having
-/// unknown module context (typical for synthetic test fixtures that
-/// declare types without importing modules). Falls back to the
-/// everything-active behaviour. Only a non-empty `imports` set engages
-/// the import gate — an adopter file with at least one `import`
-/// declaration supplies enough signal to trust the gate.
+/// `imports` is the **concrete** set of base module names the enclosing
+/// source file imports (see `ImportCollector.imports(in:)`). An empty
+/// set means "no framework-gated whitelists fire" — synthetic fixtures
+/// without imports and adopter files that simply don't use a given
+/// framework behave identically. Callers that want to bypass the gate
+/// must supply the relevant framework name explicitly.
 ///
 /// When `enabledFrameworks` is `nil`, treat every framework as enabled —
 /// the default when a project hasn't set `enabled_framework_whitelists`
-/// in its `.swiftprojectlint.yml`.
+/// in its `.swiftprojectlint.yml`. A non-nil value restricts
+/// classification to the listed frameworks.
 ///
-/// Both must be "active" for the whitelist to fire.
+/// Both the import gate and the config gate must be active for the
+/// whitelist to fire.
 public struct FrameworkContext: Sendable {
-    public let imports: Set<String>?
+    public let imports: Set<String>
     public let enabled: Set<String>?
 
-    public init(imports: Set<String>?, enabled: Set<String>?) {
+    public init(imports: Set<String>, enabled: Set<String>?) {
         self.imports = imports
         self.enabled = enabled
     }
 
     public func isFrameworkActive(_ framework: String) -> Bool {
-        let importOK: Bool
-        if let imports, !imports.isEmpty {
-            importOK = imports.contains(framework)
-        } else {
-            importOK = true
-        }
+        let importOK = imports.contains(framework)
         let enabledOK = enabled?.contains(framework) ?? true
         return importOK && enabledOK
     }

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
@@ -63,32 +63,24 @@ import SwiftSyntax
 ///   Project-level overrides are a follow-up when evidence supports it.
 public enum HeuristicEffectInferrer {
 
-    /// Returns the inferred effect of a call based on its callee syntax,
-    /// or `nil` if no heuristic applies. Backward-compatible entry point —
-    /// equivalent to `infer(call:imports: nil, enabledFrameworks: nil)`.
-    public static func infer(call: FunctionCallExprSyntax) -> DeclaredEffect? {
-        infer(call: call, imports: nil, enabledFrameworks: nil)
-    }
-
-    /// Import-aware and config-aware inference.
+    /// Infers an effect for an unannotated callee from its call-site syntax,
+    /// or returns `nil` when no heuristic applies.
     ///
     /// - Parameters:
-    ///   - call: the call syntax under test
+    ///   - call: the call syntax under test.
     ///   - imports: base module names imported in the enclosing source
-    ///     file (see `ImportCollector.imports(in:)`). Pass `nil` to skip
-    ///     import gating entirely — every framework whitelist applies by
-    ///     name, preserving the pre-round-14 behaviour that unit-test
-    ///     fixtures rely on. Pass an explicit set (even empty) to enable
-    ///     import gating — framework whitelists only fire when their
-    ///     required module is imported.
+    ///     file (see `ImportCollector.imports(in:)`). Defaults to an
+    ///     empty set, in which case no framework-gated whitelist fires —
+    ///     only un-gated paths (bare-name triggers, logger receiver
+    ///     shape) produce an effect.
     ///   - enabledFrameworks: per-framework config override. `nil` means
     ///     "all frameworks enabled" (default). Non-nil restricts
     ///     classification to the listed framework names (from
     ///     `FrameworkWhitelist.knownFrameworks`).
     public static func infer(
         call: FunctionCallExprSyntax,
-        imports: Set<String>?,
-        enabledFrameworks: Set<String>?
+        imports: Set<String> = [],
+        enabledFrameworks: Set<String>? = nil
     ) -> DeclaredEffect? {
         guard let (calleeName, receiverName) = callParts(of: call.calledExpression) else {
             return nil
@@ -189,16 +181,12 @@ public enum HeuristicEffectInferrer {
 
     /// Human-readable reason string describing why a particular effect was
     /// inferred. Used in diagnostic prose so the user can see what the
-    /// linter matched against.
-    public static func inferenceReason(for call: FunctionCallExprSyntax) -> String? {
-        inferenceReason(for: call, imports: nil, enabledFrameworks: nil)
-    }
-
-    /// Import-aware / config-aware reason string. Mirrors `infer(call:imports:enabledFrameworks:)`.
+    /// linter matched against. Same argument semantics as
+    /// `infer(call:imports:enabledFrameworks:)`.
     public static func inferenceReason(
         for call: FunctionCallExprSyntax,
-        imports: Set<String>?,
-        enabledFrameworks: Set<String>?
+        imports: Set<String> = [],
+        enabledFrameworks: Set<String>? = nil
     ) -> String? {
         guard let (calleeName, receiverName) = callParts(of: call.calledExpression) else {
             return nil

--- a/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
+++ b/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
@@ -5,14 +5,13 @@ import Testing
 import SwiftSyntax
 import SwiftParser
 
-/// Round-14 follow-on coverage. Exercises the new
-/// `infer(call:imports:enabledFrameworks:)` API along three axes:
-///   1. Backward-compat — `imports = nil` matches every framework
-///      (preserves test fixtures that don't declare imports).
-///   2. Import-gated — explicit non-empty imports only fire matching
-///      frameworks' whitelists.
-///   3. Config-gated — `enabledFrameworks` non-nil restricts the active
-///      whitelist set even when imports would allow more.
+/// Covers the `infer(call:imports:enabledFrameworks:)` API along two axes:
+///   1. Import-gated — a framework's whitelist fires only when the
+///      `imports` set contains the framework's base module name.
+///      Absent module = silent (modulo un-gated paths like the logger
+///      receiver heuristic).
+///   2. Config-gated — `enabledFrameworks` non-nil restricts the active
+///      whitelist set even when imports would otherwise allow more.
 @Suite
 struct FrameworkWhitelistGatingTests {
 
@@ -30,26 +29,37 @@ struct FrameworkWhitelistGatingTests {
         return try #require(finder.call)
     }
 
-    // MARK: - Backward compatibility (imports = nil)
+    // MARK: - Empty imports (no framework gates fire)
 
     @Test
-    func backwardCompat_importsNil_jsonDecoderClassifiesIdempotent() throws {
-        let call = try firstCall(in: "func f() { _ = JSONDecoder() }")
-        // Old call site (and existing tests) expect this to fire.
-        #expect(HeuristicEffectInferrer.infer(
-            call: call, imports: nil, enabledFrameworks: nil
-        ) == .idempotent)
-    }
-
-    @Test
-    func backwardCompat_importsEmpty_jsonDecoderStillClassifiesIdempotent() throws {
-        // Empty imports = "synthetic fixture, no module signal" — falls
-        // back to the always-active behaviour. Round-14 design choice
-        // documented in `FrameworkContext`.
+    func emptyImports_jsonDecoderDoesNotFire() throws {
+        // An empty imports set means "no framework-gated whitelist is
+        // active" — synthetic fixtures and files without imports behave
+        // identically. Foundation's JSONDecoder stays unclassified.
         let call = try firstCall(in: "func f() { _ = JSONDecoder() }")
         #expect(HeuristicEffectInferrer.infer(
             call: call, imports: [], enabledFrameworks: nil
-        ) == .idempotent)
+        ) == nil)
+    }
+
+    @Test
+    func emptyImports_bareNameStillFires() throws {
+        // Bare-name whitelist (`create`/`insert`/etc.) is un-gated, so
+        // even with no imports the heuristic still classifies.
+        let call = try firstCall(in: "func f() { insert(row) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: [], enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func emptyImports_loggerStillFires() throws {
+        // The logger receiver-shape heuristic is intentionally un-gated
+        // (see `HeuristicEffectInferrer.loggerPattern` discussion).
+        let call = try firstCall(in: "func f() { logger.info(\"x\") }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: [], enabledFrameworks: nil
+        ) == .observational)
     }
 
     // MARK: - Import-gated (non-empty imports)
@@ -232,15 +242,6 @@ struct FrameworkWhitelistGatingTests {
         #expect(HeuristicEffectInferrer.infer(
             call: call, imports: ["FluentKit"], enabledFrameworks: nil
         ) == nil)
-    }
-
-    @Test
-    func backwardCompat_importsNil_modelSaveFires() throws {
-        // nil imports = backward-compat mode where every framework is active.
-        let call = try firstCall(in: "func f() { todo.save() }")
-        #expect(HeuristicEffectInferrer.infer(
-            call: call, imports: nil, enabledFrameworks: nil
-        ) == .nonIdempotent)
     }
 
     @Test

--- a/Tests/CoreTests/Idempotency/HeuristicInferenceTests.swift
+++ b/Tests/CoreTests/Idempotency/HeuristicInferenceTests.swift
@@ -258,25 +258,25 @@ struct HeuristicInferenceUnitTests {
     @Test
     func jsonDecoderConstructor_infersIdempotent() throws {
         let call = try firstCall(in: "func f() { _ = JSONDecoder() }")
-        #expect(HeuristicEffectInferrer.infer(call: call) == .idempotent)
+        #expect(HeuristicEffectInferrer.infer(call: call, imports: ["Foundation"]) == .idempotent)
     }
 
     @Test
     func jsonEncoderConstructor_infersIdempotent() throws {
         let call = try firstCall(in: "func f() { _ = JSONEncoder() }")
-        #expect(HeuristicEffectInferrer.infer(call: call) == .idempotent)
+        #expect(HeuristicEffectInferrer.infer(call: call, imports: ["Foundation"]) == .idempotent)
     }
 
     @Test
     func dataConstructor_infersIdempotent() throws {
         let call = try firstCall(in: "func f() { _ = Data(bytes) }")
-        #expect(HeuristicEffectInferrer.infer(call: call) == .idempotent)
+        #expect(HeuristicEffectInferrer.infer(call: call, imports: ["Foundation"]) == .idempotent)
     }
 
     @Test
     func byteBufferConstructor_infersIdempotent() throws {
         let call = try firstCall(in: "func f() { _ = ByteBuffer(bytes: data) }")
-        #expect(HeuristicEffectInferrer.infer(call: call) == .idempotent)
+        #expect(HeuristicEffectInferrer.infer(call: call, imports: ["NIOCore"]) == .idempotent)
     }
 
     @Test
@@ -284,7 +284,7 @@ struct HeuristicInferenceUnitTests {
         let call = try firstCall(
             in: "func f() { _ = ALBTargetGroupResponse(statusCode: .ok) }"
         )
-        #expect(HeuristicEffectInferrer.infer(call: call) == .idempotent)
+        #expect(HeuristicEffectInferrer.infer(call: call, imports: ["AWSLambdaEvents"]) == .idempotent)
     }
 
     @Test
@@ -317,19 +317,19 @@ struct HeuristicInferenceUnitTests {
     @Test
     func decoderDotDecode_infersIdempotent() throws {
         let call = try firstCall(in: "func f() { decoder.decode(T.self, from: data) }")
-        #expect(HeuristicEffectInferrer.infer(call: call) == .idempotent)
+        #expect(HeuristicEffectInferrer.infer(call: call, imports: ["Foundation"]) == .idempotent)
     }
 
     @Test
     func encoderDotEncode_infersIdempotent() throws {
         let call = try firstCall(in: "func f() { encoder.encode(value) }")
-        #expect(HeuristicEffectInferrer.infer(call: call) == .idempotent)
+        #expect(HeuristicEffectInferrer.infer(call: call, imports: ["Foundation"]) == .idempotent)
     }
 
     @Test
     func jsonDecoderStyleReceiver_infersIdempotent() throws {
         let call = try firstCall(in: "func f() { jsonDecoder.decode(T.self, from: data) }")
-        #expect(HeuristicEffectInferrer.infer(call: call) == .idempotent)
+        #expect(HeuristicEffectInferrer.infer(call: call, imports: ["Foundation"]) == .idempotent)
     }
 
     @Test
@@ -347,25 +347,25 @@ struct HeuristicInferenceUnitTests {
     @Test
     func counterIncrement_infersObservational() throws {
         let call = try firstCall(in: "func f() { counter.increment() }")
-        #expect(HeuristicEffectInferrer.infer(call: call) == .observational)
+        #expect(HeuristicEffectInferrer.infer(call: call, imports: ["Metrics"]) == .observational)
     }
 
     @Test
     func meterDecrement_infersObservational() throws {
         let call = try firstCall(in: "func f() { activeRequestMeter.decrement() }")
-        #expect(HeuristicEffectInferrer.infer(call: call) == .observational)
+        #expect(HeuristicEffectInferrer.infer(call: call, imports: ["Metrics"]) == .observational)
     }
 
     @Test
     func timerRecordNanoseconds_infersObservational() throws {
         let call = try firstCall(in: "func f() { timer.recordNanoseconds(100) }")
-        #expect(HeuristicEffectInferrer.infer(call: call) == .observational)
+        #expect(HeuristicEffectInferrer.infer(call: call, imports: ["Metrics"]) == .observational)
     }
 
     @Test
     func gaugeRecord_infersObservational() throws {
         let call = try firstCall(in: "func f() { gauge.record(42.0) }")
-        #expect(HeuristicEffectInferrer.infer(call: call) == .observational)
+        #expect(HeuristicEffectInferrer.infer(call: call, imports: ["Metrics"]) == .observational)
     }
 
     @Test
@@ -381,7 +381,7 @@ struct HeuristicInferenceUnitTests {
         // `context.metrics.counter.increment()` — immediate-parent segment
         // is `counter`, which matches the metric-receiver shape.
         let call = try firstCall(in: "func f() { context.metrics.counter.increment() }")
-        #expect(HeuristicEffectInferrer.infer(call: call) == .observational)
+        #expect(HeuristicEffectInferrer.infer(call: call, imports: ["Metrics"]) == .observational)
     }
 
     // MARK: - Names deliberately left out of the whitelist

--- a/Tests/CoreTests/Idempotency/MultiHopUpwardInferenceTests.swift
+++ b/Tests/CoreTests/Idempotency/MultiHopUpwardInferenceTests.swift
@@ -319,7 +319,7 @@ struct MultiHopUpwardInferenceTests {
         table.applyUpwardInference(
             to: [source],
             multiHop: true,
-            heuristicEffectForCall: HeuristicEffectInferrer.infer(call:)
+            heuristicEffectForCall: { HeuristicEffectInferrer.infer(call: $0) }
         )
 
         let leafSig = FunctionSignature(name: "leaf", argumentLabels: [])
@@ -357,7 +357,7 @@ struct MultiHopUpwardInferenceTests {
         table.merge(source: source)
         table.applyUpwardInference(
             to: [source],
-            heuristicEffectForCall: HeuristicEffectInferrer.infer(call:)
+            heuristicEffectForCall: { HeuristicEffectInferrer.infer(call: $0) }
         )
 
         let leafSig = FunctionSignature(name: "leaf", argumentLabels: [])


### PR DESCRIPTION
## Summary
- Remove the `imports: Set<String>?` double-sentinel pattern introduced in round 14. `nil` and `[]` both meant "every framework active" (pre-round-14 fallback), which forced every new framework-gated whitelist to add its own backward-compat test.
- `HeuristicEffectInferrer.infer` / `inferenceReason` now take `imports: Set<String> = []` — empty set is the canonical "no framework gates fire" signal. Unary overloads removed.
- `FrameworkContext.imports` becomes non-optional; `isFrameworkActive` simplifies to `imports.contains(framework) && enabled?.contains(framework) ?? true`.
- The three rule visitors' `imports(forSiteFile:)` helpers return `Set<String>` (cache miss → `[]`), instead of `Set<String>?`. Production call sites already thread imports explicitly — zero behaviour change on real adopter code, only at the untouched edge case of a call site whose source isn't in the file cache.

## Motivation
PR #11 added the Fluent framework gate and had to ship a `backwardCompat_importsNil_modelSaveFires` test purely to participate in the nil-fallback. That was the third "backward-compat" test on the same pattern. The compat layer is dead debt in a solo repo where all production callers thread imports.

## Test plan
- [x] `swift test` — 2196 tests / 275 suites, all green.
- [x] Deleted three dead tests (`backwardCompat_importsNil_jsonDecoderClassifiesIdempotent`, `backwardCompat_importsEmpty_jsonDecoderStillClassifiesIdempotent`, `backwardCompat_importsNil_modelSaveFires`).
- [x] Added three tests explicitly asserting the new empty-imports contract (`emptyImports_jsonDecoderDoesNotFire`, `emptyImports_bareNameStillFires`, `emptyImports_loggerStillFires`).
- [x] Framework-gated fixtures in `HeuristicInferenceTests` now pass the relevant framework in `imports:` instead of relying on the nil-fallback.
- [x] `MultiHopUpwardInferenceTests` wraps the inferrer in a closure (unary function reference no longer resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)