### PR TITLE
Treat closure-typed stored properties as effect declarations

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/EffectSymbolTable.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/EffectSymbolTable.swift
@@ -84,12 +84,29 @@ public struct EffectSymbolTable: Sendable {
     /// to accumulate entries across files; the collision semantics apply
     /// uniformly within and across file boundaries.
     public mutating func merge(source: SourceFileSyntax) {
-        let collector = FunctionDeclCollector()
-        collector.walk(source)
-        for funcDecl in collector.functions {
+        let funcCollector = FunctionDeclCollector()
+        funcCollector.walk(source)
+        for funcDecl in funcCollector.functions {
             let effect = EffectAnnotationParser.parseEffect(declaration: funcDecl)
             let context = EffectAnnotationParser.parseContext(declaration: funcDecl)
             let signature = FunctionSignature.from(declaration: funcDecl)
+            record(signature: signature, effect: effect, context: context)
+        }
+
+        // Closure-typed stored properties as pseudo-method declarations.
+        // The `@DependencyClient`/`@MemberwiseInit`-style macros expose
+        // `var search: @Sendable (_ query: String) async throws -> T` as
+        // callable `search(query:)`; the linter can consume user
+        // annotations on these via the same signature-keyed table
+        // without having to run the macro.
+        let propCollector = ClosurePropertyDeclCollector()
+        propCollector.walk(source)
+        for varDecl in propCollector.properties {
+            guard let signature = FunctionSignature.from(declaration: varDecl) else {
+                continue
+            }
+            let effect = EffectAnnotationParser.parseEffect(declaration: varDecl)
+            let context = EffectAnnotationParser.parseContext(declaration: varDecl)
             record(signature: signature, effect: effect, context: context)
         }
     }
@@ -490,6 +507,34 @@ final class FunctionDeclCollector: SyntaxVisitor {
 
     override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
         functions.append(node)
+        return .visitChildren
+    }
+
+    override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
+        .skipChildren
+    }
+}
+
+/// Walks a source file and collects every `VariableDeclSyntax` that declares
+/// a single identifier whose annotated type is function-typed. These are the
+/// "closure property" shape — stored properties whose type is
+/// `(...) -> T`, `@Sendable (...) async throws -> T`, and so on. Macros
+/// like `@DependencyClient` expose them as method-call surfaces; the symbol
+/// table treats their annotations identically to real method declarations
+/// so user annotations land before macro expansion runs.
+///
+/// Collector only — filtering to function-typed bindings happens in
+/// `FunctionSignature.from(declaration: VariableDeclSyntax)`, which returns
+/// `nil` for non-qualifying vars and lets the caller skip them.
+final class ClosurePropertyDeclCollector: SyntaxVisitor {
+    var properties: [VariableDeclSyntax] = []
+
+    init() {
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+        properties.append(node)
         return .visitChildren
     }
 

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FunctionSignature.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FunctionSignature.swift
@@ -47,6 +47,84 @@ public extension FunctionSignature {
         return FunctionSignature(name: declaration.name.text, argumentLabels: labels)
     }
 
+    /// Computes the signature of a closure-typed stored property, treating it
+    /// as a pseudo-method declaration. Returns `nil` when the binding is not
+    /// a single named identifier or the declared type is not a function type.
+    ///
+    /// Attribute wrappers (`@Sendable`, `@MainActor`, `@escaping`, etc.) are
+    /// peeled before inspecting the type. A single optional wrapping a
+    /// function type (`((Int) -> Void)?`) is not supported — Swift function
+    /// types are already a nominal category, and wrapping them in `Optional`
+    /// is rare enough that pattern-matching the value shape isn't
+    /// worthwhile in this first slice.
+    ///
+    /// ## Label mapping ("Path A")
+    ///
+    /// Swift function types permit a `_ internalName:` parameter shape that
+    /// suppresses the call-site label at the type level. Macros in the
+    /// `@DependencyClient`/`@MemberwiseInit` family re-expose the var as
+    /// a method whose external label is the *internal* name, so the call
+    /// site written by users is `f(internalName:)`. This resolver honours
+    /// that convention: when `firstName` is `_` and `secondName` is a
+    /// non-empty identifier, the returned signature uses `secondName` as
+    /// the label.
+    ///
+    /// Concretely:
+    /// - `var f: (Int) -> Void`                → `f(_:)`
+    /// - `var f: (_ id: Int) -> Void`          → `f(id:)`      (Path A)
+    /// - `var f: (id: Int) -> Void`            → `f(id:)`
+    /// - `var f: @Sendable (_ x: String) async throws -> Bool` → `f(x:)`
+    ///
+    /// The tradeoff: a non-macro closure property `let f: (_ x: Int) -> Void`
+    /// called as `f(0)` produces an annotation-to-call-site mismatch
+    /// (`f(x:)` vs `f(_:)`). The mismatch is a false negative — the user's
+    /// annotation silently doesn't land — not a false positive, so the
+    /// heuristic is safe. The `_ name:` shape is in practice almost
+    /// exclusive to macro-wrapped declarations that re-label; the
+    /// alternative of using Swift-canonical `_` as the label produces
+    /// signatures that cannot match any TCA `@DependencyClient` call
+    /// site and delivers zero signal.
+    static func from(declaration: VariableDeclSyntax) -> FunctionSignature? {
+        guard let binding = declaration.bindings.first,
+              declaration.bindings.count == 1,
+              let pattern = binding.pattern.as(IdentifierPatternSyntax.self),
+              let typeAnnotation = binding.typeAnnotation else {
+            return nil
+        }
+        guard let fnType = unwrapFunctionType(typeAnnotation.type) else {
+            return nil
+        }
+        let labels = fnType.parameters.map { element -> String in
+            let first = element.firstName?.text ?? ""
+            let second = element.secondName?.text ?? ""
+            // Path A: `_ internalName:` → re-expose the internal name.
+            if first == "_" && !second.isEmpty {
+                return second
+            }
+            if first.isEmpty || first == "_" {
+                return "_"
+            }
+            return first
+        }
+        return FunctionSignature(
+            name: pattern.identifier.text,
+            argumentLabels: labels
+        )
+    }
+
+    /// Peels `AttributedTypeSyntax` wrappers (`@Sendable`, `@MainActor`,
+    /// `@escaping`) to expose the underlying `FunctionTypeSyntax`, or
+    /// returns `nil` when the type isn't function-typed.
+    private static func unwrapFunctionType(_ type: TypeSyntax) -> FunctionTypeSyntax? {
+        if let fn = type.as(FunctionTypeSyntax.self) {
+            return fn
+        }
+        if let attributed = type.as(AttributedTypeSyntax.self) {
+            return unwrapFunctionType(attributed.baseType)
+        }
+        return nil
+    }
+
     /// Computes the signature of a call site from its syntax. Each argument's
     /// external label is read from `LabeledExprSyntax.label`; unlabeled positional
     /// arguments become `"_"`. Trailing closures are counted as a single

--- a/Tests/CoreTests/Idempotency/SignatureAwareCollisionTests.swift
+++ b/Tests/CoreTests/Idempotency/SignatureAwareCollisionTests.swift
@@ -79,6 +79,192 @@ struct SignatureAwareCollisionTests {
         #expect(signature.description == "upsert(_:)")
     }
 
+    // MARK: - Closure-typed stored properties (FunctionSignature.from(declaration: VariableDecl))
+
+    /// Helper: extract a `VariableDeclSyntax` from the first statement of a source.
+    private func varDecl(_ source: String) throws -> VariableDeclSyntax {
+        let firstStatement = try #require(Parser.parse(source: source).statements.first)
+        // Member-level decls land in `MemberBlockItemListSyntax`, so we also
+        // accept a struct-wrapped source and dig out the first member.
+        if let decl = firstStatement.item.as(VariableDeclSyntax.self) {
+            return decl
+        }
+        if let structDecl = firstStatement.item.as(StructDeclSyntax.self),
+           let member = structDecl.memberBlock.members.first,
+           let varDecl = member.decl.as(VariableDeclSyntax.self) {
+            return varDecl
+        }
+        fatalError("expected a var decl in the first statement or first struct member")
+    }
+
+    @Test
+    func closureProperty_plainFunctionType_producesUnderscoreLabel() throws {
+        // `(Int) -> Void` has one unlabeled parameter. Callers write
+        // `f(0)`, which matches `f(_:)`. No Path-A remap.
+        let decl = try varDecl("var f: (Int) -> Void")
+        let signature = try #require(FunctionSignature.from(declaration: decl))
+        #expect(signature.description == "f(_:)")
+    }
+
+    @Test
+    func closureProperty_pathARemap_underscoreInternalNameBecomesLabel() throws {
+        // `(_ id: Int) -> Void` — Swift function-type semantics call this
+        // `f(_:)`. Path A honours the macro-relabeling convention
+        // (`@DependencyClient` & friends) that exposes the var as
+        // `f(id:)`. See the `from(declaration: VariableDeclSyntax)` docs.
+        let decl = try varDecl("var f: (_ id: Int) -> Void")
+        let signature = try #require(FunctionSignature.from(declaration: decl))
+        #expect(signature.description == "f(id:)")
+    }
+
+    @Test
+    func closureProperty_labelledFunctionType_usesExplicitLabel() throws {
+        let decl = try varDecl("var f: (id: Int) -> Void")
+        let signature = try #require(FunctionSignature.from(declaration: decl))
+        #expect(signature.description == "f(id:)")
+    }
+
+    @Test
+    func closureProperty_attributedType_peelsAttributes() throws {
+        // TCA `@DependencyClient`'s canonical shape — `@Sendable` attribute
+        // wraps the function type, and the closure is async-throws. Path A
+        // remaps `_ query:` → `query`.
+        let decl = try varDecl(
+            "var search: @Sendable (_ query: String) async throws -> String"
+        )
+        let signature = try #require(FunctionSignature.from(declaration: decl))
+        #expect(signature.description == "search(query:)")
+    }
+
+    @Test
+    func closureProperty_multipleParameters_preservesOrder() throws {
+        let decl = try varDecl(
+            "var f: (_ id: Int, label: String, _ count: Int) -> Void"
+        )
+        let signature = try #require(FunctionSignature.from(declaration: decl))
+        // id (path A) / label (canonical) / count (path A).
+        #expect(signature.description == "f(id:label:count:)")
+    }
+
+    @Test
+    func closureProperty_nonFunctionTypedVar_returnsNil() throws {
+        let decl = try varDecl("var count: Int")
+        #expect(FunctionSignature.from(declaration: decl) == nil)
+    }
+
+    @Test
+    func closureProperty_untypedBinding_returnsNil() throws {
+        // Inferred-type bindings don't declare the call-site shape — can't
+        // extract a signature without the type annotation.
+        let decl = try varDecl("var f = { (x: Int) in print(x) }")
+        #expect(FunctionSignature.from(declaration: decl) == nil)
+    }
+
+    @Test
+    func closureProperty_multiBindingVar_returnsNil() throws {
+        // `var a: (Int) -> Void, b: (String) -> Void` — ambiguous which
+        // binding the annotation (if any) applies to. Skip entirely.
+        let decl = try varDecl(
+            "var a: (Int) -> Void, b: (String) -> Void"
+        )
+        #expect(FunctionSignature.from(declaration: decl) == nil)
+    }
+
+    @Test
+    func closureProperty_memberLevelStruct_stillExtracts() throws {
+        // Verify extraction works when the var is nested in a struct
+        // (the common TCA shape). The helper digs into the first member.
+        let decl = try varDecl("""
+        struct Client {
+            var search: @Sendable (_ query: String) async throws -> String
+        }
+        """)
+        let signature = try #require(FunctionSignature.from(declaration: decl))
+        #expect(signature.description == "search(query:)")
+    }
+
+    // MARK: - EffectSymbolTable closure-property integration
+
+    @Test
+    func symbolTable_mergesAnnotatedClosureProperty() throws {
+        let source = """
+        struct WeatherClient {
+            /// @lint.effect idempotent
+            var search: @Sendable (_ query: String) async throws -> String
+        }
+        """
+        let table = tableOf(source)
+        let signature = FunctionSignature(name: "search", argumentLabels: ["query"])
+        #expect(table.effect(for: signature) == .idempotent)
+    }
+
+    @Test
+    func symbolTable_unannotatedClosureProperty_notRecorded() throws {
+        let source = """
+        struct WeatherClient {
+            var search: @Sendable (_ query: String) async throws -> String
+        }
+        """
+        let table = tableOf(source)
+        let signature = FunctionSignature(name: "search", argumentLabels: ["query"])
+        #expect(table.effect(for: signature) == nil)
+    }
+
+    @Test
+    func symbolTable_collision_closurePropertyVsFunctionDecl() throws {
+        // A struct declares `search(query:)` as a closure property with
+        // `idempotent`, and a separate type declares a method with the
+        // same signature as `non_idempotent`. Collision policy withdraws.
+        let source = """
+        struct WeatherClient {
+            /// @lint.effect idempotent
+            var search: @Sendable (_ query: String) async throws -> String
+        }
+        struct MailClient {
+            /// @lint.effect non_idempotent
+            func search(query: String) async throws -> String { "" }
+        }
+        """
+        let table = tableOf(source)
+        let signature = FunctionSignature(name: "search", argumentLabels: ["query"])
+        #expect(table.effect(for: signature) == nil)
+        #expect(table.isCollision(signature: signature))
+    }
+
+    @Test
+    func symbolTable_closureProperty_contextAnnotationLands() throws {
+        // `@lint.context strict_replayable` on a closure-property declaration
+        // should populate the context entry the same way a function decl does.
+        let source = """
+        struct Workflow {
+            /// @lint.context strict_replayable
+            var run: @Sendable () async throws -> Void
+        }
+        """
+        let table = tableOf(source)
+        let signature = FunctionSignature(name: "run", argumentLabels: [])
+        #expect(table.context(for: signature) == .strictReplayable)
+    }
+
+    @Test
+    func symbolTable_closureInNestedClosure_skipped() throws {
+        // Mirrors FunctionDeclCollector: we don't collect declarations
+        // that live inside a closure body (they're not nominal surfaces
+        // addressable by bare name from outside the closure).
+        let source = """
+        func outer() {
+            _ = { (x: Int) -> Void in
+                /// @lint.effect idempotent
+                var inner: (Int) -> Void = { _ in }
+                inner(x)
+            }
+        }
+        """
+        let table = tableOf(source)
+        let signature = FunctionSignature(name: "inner", argumentLabels: ["_"])
+        #expect(table.effect(for: signature) == nil)
+    }
+
     @Test
     func extractsSignatureFromCallSite_matchingDeclarationForm() throws {
         let source = """


### PR DESCRIPTION
## Summary

- Extends `EffectSymbolTable.merge(source:)` to also walk `VariableDeclSyntax` bindings whose annotated type is function-typed, treating them as pseudo-method declarations for annotation-lookup purposes.
- Motivating case: TCA's `@DependencyClient`-style structs expose callable methods as closure properties:
  ```swift
  @DependencyClient
  struct WeatherClient {
      /// @lint.effect idempotent
      var search: @Sendable (_ query: String) async throws -> GeocodingSearch
  }
  ```
  The macro re-exposes `search` as a callable `search(query:)`; without this slice the user annotation silently didn't land because the linter was only walking `FunctionDeclSyntax`.
- New `FunctionSignature.from(declaration: VariableDeclSyntax)` — returns nil when not single-identifier or not function-typed (after peeling `AttributedTypeSyntax` wrappers for `@Sendable` / `@MainActor` / etc). Derives `name(labels:)` from the function type's parameters.
- New `ClosurePropertyDeclCollector` — mirrors `FunctionDeclCollector` but for VariableDecls; skips closure-body descent.
- **Labeling rule ("Path A"):** when a function-type parameter has `firstName == "_"` and a non-empty `secondName`, the label is `secondName`. Swift function types treat `(_ x:)` as suppressed-label at the type level, but macros in the `@DependencyClient` family re-expose the var as a method whose external label is the internal name. Honouring that convention lets user annotations line up with call sites without running the macro. The tradeoff — non-macro closure properties using `_ name:` and called unlabeled produce a silent no-op annotation — is a false negative, never a false positive.

## Validation

Measured against the `trial-tca` branch of swift-composable-architecture with `WeatherClient.search`, `WeatherClient.forecast`, `FactClient.fetch` annotated `/// @lint.effect idempotent`:

| Run | Total strict_replayable diagnostics |
|---|---|
| main (pre-slice) | 22 |
| this branch | **19** |

Closes the 3 adoption-gap fires on dependency-client calls tracked as cluster 4 in the TCA post-fix remeasurement. The remaining 19 diagnostics are unrelated (clock/sleep, `send` on closure-parameter, response enum-case construction).

## Test plan
- [x] 14 new tests in `SignatureAwareCollisionTests` covering: plain function type, Path-A remap, labelled type, attributed type, multi-parameter ordering, non-function-typed rejection, untyped-binding rejection, multi-binding rejection, member-level extraction, annotated/unannotated closure-property merge, collision with same-signature FunctionDecl, context annotation, nested-closure skip.
- [x] `swift test` — 2243 tests / 275 suites, all green (was 2229 pre-slice).
- [ ] Follow-up: roll trial-tca forward with the client annotations to commit the 3-diagnostic drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)