### PR TITLE
Walk CodeBlockItem trivia for prefix-statement annotations

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/Visitors/NonIdempotentInRetryContextVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/Visitors/NonIdempotentInRetryContextVisitor.swift
@@ -111,17 +111,20 @@ final class NonIdempotentInRetryContextVisitor: BasePatternVisitor, CrossFilePat
     /// un-bound closure passed to a call — the Vapor / Hummingbird /
     /// Lambda idiom `app.on(.POST, "login") { req in ... }` — is its
     /// own analysis site when the call expression carries a
-    /// `/// @lint.context` annotation in its leading trivia.
+    /// `/// @lint.context` annotation.
     ///
     /// Round 6 flagged closure-based handlers as unannotatable under the
     /// original grammar, which blocked >50% of Vapor's routes surface.
     /// Round 10 re-surfaced it on Vapor's `Sources/Development/routes.swift`.
-    /// This visit method closes the gap for the common
-    /// "doc-comment-above-the-call" shape.
+    /// The TCA round (see
+    /// `swiftIdempotency/docs/swift-composable-architecture/`) surfaced a
+    /// follow-on gap: annotations above `return .run { ... }` bind to the
+    /// `return` keyword, not the call, so the call's own `leadingTrivia`
+    /// missed them. `parseContextAtCallSite` now walks the enclosing
+    /// `CodeBlockItemSyntax` to pick up prefix-statement placements
+    /// (`return`, `try`, `await`, `let x =`) and ternary branches.
     override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
-        guard let context = EffectAnnotationParser.parseContext(
-                leadingTrivia: node.leadingTrivia
-              ),
+        guard let context = EffectAnnotationParser.parseContextAtCallSite(of: node),
               let closure = node.trailingClosure else {
             return .visitChildren
         }
@@ -190,10 +193,12 @@ final class NonIdempotentInRetryContextVisitor: BasePatternVisitor, CrossFilePat
         // Same rule for annotated trailing-closure sites: the outer walk
         // must not descend into a call whose closure is its own analysis
         // site, or the inner calls would be attributed to the outer
-        // context twice.
+        // context twice. Must mirror the `visit` method's trivia lookup
+        // (call site + enclosing statement) or prefix-statement annotated
+        // sites get walked twice.
         if let call = syntax.as(FunctionCallExprSyntax.self),
            call.trailingClosure != nil,
