### PR TITLE
Framework whitelist: Hummingbird primitives (HTTPError + request.decode + parameters.require)

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
@@ -28,12 +28,14 @@ public enum FrameworkWhitelist {
     public static let osLog = "os"
     public static let metrics = "Metrics"
     public static let fluent = "FluentKit"
+    public static let hummingbird = "Hummingbird"
 
     /// Every framework this project recognises. Order-insensitive.
     /// Used as the default `enabledFrameworks` set when a project
     /// hasn't opted out of any framework's classifications.
     public static let knownFrameworks: Set<String> = [
-        foundation, nio, awsLambdaEvents, logging, osLog, metrics, fluent
+        foundation, nio, awsLambdaEvents, logging, osLog, metrics, fluent,
+        hummingbird
     ]
 
     // MARK: - Idempotent type constructors (bare-identifier call)
@@ -59,6 +61,11 @@ public enum FrameworkWhitelist {
         "ALBTargetGroupResponse": awsLambdaEvents,
         "APIGatewayResponse": awsLambdaEvents,
         "APIGatewayV2Response": awsLambdaEvents,
+
+        // Hummingbird — error constructors (value types; throwing them
+        // is the control-flow mechanism, but constructing the value
+        // is pure).
+        "HTTPError": hummingbird,
     ]
 
     /// Returns the framework that owns a given idempotent type
@@ -122,6 +129,35 @@ public enum FrameworkWhitelist {
     /// name, or nil when the name isn't on any framework's list.
     public static func framework(forIdempotentMethod name: String) -> String? {
         idempotentMethodsByFramework[name]
+    }
+
+    // MARK: - Idempotent receiver/method pairs (framework-gated)
+
+    /// Idempotent `(receiver, method)` pairs — used when the method
+    /// name alone is too ambiguous to whitelist but the combination
+    /// is a specific framework idiom. Nested dictionary keyed by
+    /// method first (matching the inferrer's lookup pattern) then
+    /// by receiver name.
+    ///
+    /// Hummingbird's `request.decode(...)` and `parameters.require(...)`
+    /// are the motivating pair. `decode` as a bare method would fire
+    /// on any `.decode()` call in a Hummingbird-importing file (the
+    /// existing codec-receiver path only matches `decoder` / `encoder`
+    /// receivers), and `require` is generic enough to collide with
+    /// user-defined validation helpers. Pinning to the specific
+    /// framework-canonical receiver name avoids both problems.
+    private static let idempotentReceiverMethodsByFramework: [String: [String: String]] = [
+        "decode": ["request": hummingbird],
+        "require": ["parameters": hummingbird],
+    ]
+
+    /// Returns the framework that owns a given idempotent
+    /// `(receiver, method)` pair, or nil when the pair isn't listed.
+    public static func framework(
+        forIdempotentReceiver receiver: String,
+        method: String
+    ) -> String? {
+        idempotentReceiverMethodsByFramework[method]?[receiver]
     }
 }
 

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
@@ -49,6 +49,15 @@ import SwiftSyntax
 ///   chains without requiring per-callee annotations.
 ///   See `FrameworkWhitelist.framework(forIdempotentMethod:)`.
 ///
+/// - Framework-gated receiver/method pairs: where a method name is
+///   too generic to whitelist alone but the `(receiver, method)`
+///   combination is a specific framework idiom. Hummingbird's
+///   `request.decode(...)` and `parameters.require(...)` are the
+///   motivating cases — pinned to the framework-canonical receiver
+///   name so that unrelated `.decode()` / `.require()` calls in the
+///   same file don't incorrectly classify.
+///   See `FrameworkWhitelist.framework(forIdempotentReceiver:method:)`.
+///
 /// - Idempotent bare-name triggers: `upsert`, `setIfAbsent`, `replace`.
 ///   These are explicit declarations of intent in the name itself.
 ///
@@ -137,6 +146,19 @@ public enum HeuristicEffectInferrer {
            isCodecReceiver(receiverName),
            codecMethods.contains(calleeName),
            context.isFrameworkActive(FrameworkWhitelist.foundation) {
+            return .idempotent
+        }
+
+        // Framework-gated idempotent (receiver, method) pairs —
+        // Hummingbird's `request.decode(...)` / `parameters.require(...)`
+        // motivating case. Specific pair match; the receiver has to
+        // be exactly the framework-canonical name.
+        if let receiverName,
+           let framework = FrameworkWhitelist.framework(
+               forIdempotentReceiver: receiverName,
+               method: calleeName
+           ),
+           context.isFrameworkActive(framework) {
             return .idempotent
         }
 
@@ -238,6 +260,14 @@ public enum HeuristicEffectInferrer {
            codecMethods.contains(calleeName),
            context.isFrameworkActive(FrameworkWhitelist.foundation) {
             return "from codec-pattern receiver `\(receiverName).\(calleeName)`"
+        }
+        if let receiverName,
+           let framework = FrameworkWhitelist.framework(
+               forIdempotentReceiver: receiverName,
+               method: calleeName
+           ),
+           context.isFrameworkActive(framework) {
+            return "from the \(framework) primitive `\(receiverName).\(calleeName)`"
         }
         if idempotentNames.contains(calleeName) || nonIdempotentNames.contains(calleeName) {
             // Receiver-type-excluded pairs produce no reason, mirroring

--- a/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
+++ b/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
@@ -366,6 +366,107 @@ struct FrameworkWhitelistGatingTests {
         #expect(reason == "from the FluentKit query-builder read `all`")
     }
 
+    // MARK: - Hummingbird primitives (framework-gated)
+
+    @Test
+    func importGated_hummingbirdPresent_httpErrorFires() throws {
+        let call = try firstCall(in: "func f() { _ = HTTPError(.notFound) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Hummingbird"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_hummingbirdAbsent_httpErrorDoesNotFire() throws {
+        // A user-defined `HTTPError` type in a module without Hummingbird
+        // shouldn't classify.
+        let call = try firstCall(in: "func f() { _ = HTTPError(.notFound) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["MyApp"], enabledFrameworks: nil
+        ) == nil)
+    }
+
+    @Test
+    func importGated_hummingbirdPresent_requestDecodeFires() throws {
+        let call = try firstCall(in: "func f() { try await request.decode(as: T.self) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Hummingbird"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_hummingbirdAbsent_requestDecodeDoesNotFire() throws {
+        let call = try firstCall(in: "func f() { try await request.decode(as: T.self) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["MyApp"], enabledFrameworks: nil
+        ) == nil)
+    }
+
+    @Test
+    func importGated_hummingbirdPresent_parametersRequireFires() throws {
+        // Chained receiver — callParts extracts "parameters" from
+        // context.parameters.require(...) via the immediate-parent rule.
+        let call = try firstCall(in: "func f() { try context.parameters.require(\"id\", as: UUID.self) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Hummingbird"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_hummingbirdAbsent_parametersRequireDoesNotFire() throws {
+        let call = try firstCall(in: "func f() { try context.parameters.require(\"id\", as: UUID.self) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["MyApp"], enabledFrameworks: nil
+        ) == nil)
+    }
+
+    @Test
+    func hummingbirdPair_wrongReceiver_doesNotFire() throws {
+        // `.decode()` on a non-`request` receiver in a Hummingbird-
+        // importing file: should NOT match the Hummingbird pair (only
+        // `request.decode` is whitelisted, not arbitrary `.decode()`).
+        // Codec-receiver path handles `decoder.decode` etc. separately.
+        let call = try firstCall(in: "func f() { try foo.decode(T.self) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Hummingbird"], enabledFrameworks: nil
+        ) == nil)
+    }
+
+    @Test
+    func hummingbirdPair_wrongMethod_doesNotFire() throws {
+        // `.wibble()` on `request` — method isn't in the pair table.
+        let call = try firstCall(in: "func f() { request.wibble() }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Hummingbird"], enabledFrameworks: nil
+        ) == nil)
+    }
+
+    @Test
+    func configGated_hummingbirdDisabled_httpErrorDoesNotFire() throws {
+        let call = try firstCall(in: "func f() { _ = HTTPError(.notFound) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Hummingbird"], enabledFrameworks: ["Foundation"]
+        ) == nil)
+    }
+
+    @Test
+    func hummingbird_httpError_inferenceReason() throws {
+        let call = try firstCall(in: "func f() { _ = HTTPError(.notFound) }")
+        let reason = HeuristicEffectInferrer.inferenceReason(
+            for: call, imports: ["Hummingbird"], enabledFrameworks: nil
+        )
+        #expect(reason == "from the known-idempotent Hummingbird type `HTTPError`")
+    }
+
+    @Test
+    func hummingbird_requestDecode_inferenceReason() throws {
+        let call = try firstCall(in: "func f() { try request.decode(as: T.self) }")
+        let reason = HeuristicEffectInferrer.inferenceReason(
+            for: call, imports: ["Hummingbird"], enabledFrameworks: nil
+        )
+        #expect(reason == "from the Hummingbird primitive `request.decode`")
+    }
+
     // MARK: - ImportCollector
 
     @Test


### PR DESCRIPTION
## Summary
- Adds `Hummingbird` as a recognised framework with three primitive entries:
  - `HTTPError` — bare-identifier type constructor into `idempotentTypesByFramework`
  - `request.decode(...)` — receiver-method pair into new `idempotentReceiverMethodsByFramework`
  - `parameters.require(...)` — same pair-based lookup
- Pair-based lookup is the new precision mechanism: `.decode` as a bare method would fire on any `.decode()` call in a Hummingbird-importing file (the existing codec-receiver path only handles `decoder`/`encoder` receivers). Pinning to the framework-canonical receiver name avoids collisions with user-defined `.decode()` / `.require()` helpers.
- Closes 4 of 6 strict-only diagnostics on the `hummingbird-examples/todos-fluent` corpus (see `swiftIdempotency/docs/hummingbird-examples/trial-findings.md`).

## Test plan
- [x] 11 new tests in `FrameworkWhitelistGatingTests` — each shape (type constructor + two pair shapes), positive + absent-import negative, wrong-receiver + wrong-method negatives (precision), config-gated negative, inference-reason strings.
- [x] `swift test` — 2215 tests / 275 suites, all green (was 2204 pre-slice).
- [ ] Follow-up: remeasure todos-fluent strict_replayable to confirm the predicted 4-diagnostic drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)