### PR TITLE
Framework whitelist: Fluent query-builder reads as idempotent

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
@@ -91,6 +91,38 @@ public enum FrameworkWhitelist {
     public static func framework(forNonIdempotentMethod name: String) -> String? {
         nonIdempotentMethodsByFramework[name]
     }
+
+    // MARK: - Idempotent methods (framework-gated)
+
+    /// Maps a method name to the framework it belongs to, when the
+    /// method is a known read-only / pure operation inside that
+    /// framework. Fluent's query-builder reads are the motivating case:
+    /// `db`, `query`, `all`, `first`, `filter` are all idempotent when
+    /// invoked through FluentKit's `Database` / `QueryBuilder` surface,
+    /// but have unrelated (usually also idempotent) senses elsewhere
+    /// in Swift. Gating on `import FluentKit` resolves which module
+    /// owns the name; the idempotent classification is correct for
+    /// either interpretation, so a cross-framework false positive
+    /// would only change the *reason* string, not the effect.
+    ///
+    /// Unlike type-constructor whitelists, these are ordinary
+    /// method-call names — they can appear as `.method()` on any
+    /// receiver, or bare-style when chained after another call.
+    /// The gate therefore does not require a receiver; the import
+    /// presence is the load-bearing signal.
+    private static let idempotentMethodsByFramework: [String: String] = [
+        "db": fluent,
+        "query": fluent,
+        "all": fluent,
+        "first": fluent,
+        "filter": fluent,
+    ]
+
+    /// Returns the framework that owns a given idempotent method
+    /// name, or nil when the name isn't on any framework's list.
+    public static func framework(forIdempotentMethod name: String) -> String? {
+        idempotentMethodsByFramework[name]
+    }
 }
 
 /// Combines file-level imports and project-level config into an

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
@@ -40,6 +40,15 @@ import SwiftSyntax
 ///   senses elsewhere (`Set.update(with:)`, a cache's `save(key:value:)`).
 ///   See `FrameworkWhitelist.framework(forNonIdempotentMethod:)`.
 ///
+/// - Framework-gated idempotent triggers: Fluent's query-builder
+///   read verbs (`db`, `query`, `all`, `first`, `filter`) fire as
+///   `idempotent` when the file imports `FluentKit`. These are the
+///   read-only counterparts to the save/update/delete gate above —
+///   same import signal, opposite classification. Silences strict-
+///   mode diagnostics on typical `Model.query(on: db).filter(...).all()`
+///   chains without requiring per-callee annotations.
+///   See `FrameworkWhitelist.framework(forIdempotentMethod:)`.
+///
 /// - Idempotent bare-name triggers: `upsert`, `setIfAbsent`, `replace`.
 ///   These are explicit declarations of intent in the name itself.
 ///
@@ -152,6 +161,19 @@ public enum HeuristicEffectInferrer {
             return .nonIdempotent
         }
 
+        // Framework-gated idempotent methods (Fluent's query-builder reads).
+        // No receiver requirement: these commonly appear as chained
+        // calls like `Todo.query(on: db).filter(...).all()` where the
+        // AST walker can't bind a simple receiver identifier to the
+        // terminal call. The FluentKit import presence is the
+        // load-bearing signal.
+        if let framework = FrameworkWhitelist.framework(
+               forIdempotentMethod: calleeName
+           ),
+           context.isFrameworkActive(framework) {
+            return .idempotent
+        }
+
         // Framework-gated non-idempotent methods (Fluent's save/update/delete).
         // Receiver-only: `model.save()` is the adopter shape; a bare
         // `save()` in a module that imports FluentKit is structurally
@@ -234,6 +256,12 @@ public enum HeuristicEffectInferrer {
            ),
            context.isFrameworkActive(framework) {
             return "from the \(framework) ORM verb `\(calleeName)`"
+        }
+        if let framework = FrameworkWhitelist.framework(
+               forIdempotentMethod: calleeName
+           ),
+           context.isFrameworkActive(framework) {
+            return "from the \(framework) query-builder read `\(calleeName)`"
         }
         // Prefix-matched calls credit the matched verb explicitly so the
         // user can see which heuristic fired and why.

--- a/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
+++ b/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
@@ -29,6 +29,32 @@ struct FrameworkWhitelistGatingTests {
         return try #require(finder.call)
     }
 