-           EffectAnnotationParser.parseContext(leadingTrivia: call.leadingTrivia) != nil {
+           EffectAnnotationParser.parseContextAtCallSite(of: call) != nil {
             return
         }
         if let closure = syntax.as(ClosureExprSyntax.self), isEscapingClosure(closure) {

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/Visitors/UnannotatedInStrictReplayableContextVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/Visitors/UnannotatedInStrictReplayableContextVisitor.swift
@@ -122,11 +122,11 @@ final class UnannotatedInStrictReplayableContextVisitor:
     /// un-bound closure passed to a call with `/// @lint.context
     /// strict_replayable` above it becomes an analysis site. Matches the
     /// pattern in `NonIdempotentInRetryContextVisitor.visit(_:)`; see
-    /// that visitor's doc comment for the shape rationale.
+    /// that visitor's doc comment for the shape rationale and the TCA
+    /// adopter round for the prefix-statement gap this helper closes.
     override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
-        guard EffectAnnotationParser.parseContext(
-                leadingTrivia: node.leadingTrivia
-              ) == .strictReplayable,
+        guard EffectAnnotationParser.parseContextAtCallSite(of: node)
+                == .strictReplayable,
               let closure = node.trailingClosure else {
             return .visitChildren
         }
@@ -177,10 +177,13 @@ final class UnannotatedInStrictReplayableContextVisitor:
            EffectAnnotationParser.parseContext(declaration: varDecl) != nil {
             return
         }
-        // Same rule for annotated trailing-closure sites (round-11).
+        // Same rule for annotated trailing-closure sites (round-11). Use
+        // the call-site variant so prefix-statement annotations don't get
+        // double-walked — see NonIdempotentInRetryContextVisitor's matching
+        // guard.
         if let call = syntax.as(FunctionCallExprSyntax.self),
            call.trailingClosure != nil,
-           EffectAnnotationParser.parseContext(leadingTrivia: call.leadingTrivia) != nil {
+           EffectAnnotationParser.parseContextAtCallSite(of: call) != nil {
             return
         }
         if let closure = syntax.as(ClosureExprSyntax.self), isEscapingClosure(closure) {

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/EffectAnnotationParser.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/EffectAnnotationParser.swift
@@ -85,6 +85,54 @@ public enum EffectAnnotationParser {
         return nil
     }
 
+    /// Reads the `@lint.context` kind that applies to a call site, tolerating
+    /// prefix-statement placements that SwiftSyntax binds to a keyword token
+    /// rather than to the call expression itself.
+    ///
+    /// The call's own `leadingTrivia` catches the direct idiom
+    /// `/// @lint.context replayable\napp.post(...) { req in ... }`. But adopter
+    /// code often wraps the annotated call in a prefix statement —
+    /// `return .run { ... }`, `try foo { ... }`, `let x = bar { ... }`, or a
+    /// ternary branch `? a : .run { ... }`. In those cases SwiftSyntax attaches
+    /// the doc comment to the keyword (`return`, `try`, `await`, `let`) or to
+    /// the ternary `:`, not to the call's first token. The earlier implementation
+    /// checked only the call's own leading trivia and silently missed these
+    /// placements, yielding zero diagnostics on 100% of TCA-style reducer
+    /// effects.
+    ///
+    /// Policy: the enclosing `CodeBlockItemSyntax` bounds the search. Within
+    /// that statement, the most recent doc-comment annotation that precedes
+    /// the call (in source order) wins. Unrelated annotations in earlier
+    /// statements are isolated by the CodeBlockItem boundary.
+    public static func parseContextAtCallSite(
+        of call: FunctionCallExprSyntax
+    ) -> ContextEffect? {
+        if let context = parseContext(leadingTrivia: call.leadingTrivia) {
+            return context
+        }
+
+        var cursor: Syntax? = Syntax(call).parent
+        var enclosingItem: CodeBlockItemSyntax?
+        while let node = cursor {
+            if let item = node.as(CodeBlockItemSyntax.self) {
+                enclosingItem = item
+                break
+            }
+            cursor = node.parent
+        }
+        guard let enclosingItem else { return nil }
+
+        let callStart = call.positionAfterSkippingLeadingTrivia
+        var mostRecent: ContextEffect?
+        for token in enclosingItem.tokens(viewMode: .sourceAccurate) {
+            if token.position >= callStart { break }
+            if let context = parseContext(leadingTrivia: token.leadingTrivia) {
+                mostRecent = context
+            }
+        }
+        return mostRecent
+    }
+
     /// Reads the `@lint.effect` tier declared on a function. Considers
     /// both doc-comment annotations (`/// @lint.effect idempotent`) and
     /// attribute-form annotations emitted by the `SwiftIdempotency` macros

--- a/Tests/CoreTests/Idempotency/NonIdempotentInRetryContextVisitorTests.swift
+++ b/Tests/CoreTests/Idempotency/NonIdempotentInRetryContextVisitorTests.swift
@@ -260,6 +260,192 @@ struct NonIdempotentInRetryContextVisitorTests {
 
         #expect(visitor.detectedIssues.isEmpty)
     }
+
+    // MARK: - Prefix-statement annotation (return-trailing-annotation slice)
+    //
+    // Surfaced on the TCA adopter round
+    // (`swiftIdempotency/docs/swift-composable-architecture/trial-findings.md`).
+    // Doc comments above `return <call>`, `try <call>`, `await <call>`,
+    // `let x = <call>`, and ternary branches bind to the keyword token
+    // rather than the call's first token. The visitor now walks the
+    // enclosing `CodeBlockItemSyntax` to recover the annotation in these
+    // shapes.
+
+    @Test
+    func trailingClosureAnnotatedReplayable_underReturnCall_fires() throws {
+        // The TCA canonical shape: `return .run { send in ... }`.
+        let source = """
+        enum Effect {
+            static func run<A>(_ body: (Int) async throws -> Void) -> Effect<A> { fatalError() }
+        }
+
+        /// @lint.effect non_idempotent
+        func sendNotification(_ id: Int) async throws {}
+
+        func reduce(_ id: Int) -> Effect<Int> {
+            /// @lint.context replayable
+            return Effect.run { send in
+                try await sendNotification(id)
+            }
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.count == 1)
+        #expect(visitor.detectedIssues.first?.message.contains("sendNotification") == true)
+    }
+
+    @Test
+    func trailingClosureAnnotatedReplayable_underTryPrefix_fires() throws {
+        let source = """
+        /// @lint.effect non_idempotent
+        func sendNotification(_ id: Int) async throws {}
+
+        func wrapper(_ id: Int) throws {
+            /// @lint.context replayable
+            try withThrowingCallback { send in
+                try await sendNotification(id)
+            }
+        }
+
+        func withThrowingCallback(_ body: ((Int) async throws -> Void) throws -> Void) throws {}
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.count == 1)
+    }
+
+    @Test
+    func trailingClosureAnnotatedReplayable_underAwaitPrefix_fires() throws {
+        let source = """
+        /// @lint.effect non_idempotent
+        func sendNotification(_ id: Int) async throws {}
+
+        func wrapper(_ id: Int) async throws {
+            /// @lint.context replayable
+            await withAsyncCallback { send in
+                try await sendNotification(id)
+            }
+        }
+
+        func withAsyncCallback(_ body: ((Int) async throws -> Void) async -> Void) async {}
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.count == 1)
+    }
+
+    @Test
+    func trailingClosureAnnotatedReplayable_underLetAssignment_fires() throws {
+        let source = """
+        /// @lint.effect non_idempotent
+        func sendNotification(_ id: Int) async throws {}
+
+        func builder(_ id: Int) {
+            /// @lint.context replayable
+            let effect = EffectBuilder.build { send in
+                try await sendNotification(id)
+            }
+            _ = effect
+        }
+
+        enum EffectBuilder {
+            static func build(_ body: (Int) async throws -> Void) -> Int { 0 }
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.count == 1)
+    }
+
+    @Test
+    func trailingClosureAnnotatedReplayable_underTernaryBranch_fires() throws {
+        // TCA EffectsBasics shape: annotation between `?` and `:` branches.
+        let source = """
+        /// @lint.effect non_idempotent
+        func sendNotification(_ id: Int) async throws {}
+
+        enum Effect<A> {
+            static var none: Effect<A> { fatalError() }
+            static func run(_ body: (Int) async throws -> Void) -> Effect<A> { fatalError() }
+        }
+
+        func reduce(_ condition: Bool, _ id: Int) -> Effect<Int> {
+            return condition
+                ? .none
+                /// @lint.context replayable
+                : Effect.run { send in
+                    try await sendNotification(id)
+                }
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.count == 1)
+    }
+
+    @Test
+    func annotationInEarlierStatement_doesNotLeakIntoLaterCall() {
+        // The CodeBlockItem boundary isolates annotations. An annotation on
+        // one statement must not silently attach to the following
+        // statement's trailing-closure call.
+        let source = """
+        /// @lint.effect non_idempotent
+        func sendNotification(_ id: Int) async throws {}
+
+        func handler(_ id: Int) throws {
+            /// @lint.context replayable
+            let marker = 1
+
+            withCallback { send in
+                try await sendNotification(id)
+            }
+        }
+
+        func withCallback(_ body: ((Int) async throws -> Void) -> Void) {}
+        """
+
+        let visitor = run(source: source)
+
+        // The `let marker = 1` consumes the annotation (it has no closure,
+        // so it never becomes an analysis site — but its CodeBlockItem owns
+        // the trivia). The subsequent `withCallback { ... }` is its own
+        // CodeBlockItem with no annotation. No diagnostic.
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    @Test
+    func returnCallShape_strictReplayableAlsoCarried() throws {
+        // The same prefix-statement shape must carry through for
+        // strict_replayable as the label on the emitted message.
+        let source = """
+        enum Effect<A> {
+            static func run(_ body: (Int) async throws -> Void) -> Effect<A> { fatalError() }
+        }
+
+        /// @lint.effect non_idempotent
+        func sendNotification(_ id: Int) async throws {}
+
+        func reduce(_ id: Int) -> Effect<Int> {
+            /// @lint.context strict_replayable
+            return Effect.run { send in
+                try await sendNotification(id)
+            }
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.count == 1)
+        #expect(
+            visitor.detectedIssues.first?.message.contains("strict_replayable") == true
+        )
+    }
 }
 
 /// Cross-rule fixture: a function annotated with both an effect and a context.

--- a/Tests/CoreTests/Idempotency/UnannotatedInStrictReplayableContextVisitorTests.swift
+++ b/Tests/CoreTests/Idempotency/UnannotatedInStrictReplayableContextVisitorTests.swift
@@ -454,6 +454,85 @@ struct UnannotatedInStrictReplayableContextVisitorTests {
         #expect(visitor.detectedIssues.count == 1)
         #expect(visitor.detectedIssues.first?.message.contains("outer") == true)
     }
+
+    // MARK: - Prefix-statement annotation (return-trailing-annotation slice)
+    //
+    // Same shape as the matching tests in
+    // `NonIdempotentInRetryContextVisitorTests`; strict mode needs the
+    // same trivia lookup to create analysis sites for
+    // `return .run { ... }` / ternary-branch trailing-closure calls.
+
+    @Test
+    func strictReplayable_underReturnCall_firesOnUnannotated() throws {
+        let source = """
+        enum Effect<A> {
+            static func run(_ body: (Int) async throws -> Void) -> Effect<A> { fatalError() }
+        }
+
+        func mystery(_ id: Int) async throws {}
+
+        func reduce(_ id: Int) -> Effect<Int> {
+            /// @lint.context strict_replayable
+            return Effect.run { send in
+                try await mystery(id)
+            }
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.count == 1)
+        #expect(visitor.detectedIssues.first?.message.contains("mystery") == true)
+    }
+
+    @Test
+    func strictReplayable_underTernaryBranch_firesOnUnannotated() throws {
+        let source = """
+        enum Effect<A> {
+            static var none: Effect<A> { fatalError() }
+            static func run(_ body: (Int) async throws -> Void) -> Effect<A> { fatalError() }
+        }
+
+        func mystery(_ id: Int) async throws {}
+
+        func reduce(_ condition: Bool, _ id: Int) -> Effect<Int> {
+            return condition
+                ? .none
+                /// @lint.context strict_replayable
+                : Effect.run { send in
+                    try await mystery(id)
+                }
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.count == 1)
+    }
+
+    @Test
+    func strictReplayable_unrelatedEarlierAnnotation_doesNotLeak() {
+        // Regression guard: an earlier statement's annotation must not
+        // attach to a later trailing-closure call in the same scope.
+        let source = """
+        func mystery(_ id: Int) async throws {}
+
+        func handler(_ id: Int) throws {
+            /// @lint.context strict_replayable
+            let marker = 1
+
+            withCallback { send in
+                try await mystery(id)
+            }
+        }
+
+        func withCallback(_ body: ((Int) async throws -> Void) -> Void) {}
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
 }
 
 /// Cross-rule interaction: strict_replayable + declared non-idempotent callee


### PR DESCRIPTION
## Summary

Closes the `return-trailing-annotation` correctness slice surfaced on
the TCA adopter round
([swift-composable-architecture/trial-findings.md](https://github.com/Joseph-Cursio/SwiftIdempotency/blob/main/docs/swift-composable-architecture/trial-findings.md)).

Before: `/// @lint.context replayable` placed above `return .run { ... }`,
`try foo { ... }`, `await bar { ... }`, `let x = baz { ... }`, or a
ternary branch `? a : .run { ... }` was silently ignored. SwiftSyntax
attaches doc-comment trivia to the keyword token (`return`, `try`,
`await`, `let`, or `:`), not to the wrapped call expression, so the
old `node.leadingTrivia` check found nothing. 6 of 6 TCA annotation
sites were invisible to the visitor.

After: new helper `EffectAnnotationParser.parseContextAtCallSite(of:)`
walks up to the enclosing `CodeBlockItemSyntax` and scans every
preceding token's leading trivia for a context annotation. The
CodeBlockItem boundary isolates annotations so an earlier statement's
annotation can't leak into a later call.

Validation on the TCA adopter round: all 6 annotated `.run { send in
... }` sites across Todos / Search / EffectsBasics now produce
diagnostics. 22 in strict mode, 7 in replayable — up from 1 pre-fix
(the positive control).

## Test plan

- [x] `swift test` — 2229/275 green (up from 2219/275; 10 new tests)
- [x] New test coverage: `return Effect.run { }`, `try foo { }`,
      `await bar { }`, `let x = baz { }`, ternary `? a : .run { }`,
      `strict_replayable` variants, and a no-leak regression guard
      confirming the CodeBlockItem boundary works as intended
- [x] Re-ran the TCA round against the fixed linter; 6 of 6 annotated
      `.run { }` sites now fire as expected