### PR TITLE
Move update to bare non-idempotent list (non-Fluent DB surfaces)

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
@@ -89,7 +89,6 @@ public enum FrameworkWhitelist {
     /// Gating on `import FluentKit` resolves the ambiguity.
     private static let nonIdempotentMethodsByFramework: [String: String] = [
         "save": fluent,
-        "update": fluent,
         "delete": fluent,
     ]
 

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
@@ -29,15 +29,22 @@ import SwiftSyntax
 /// - Non-idempotent bare-name triggers: names that are ~universally
 ///   non-idempotent in Swift/database/messaging codebases: `create`,
 ///   `insert`, `append`, `publish`, `enqueue`, `post`, `send`, `stop`,
-///   `destroy`. Names like `store`, `put`, `write` remain deliberately
-///   **not** in this list — they have too many idempotent interpretations
-///   (`put` is idempotent in REST semantics, `write` could mean atomic
-///   file write).
+///   `destroy`, `update`. The `update` entry catches non-Fluent DB
+///   surfaces (e.g. adopters with `@Dependency(\.database)` styles
+///   calling `database.updateX(...)`) — stdlib mutation APIs with
+///   the same name (`Set.update(with:)`, `Dictionary.updateValue(...)`)
+///   are suppressed via `StdlibExclusions` / the prefix-match stdlib
+///   gate. Names like `store`, `put`, `write` remain deliberately
+///   **not** in this list — they have too many idempotent
+///   interpretations (`put` is idempotent in REST semantics, `write`
+///   could mean atomic file write).
 ///
-/// - Framework-gated non-idempotent triggers: `save`, `update`, `delete`
-///   fire only when the file imports `FluentKit`. These are canonical
+/// - Framework-gated non-idempotent triggers: `save`, `delete` fire
+///   only when the file imports `FluentKit`. These are canonical
 ///   Fluent ORM verbs on `Model`-conforming types, but have idempotent
-///   senses elsewhere (`Set.update(with:)`, a cache's `save(key:value:)`).
+///   senses elsewhere (a cache's `save(key:value:)`, `collection.delete`
+///   wrappers in value-oriented APIs). `update` is no longer in the
+///   Fluent list — it's bare-matched instead (see the bullet above).
 ///   See `FrameworkWhitelist.framework(forNonIdempotentMethod:)`.
 ///
 /// - Framework-gated idempotent triggers: Fluent's query-builder
@@ -397,7 +404,8 @@ public enum HeuristicEffectInferrer {
         "post",
         "send",
         "stop",
-        "destroy"
+        "destroy",
+        "update"
     ]
 
     private static let idempotentNames: Set<String> = [

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/StdlibExclusions.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/StdlibExclusions.swift
@@ -69,10 +69,12 @@ public enum StdlibExclusions {
         TypeMethodPair(type: "String", method: "append"),
         TypeMethodPair(type: "String", method: "insert"),
 
-        // Set — semantic idempotency (insert/remove are set-idempotent).
+        // Set — semantic idempotency (insert/remove/update are set-idempotent;
+        // calling twice with the same element leaves the set in the same state).
         TypeMethodPair(type: "Set", method: "insert"),
         TypeMethodPair(type: "Set", method: "remove"),
         TypeMethodPair(type: "Set", method: "removeAll"),
+        TypeMethodPair(type: "Set", method: "update"),
 
         // Dictionary — key-addressed mutation is replay-safe.
         TypeMethodPair(type: "Dictionary", method: "removeValue"),

--- a/Tests/CoreTests/Idempotency/HeuristicInferenceTests.swift
+++ b/Tests/CoreTests/Idempotency/HeuristicInferenceTests.swift
@@ -403,15 +403,41 @@ struct HeuristicInferenceUnitTests {
     }
 
     @Test
-    func update_notInferred_withoutFluentImport() throws {
-        // `update` is framework-gated: fires on `model.update()` when
-        // FluentKit is imported (see `FrameworkWhitelistGatingTests`),
-        // stays silent otherwise. A user-defined `db.update(row)` in
-        // a module without `import FluentKit` does not trigger inference.
-        let call = try firstCall(in: "func f() { db.update(row) }")
-        #expect(HeuristicEffectInferrer.infer(
-            call: call, imports: ["MyApp"], enabledFrameworks: nil
-        ) == nil)
+    func update_bareName_firesOnNonStdlibReceivers() throws {
+        // `update` is in the bare non-idempotent list. Catches
+        // non-Fluent DB surfaces where an adopter has an
+        // `@Dependency(\.database)`-style accessor with `updateX`
+        // naming — the pointfreeco-shape case. Fires on any
+        // non-stdlib receiver; the stdlib-collection exclusions
+        // (Set.update, Dictionary.updateValue) are handled via
+        // `StdlibExclusions`.
+        let call = try firstCall(in: "func f() { database.update(row) }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .nonIdempotent)
+    }
+
+    @Test
+    func setUpdateWith_isExcluded() throws {
+        // `Set.update(with:)` leaves the set in the same final state
+        // on repeat invocation (set-idempotent semantics). Stdlib
+        // exclusion must suppress the bare-name `update` match.
+        let call = try memberCall(
+            method: "update",
+            in: "func f(s: Set<Int>) { s.update(with: 1) }"
+        )
+        #expect(HeuristicEffectInferrer.infer(call: call) == nil)
+    }
+
+    @Test
+    func prefixUpdateGiftStatus_firesOnUnresolvedReceiver() throws {
+        // Regression fixture for the pointfreeco adopter case:
+        // `database.updateGiftStatus(...)` via a swift-dependencies
+        // property. Receiver `database` resolves to `.unresolved`
+        // (not stdlib), so the prefix-match path fires.
+        let call = try memberCall(
+            method: "updateGiftStatus",
+            in: "func f() { database.updateGiftStatus(id, status, deliverNow) }"
+        )
+        #expect(HeuristicEffectInferrer.infer(call: call) == .nonIdempotent)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Closes the biggest cross-adopter gap from the pointfreeco road-test: non-Fluent adopters using \`database.updateX(...)\` patterns (very common with swift-dependencies or hand-rolled DB protocols) weren't catching retry-unsafe DB writes.
- Moves \`update\` from the Fluent framework gate (PR #11) into the bare \`nonIdempotentNames\` list. Fires on any \`update*\` call where the receiver doesn't resolve to a stdlib collection.
- Fluent adopters unaffected — \`model.update(on: db)\` still catches, just via the bare path instead of the framework path. Reason string shifts from "FluentKit ORM verb" to "callee-name prefix".

## Stdlib handling
- \`Set.update(with:)\` added to \`StdlibExclusions\`. Set semantics make same-element-twice idempotent.
- \`Dictionary.updateValue(_:forKey:)\` was already excluded under that exact method name.
- Prefix-match path already has a \`.stdlibCollection\` gate that handles \`updateX\` camelCase forms on stdlib receivers.

## Test plan
- [x] Rewrote \`update_notInferred_withoutFluentImport\` → \`update_bareName_firesOnNonStdlibReceivers\` (asserts new contract).
- [x] Added \`setUpdateWith_isExcluded\` regression guard.
- [x] Added \`prefixUpdateGiftStatus_firesOnUnresolvedReceiver\` for the pointfreeco-shape fixture.
- [x] \`swift test\` — 2217 tests / 275 suites, all green.
- [ ] Remeasure pointfreeco to confirm the predicted 2-catch lift (updateStripeSubscription + updateGiftStatus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)