### PR TITLE
Framework whitelist: TCA send-closure-parameter override

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
@@ -29,13 +29,14 @@ public enum FrameworkWhitelist {
     public static let metrics = "Metrics"
     public static let fluent = "FluentKit"
     public static let hummingbird = "Hummingbird"
+    public static let composableArchitecture = "ComposableArchitecture"
 
     /// Every framework this project recognises. Order-insensitive.
     /// Used as the default `enabledFrameworks` set when a project
     /// hasn't opted out of any framework's classifications.
     public static let knownFrameworks: Set<String> = [
         foundation, nio, awsLambdaEvents, logging, osLog, metrics, fluent,
-        hummingbird
+        hummingbird, composableArchitecture
     ]
 
     // MARK: - Idempotent type constructors (bare-identifier call)
@@ -157,6 +158,43 @@ public enum FrameworkWhitelist {
         method: String
     ) -> String? {
         idempotentReceiverMethodsByFramework[method]?[receiver]
+    }
+
+    // MARK: - Bare-name overrides of the non-idempotent list (framework-gated)
+
+    /// Bare-name callees that would otherwise hit
+    /// `HeuristicEffectInferrer.nonIdempotentNames` but are structurally
+    /// safe inside a specific framework's closure-parameter idiom. The
+    /// bare-name check is consulted *before* the non-idempotent list so
+    /// the framework import wins over the name heuristic.
+    ///
+    /// TCA's `Send<Action>` is the motivating case. Inside an `Effect`
+    /// closure (`.run { send in ... await send(.action) ... }`) the
+    /// `send` identifier is a closure parameter — calling it dispatches
+    /// an action value through the reducer, which is a pure state
+    /// transition, not a mail-sending side effect. The heuristic can't
+    /// tell the closure-parameter `send` apart from a receiverless
+    /// `mailer.send` by structure alone; the `ComposableArchitecture`
+    /// import is the disambiguating signal.
+    ///
+    /// Precision:
+    /// - Receiver must be nil — `mailer.send(.email)` keeps its
+    ///   non-idempotent classification even in a TCA-importing file.
+    /// - Exact-match only — `sendEmail(...)` still hits the prefix-match
+    ///   non-idempotent path; only the literal callee name `send` is
+    ///   exempted.
+    private static let bareNameIdempotentOverridesByFramework: [String: String] = [
+        "send": composableArchitecture,
+    ]
+
+    /// Returns the framework that owns a given bare-name override, or
+    /// nil when the name isn't listed. Callers must additionally check
+    /// that the call site has no receiver and that the framework is
+    /// active in the current `FrameworkContext`.
+    public static func framework(
+        forBareNameIdempotentOverride name: String
+    ) -> String? {
+        bareNameIdempotentOverridesByFramework[name]
     }
 }
 

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
@@ -169,6 +169,21 @@ public enum HeuristicEffectInferrer {
             return .idempotent
         }
 
+        // Framework-gated bare-name overrides of the non-idempotent list.
+        // TCA's `Send<Action>` closure parameter is the motivating case:
+        // `await send(.action)` inside an effect closure is a structural
+        // state-transition dispatch, not a mail-sending call. Must fire
+        // *before* the bare-name non-idempotent list below, otherwise
+        // `send` hits that list first. Exact-match + receiverless only;
+        // `sendEmail` and `mailer.send` stay non-idempotent.
+        if receiverName == nil,
+           let framework = FrameworkWhitelist.framework(
+               forBareNameIdempotentOverride: calleeName
+           ),
+           context.isFrameworkActive(framework) {
+            return .idempotent
+        }
+
         // Bare-name whitelists — now receiver-type gated. If the receiver
         // resolves to a stdlib collection whose (type, method) pair is in
         // the exclusion table, the bare-name match is suppressed. Named