+    /// Locates a specific member-access call by method name in a source
+    /// snippet. Needed to pick the terminal `.all()` / `.first()` etc.
+    /// out of a chained expression where `firstCall` would return the
+    /// outer-most call.
+    private func memberCall(method: String, in source: String) throws -> FunctionCallExprSyntax {
+        final class Finder: SyntaxVisitor {
+            let method: String
+            var call: FunctionCallExprSyntax?
+            init(method: String) {
+                self.method = method
+                super.init(viewMode: .sourceAccurate)
+            }
+            override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+                if call == nil,
+                   let member = node.calledExpression.as(MemberAccessExprSyntax.self),
+                   member.declName.baseName.text == method {
+                    call = node
+                }
+                return .visitChildren
+            }
+        }
+        let finder = Finder(method: method)
+        finder.walk(Parser.parse(source: source))
+        return try #require(finder.call, "expected a call to .\(method)")
+    }
+
     // MARK: - Empty imports (no framework gates fire)
 
     @Test
@@ -261,6 +287,83 @@ struct FrameworkWhitelistGatingTests {
             for: call, imports: ["FluentKit"], enabledFrameworks: nil
         )
         #expect(reason == "from the FluentKit ORM verb `save`")
+    }
+
+    // MARK: - Fluent query-builder idempotent reads (framework-gated)
+
+    @Test
+    func importGated_fluentPresent_queryFires() throws {
+        let call = try firstCall(in: "func f() { Todo.query(on: db) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["FluentKit"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_fluentPresent_allFires_onChainedCall() throws {
+        // Critical shape: `Todo.query(on: db).all()` — the terminal
+        // `.all()` has no simple receiver identifier (its base is a
+        // FunctionCallExpr, not a DeclRefExpr). The idempotent gate
+        // must fire without a receiver binding.
+        let source = "func f() { _ = Todo.query(on: db).all() }"
+        let call = try memberCall(method: "all", in: source)
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["FluentKit"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_fluentPresent_firstFires_onChainedCall() throws {
+        let source = "func f() { _ = Todo.query(on: db).filter(x).first() }"
+        let call = try memberCall(method: "first", in: source)
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["FluentKit"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_fluentPresent_filterFires_onChainedCall() throws {
+        let source = "func f() { _ = Todo.query(on: db).filter(x).all() }"
+        let call = try memberCall(method: "filter", in: source)
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["FluentKit"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_fluentPresent_dbFires() throws {
+        let call = try firstCall(in: "func f() { fluent.db() }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["FluentKit"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_fluentAbsent_queryDoesNotFire() throws {
+        // User-defined `.query()` in a module without FluentKit —
+        // classification is not Fluent's business.
+        let call = try firstCall(in: "func f() { db.query(on: x) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["MyApp"], enabledFrameworks: nil
+        ) == nil)
+    }
+
+    @Test
+    func configGated_fluentDisabled_queryDoesNotFire() throws {
+        let call = try firstCall(in: "func f() { Todo.query(on: db) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["FluentKit"], enabledFrameworks: ["Foundation"]
+        ) == nil)
+    }
+
+    @Test
+    func fluentIdempotent_inferenceReason_namesFramework() throws {
+        let source = "func f() { _ = Todo.query(on: db).all() }"
+        let call = try memberCall(method: "all", in: source)
+        let reason = HeuristicEffectInferrer.inferenceReason(
+            for: call, imports: ["FluentKit"], enabledFrameworks: nil
+        )
+        #expect(reason == "from the FluentKit query-builder read `all`")
     }
 
     // MARK: - ImportCollector


### PR DESCRIPTION
## Summary
- Parallel to PR #11 (Fluent ORM-verb non_idempotent gate). Adds the read-only counterpart: `db`, `query`, `all`, `first`, `filter` classify as `idempotent` when the file imports `FluentKit`.
- Closes the biggest named adoption-gap cluster from the hummingbird-examples/todos-fluent road-test: **7 of 14** strict-mode "unannotated callee" diagnostics on that round fall inside this whitelist.
- No receiver requirement — unlike the non-idempotent gate, these verbs commonly appear as terminal calls in chained expressions (`Todo.query(on: db).filter(...).all()`) where the AST walker can't bind a simple receiver identifier.

## Architecture
`FrameworkWhitelist.framework(forIdempotentMethod:)` mirrors the non-idempotent lookup from PR #11. Same FrameworkContext gating (import + config). Doc comment on `HeuristicEffectInferrer` extended to describe both Fluent gates symmetrically.

## Test plan
- [x] Eight new tests in `FrameworkWhitelistGatingTests` — each of the 5 verbs (positive), chained-call shape (critical for `.all()` / `.first()` / `.filter()` where the base is a FunctionCallExpr), absent-import negative, config-disabled negative, inference-reason wording check.
- [x] `swift test` — 2204 tests / 275 suites, all green (was 2196 pre-slice).
- [ ] Next round will re-measure todos-fluent strict_replayable to confirm the predicted ~7 silences land in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)