### PR TITLE
Wall-clock budget on upward-inference fixed-point loop

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/EffectSymbolTable.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/EffectSymbolTable.swift
@@ -210,23 +210,37 @@ public struct EffectSymbolTable: Sendable {
         to sources: [SourceFileSyntax],
         multiHop: Bool = false,
         maxHops: Int = 5,
+        wallClockBudget: Duration = .seconds(30),
         heuristicEffectForCall: (FunctionCallExprSyntax, SourceFileSyntax) -> DeclaredEffect?
     ) {
+        // Wall-clock safety net for pathological corpora. The fixed-point
+        // loop is bounded by `maxHops`, but a single pass over a large
+        // corpus (e.g. swift-nio at 258 files × ~346 LOC average, wider
+        // per-file call graphs than typical adopter codebases) can take
+        // several minutes. Bail out with partial inference rather than
+        // hang indefinitely. Discovered when a 12-minute scan on swift-nio
+        // was still inside `runInferencePass` — see the trial notes under
+        // `docs/swift-nio/` in the companion SwiftIdempotency repo.
+        let deadline = ContinuousClock.now.advanced(by: wallClockBudget)
+
         runInferencePass(
             sources: sources,
             includeUpward: false,
             maxHops: maxHops,
+            deadline: deadline,
             heuristicEffectForCall: heuristicEffectForCall
         )
 
         guard multiHop else { return }
 
         for _ in 0..<maxHops {
+            if ContinuousClock.now >= deadline { return }
             let previousEffects = upwardInferredEffects.mapValues { $0.effect }
             runInferencePass(
                 sources: sources,
                 includeUpward: true,
                 maxHops: maxHops,
+                deadline: deadline,
                 heuristicEffectForCall: heuristicEffectForCall
             )
             let currentEffects = upwardInferredEffects.mapValues { $0.effect }
@@ -238,9 +252,11 @@ public struct EffectSymbolTable: Sendable {
         sources: [SourceFileSyntax],
         includeUpward: Bool,
         maxHops: Int,
+        deadline: ContinuousClock.Instant,
         heuristicEffectForCall: (FunctionCallExprSyntax, SourceFileSyntax) -> DeclaredEffect?
     ) {
         for source in sources {
+            if ContinuousClock.now >= deadline { return }
             let inferred = UpwardEffectInferrer.inferEffects(
                 in: source,
                 resolveCalleeEffect: { call in

--- a/Tests/CoreTests/Idempotency/MultiHopUpwardInferenceTests.swift
+++ b/Tests/CoreTests/Idempotency/MultiHopUpwardInferenceTests.swift
@@ -338,6 +338,69 @@ struct MultiHopUpwardInferenceTests {
         #expect(top.depth == 3)
     }
 
+    // MARK: - Wall-clock budget (pathological-corpus safety net)
+
+    @Test
+    func wallClockBudgetExpired_skipsInference() {
+        // Defensive guard for large corpora where a single upward-inference
+        // pass can run for minutes (the swift-nio case — 258 files ×
+        // ~346 LOC average produced a 12-minute hang before this guard
+        // shipped). A zero budget means the deadline has already passed
+        // by the time the inner-loop check runs, so no source is
+        // processed. Useful primarily as a degenerate regression guard
+        // that the budget parameter is actually wired in and checked.
+        let source = Parser.parse(source: """
+        /// @lint.effect non_idempotent
+        func sink() async throws {}
+
+        func leaf() async throws { try await sink() }
+        func mid() async throws { try await leaf() }
+        """)
+        var table = EffectSymbolTable()
+        table.merge(source: source)
+        table.applyUpwardInferenceImportAware(
+            to: [source],
+            multiHop: true,
+            wallClockBudget: .zero,
+            heuristicEffectForCall: { _, _ in nil }
+        )
+
+        let leafSig = FunctionSignature(name: "leaf", argumentLabels: [])
+        let midSig = FunctionSignature(name: "mid", argumentLabels: [])
+
+        // Zero budget ⇒ no work ⇒ no inference recorded.
+        #expect(table.upwardInferredEffect(for: leafSig) == nil)
+        #expect(table.upwardInferredEffect(for: midSig) == nil)
+    }
+
+    @Test
+    func wallClockBudgetGenerous_inferenceStillLands() {
+        // Sanity check the happy path: a generous budget on a tiny
+        // corpus does NOT interfere with normal inference. Ensures the
+        // guard isn't a correctness regression on small inputs.
+        let source = Parser.parse(source: """
+        /// @lint.effect non_idempotent
+        func sink() async throws {}
+
+        func leaf() async throws { try await sink() }
+        func mid() async throws { try await leaf() }
+        """)
+        var table = EffectSymbolTable()
+        table.merge(source: source)
+        table.applyUpwardInferenceImportAware(
+            to: [source],
+            multiHop: true,
+            wallClockBudget: .seconds(30),
+            heuristicEffectForCall: { _, _ in nil }
+        )
+
+        let leafSig = FunctionSignature(name: "leaf", argumentLabels: [])
+        let midSig = FunctionSignature(name: "mid", argumentLabels: [])
+
+        #expect(table.upwardInferredEffect(for: leafSig) == .nonIdempotent)
+        #expect(table.upwardInferredEffect(for: midSig) == .nonIdempotent)
+    }
+
     // MARK: - One-hop default still works for callers that opt out
 
     @Test


### PR DESCRIPTION
## Summary
- Adds a \`wallClockBudget: Duration = .seconds(30)\` parameter to \`EffectSymbolTable.applyUpwardInferenceImportAware\`. Bails out of the fixed-point loop with partial inference when the deadline expires.
- Defense in depth: deadline checked both at the outer multi-hop loop boundary and at each \`for source in sources\` iteration inside \`runInferencePass\`.
- Discovered investigating a 12-minute hang on \`apple/swift-nio\` — every stack sample (2215/2215) pinned the bottleneck inside \`runInferencePass\` during \`IdempotencyViolationVisitor.finalizeAnalysis\`. The outer loop is bounded by maxHops (5), but a single pass can itself be pathological on large corpora.

## Empirical result
swift-nio scan (258 files × ~346 LOC average): **12+ minutes hung → 3 minutes to completion**. Same result (\`No issues found\` on un-annotated corpus), delivered promptly.

## Graceful-degradation semantics
Multi-hop chains that would have resolved with infinite time may not resolve on huge corpora. Single-hop catches are preserved for the subset of sources processed before expiry. Small corpora (unit tests, typical adopter apps) see no behaviour change — 30s default is orders of magnitude larger than any realistic scan time there.

## Not in scope
Deep performance fix on the inner loop. The cause is likely quadratic-or-worse behaviour in some dimension of the call graph; proper fix would require profiling and restructuring. This PR is the safety net, not the cure.

## Test plan
- [x] Two new tests in \`MultiHopUpwardInferenceTests\`: zero-budget degenerate (nothing inferred) + generous-budget happy path (normal inference still lands).
- [x] \`swift test\` — 2219 tests / 275 suites, all green.
- [x] Empirical validation on swift-nio: scan completes in ~3 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)