@@ -275,6 +290,13 @@ public enum HeuristicEffectInferrer {
            ),
            context.isFrameworkActive(framework) {
             return "from the \(framework) primitive `\(receiverName).\(calleeName)`"
+        }
+        if receiverName == nil,
+           let framework = FrameworkWhitelist.framework(
+               forBareNameIdempotentOverride: calleeName
+           ),
+           context.isFrameworkActive(framework) {
+            return "from the \(framework) closure-parameter primitive `\(calleeName)`"
         }
         if idempotentNames.contains(calleeName) || nonIdempotentNames.contains(calleeName) {
             // Receiver-type-excluded pairs produce no reason, mirroring

--- a/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
+++ b/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
@@ -467,6 +467,73 @@ struct FrameworkWhitelistGatingTests {
         #expect(reason == "from the Hummingbird primitive `request.decode`")
     }
 
+    // MARK: - ComposableArchitecture (TCA) send-closure-parameter override
+
+    @Test
+    func importGated_tcaPresent_bareSendFiresIdempotent() throws {
+        // `await send(.action)` inside a TCA Effect closure — the bare
+        // `send` identifier is a `Send<Action>` closure parameter, and
+        // calling it dispatches a pure state transition through the
+        // reducer. With `import ComposableArchitecture` the override
+        // beats the bare-name non-idempotent entry for `send`.
+        let call = try firstCall(in: "func f() { send(.action) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["ComposableArchitecture"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_tcaAbsent_bareSendStaysNonIdempotent() throws {
+        // No TCA import — `send(...)` hits the bare-name non-idempotent
+        // list, which is the default posture for ambiguous `send` calls.
+        let call = try firstCall(in: "func f() { send(.action) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["MyApp"], enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func importGated_tcaPresent_receiverBasedSendStaysNonIdempotent() throws {
+        // Receiver-based `mailer.send(.email)` in a TCA-importing file —
+        // the override is receiverless-only. A user's mail-sending
+        // helper should stay non-idempotent; only the closure-parameter
+        // shape is exempted.
+        let call = try firstCall(in: "func f() { mailer.send(.email) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["ComposableArchitecture"], enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func importGated_tcaPresent_sendEmailStillPrefixMatches() throws {
+        // Exact-match only. `sendEmail(...)` still hits the
+        // `matchesNonIdempotentPrefix` path for composed camelCase verbs.
+        let call = try firstCall(in: "func f() { sendEmail(to: user) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["ComposableArchitecture"], enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func configGated_tcaDisabled_bareSendStaysNonIdempotent() throws {
+        // Adopter imports ComposableArchitecture but opted out via
+        // `enabled_framework_whitelists`. Override does not fire; the
+        // bare-name non-idempotent list wins.
+        let call = try firstCall(in: "func f() { send(.action) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["ComposableArchitecture"], enabledFrameworks: ["Foundation"]
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func tca_bareSend_inferenceReason_namesFramework() throws {
+        let call = try firstCall(in: "func f() { send(.action) }")
+        let reason = HeuristicEffectInferrer.inferenceReason(
+            for: call, imports: ["ComposableArchitecture"], enabledFrameworks: nil
+        )
+        #expect(reason == "from the ComposableArchitecture closure-parameter primitive `send`")
+    }
+
     // MARK: - ImportCollector
 
     @Test


### PR DESCRIPTION
## Summary
- Adds `ComposableArchitecture` as a recognised framework with one entry: `send` — bare-identifier closure-parameter override in a new `bareNameIdempotentOverridesByFramework` bucket.
- Motivating case: `await send(.action)` inside a TCA Effect closure invokes the `Send<Action>` closure parameter, which is a pure state-transition dispatch through the reducer — not a mail-sending side effect. Surfaced by the TCA post-fix re-run, where 6 of 6 effect closures were classified `non_idempotent` by the bare-name heuristic.
- The new bucket fires *before* the bare-name non-idempotent list so the framework import wins over the name heuristic. **Exact-match + receiverless only**:
  - `mailer.send(.email)` in a TCA-importing file stays non-idempotent (receiver is non-nil).
  - `sendEmail(...)` still hits the `matchesNonIdempotentPrefix` path (the override is exact-match).
- Parallels PR #14's Hummingbird primitive shape: per-framework lookup, gated on `import ComposableArchitecture` + `enabled_framework_whitelists` config.

## Test plan
- [x] 6 new tests in `FrameworkWhitelistGatingTests` — positive with import, absent-import negative, receiver-present negative (precision), prefix-match negative (precision), config-gated negative, inference-reason string.
- [x] `swift test` — 2235 tests / 275 suites, all green (was 2229 pre-slice).
- [ ] Follow-up: re-run the TCA post-fix corpus to confirm the predicted 6-of-6 drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)