### PR TITLE
Normalise Type.init(...) to the bare-ctor whitelist path

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
@@ -348,6 +348,12 @@ public enum HeuristicEffectInferrer {
     ///   `context.logger.info(...)` where `logger` is the logger-shaped
     ///   segment even though it isn't the outermost base.
     /// - `a.b.c.foo()` → `("foo", "c")` — same rule extends to any depth.
+    /// - `Foo.init(...)` → `("Foo", nil)` — normalised to the bare-identifier
+    ///   form so the type-constructor whitelist fires on either spelling.
+    ///   `A.B.init(...)` → `("B", nil)` (immediate type name); `Foo<T>.init(...)`
+    ///   → `("Foo", nil)` (generic base peeled). `self.init(...)` and
+    ///   `super.init(...)` normalise to `("self", nil)` / `("super", nil)`,
+    ///   which match no whitelist — outcome unchanged.
     /// - Anything structurally more complex (subscripts, casts, function-
     ///   call bases, tuple projections) → `nil`.
     private static func callParts(of expr: ExprSyntax) -> (String, String?)? {
@@ -359,6 +365,14 @@ public enum HeuristicEffectInferrer {
             guard let base = member.base else {
                 return (callee, nil)
             }
+            // `Type.init(...)` — treat the explicit-initializer form as
+            // semantically identical to `Type(...)`. Without this normalisation
+            // the type-constructor whitelist fires on `JSONDecoder()` but
+            // misses `JSONDecoder.init()`, producing one stray diagnostic per
+            // framework-response-builder call site that uses the explicit form.
+            if callee == "init", let typeName = typeIdentifierName(of: base) {
+                return (typeName, nil)
+            }
             if let baseRef = base.as(DeclReferenceExprSyntax.self) {
                 return (callee, baseRef.baseName.text)
             }
@@ -366,6 +380,28 @@ public enum HeuristicEffectInferrer {
                 return (callee, innerMember.declName.baseName.text)
             }
             return (callee, nil)
+        }
+        return nil
+    }
+
+    /// Extracts the leaf type identifier from an expression used as the
+    /// base of a `.init(...)` call. Returns nil when the base is not a
+    /// type reference the whitelist could match (closure calls, subscripts,
+    /// tuple projections, etc.).
+    ///
+    /// - `Foo` → `"Foo"`
+    /// - `A.B` → `"B"` (nested type; immediate leaf)
+    /// - `Foo<T>` → `"Foo"` (generic-specialization base peeled)
+    /// - `A.B<T>` → `"B"`
+    private static func typeIdentifierName(of expr: ExprSyntax) -> String? {
+        if let ref = expr.as(DeclReferenceExprSyntax.self) {
+            return ref.baseName.text
+        }
+        if let member = expr.as(MemberAccessExprSyntax.self) {
+            return member.declName.baseName.text
+        }
+        if let spec = expr.as(GenericSpecializationExprSyntax.self) {
+            return typeIdentifierName(of: spec.expression)
         }
         return nil
     }

--- a/Tests/CoreTests/Idempotency/HeuristicInferenceTests.swift
+++ b/Tests/CoreTests/Idempotency/HeuristicInferenceTests.swift
@@ -312,6 +312,120 @@ struct HeuristicInferenceUnitTests {
         #expect(HeuristicEffectInferrer.infer(call: call) == nil)
     }
 
+    // MARK: - Framework whitelist — `.init(...)` member-access form
+    //
+    // The explicit-initializer form `JSONDecoder.init()` is semantically
+    // identical to the bare `JSONDecoder()` — but without normalisation in
+    // `callParts`, the member-access form would produce
+    // `(calleeName: "init", receiverName: "JSONDecoder")` and miss the
+    // type-constructor whitelist entirely. Adopter corpora surface the
+    // `.init(...)` form at ~1 diagnostic per round on framework-response
+    // builders. These fixtures pin the normalisation so the whitelist
+    // fires on either spelling.
+
+    @Test
+    func jsonDecoderDotInit_infersIdempotent() throws {
+        let call = try firstCall(in: "func f() { _ = JSONDecoder.init() }")
+        #expect(HeuristicEffectInferrer.infer(call: call, imports: ["Foundation"]) == .idempotent)
+    }
+
+    @Test
+    func dataDotInit_infersIdempotent() throws {
+        let call = try firstCall(in: "func f() { _ = Data.init(bytes) }")
+        #expect(HeuristicEffectInferrer.infer(call: call, imports: ["Foundation"]) == .idempotent)
+    }
+
+    @Test
+    func albResponseDotInit_infersIdempotent() throws {
+        // Framework-response-builder call-site shape — the motivating case
+        // for normalising `.init(...)` to the bare-ctor path.
+        let call = try firstCall(
+            in: "func f() { _ = ALBTargetGroupResponse.init(statusCode: .ok) }"
+        )
+        #expect(
+            HeuristicEffectInferrer.infer(call: call, imports: ["AWSLambdaEvents"])
+                == .idempotent
+        )
+    }
+
+    @Test
+    func httpErrorDotInit_infersIdempotent() throws {
+        let call = try firstCall(in: "func f() { _ = HTTPError.init(.notFound) }")
+        #expect(
+            HeuristicEffectInferrer.infer(call: call, imports: ["Hummingbird"])
+                == .idempotent
+        )
+    }
+
+    @Test
+    func genericTypeDotInit_infersIdempotent() throws {
+        // `Data<T>` doesn't exist, but the generic-specialisation peel
+        // applies uniformly — any whitelisted type invoked in the
+        // `TypeName<...>.init(...)` shape normalises to the base name.
+        // Use `ByteBuffer` with a fabricated generic for the AST shape.
+        let call = try firstCall(in: "func f() { _ = ByteBuffer<UInt8>.init(bytes: data) }")
+        #expect(HeuristicEffectInferrer.infer(call: call, imports: ["NIOCore"]) == .idempotent)
+    }
+
+    @Test
+    func nestedTypeDotInit_picksLeafName() throws {
+        // `Foo.APIGatewayV2Response.init(...)` — the nested form appears
+        // when the response type is re-exported under a module namespace.
+        // `callParts` returns the leaf type identifier, so the whitelist
+        // lookup on `APIGatewayV2Response` still fires.
+        let call = try firstCall(
+            in: "func f() { _ = Outer.APIGatewayV2Response.init(statusCode: .ok) }"
+        )
+        #expect(
+            HeuristicEffectInferrer.infer(call: call, imports: ["AWSLambdaEvents"])
+                == .idempotent
+        )
+    }
+
+    @Test
+    func userTypeDotInit_staysUnclassified() throws {
+        // `.init(...)` normalisation does NOT silence user-local types —
+        // only types already on the framework whitelist benefit. A
+        // project-local `OrderService.init()` remains unclassified, same
+        // as the bare `OrderService()` form.
+        let call = try firstCall(in: "func f() { _ = OrderService.init() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == nil)
+    }
+
+    @Test
+    func uuidDotInit_staysUnclassified() throws {
+        // Mirrors `uuidConstructor_staysUnclassified` — `UUID` is
+        // deliberately excluded from the idempotent-type whitelist
+        // because it produces a fresh-per-call identity. The
+        // `.init(...)` form must not accidentally classify it either.
+        let call = try firstCall(in: "func f() { _ = UUID.init() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == nil)
+    }
+
+    @Test
+    func selfDotInit_staysUnclassified() throws {
+        // Delegating initializer — `self.init(...)` is a convenience-init
+        // dispatch, not a fresh construction. `"self"` isn't on any
+        // whitelist, so the normalisation returns no inferred effect,
+        // matching pre-slice behaviour exactly.
+        let call = try firstCall(
+            in: "struct S { init() { self.init(default: true) } }"
+        )
+        #expect(HeuristicEffectInferrer.infer(call: call) == nil)
+    }
+
+    @Test
+    func jsonDecoderDotInit_reasonMatchesBareForm() throws {
+        // Inference reason credits the whitelisted type, not "init",
+        // so adopter diagnostics read coherently on both spellings.
+        let call = try firstCall(in: "func f() { _ = JSONDecoder.init() }")
+        let reason = HeuristicEffectInferrer.inferenceReason(
+            for: call,
+            imports: ["Foundation"]
+        )
+        #expect(reason == "from the known-idempotent Foundation type `JSONDecoder`")
+    }
+
     // MARK: - Framework whitelist — codec-pattern methods
 
     @Test


### PR DESCRIPTION
## Summary

Closes the long-running `.init(...)` member-access form gap
([swiftIdempotency/docs/next_steps.md slot 2](https://github.com/Joseph-Cursio/SwiftIdempotency/blob/main/docs/next_steps.md)).
`HeuristicEffectInferrer.callParts` was returning `("init", "Foo")`
for the explicit-initializer spelling `Foo.init(...)` while returning
`("Foo", nil)` for the bare `Foo()` form. The type-constructor
whitelist keys on the bare-ctor callee name, so the explicit form
missed the whitelist and produced one stray `Unannotated In Strict
Replayable Context` diagnostic per framework-response-builder call
site.

Observed at ~1 diagnostic per round on `todos-fluent` and `pointfreeco`;
captured in `next_steps.md` as "slice when the firing rate exceeds
~2/round consistently." Promoting the slice now since the fix itself
is structural — not config-driven, no YAML, no new whitelist entries —
and closes the gap for every type already on the whitelist without
further per-corpus work.

## What changed

- New helper `typeIdentifierName(of:)` extracts the leaf type identifier
  from a type-expression base:
  - `Foo` → `"Foo"`
  - `A.B` → `"B"` (nested type; immediate leaf matches the existing
    `a.b.c.foo()` → `("foo", "c")` rule)
  - `Foo<T>` → `"Foo"` (generic-specialisation peeled via the
    `GenericSpecializationExprSyntax.expression` field, same peel
    `ReceiverTypeResolver.firstArgumentTypeName` already uses)
- `callParts` detects `MemberAccessExprSyntax` with
  `declName.baseName.text == "init"` and normalises to
  `(leafTypeName, nil)` — the same shape the bare-identifier path
  produces. Everything downstream (whitelist lookup, inference reason,
  upward inferrer consumers) benefits automatically.

## Precision

The normalisation is purely additive — it only enables the type-
constructor whitelist to fire on the explicit-initializer form:

- Receiver-gated heuristics (logger, metric, codec, framework
  receiver/method pairs) all require `receiverName != nil`. The
  normalised form has nil receiver, so they don't fire.
- Bare-name idempotent / non-idempotent lists use lowercase verbs
  (`insert`, `create`, `send`, `upsert`, etc.); PascalCase type names
  don't collide.
- Prefix-match path requires a lowercase-starting verb prefix followed
  by an uppercase character; PascalCase type names fail the prefix
  condition immediately.
- `self.init(...)` and `super.init(...)` normalise to `("self", nil)` /
  `("super", nil)`, neither of which are on any whitelist — outcome
  unchanged (nil inferred effect).

## Not in scope

- **User-local type constructors.** `OrderService.init()` still
  returns nil inferred effect, same as `OrderService()`. The
  normalisation only matters for types already on the framework
  whitelist; project-local types require explicit annotation.
- **Deliberate exclusions preserved.** `UUID.init()` and `Date.init()`
  stay unclassified — `UUID` and `Date` are deliberately off the
  whitelist because each call produces fresh-per-invocation identity
  / time, and classifying them would contradict the
  `missingIdempotencyKey` rule the project specifically catches.
- **No new types added to the whitelist.** Whether to add any is a
  separate evidence-driven decision; this slice is structural only.

## Test plan

- [x] 10 new tests in `HeuristicInferenceUnitTests` covering:
  - Positive cases: `JSONDecoder.init()`, `Data.init(bytes)`,
    `ALBTargetGroupResponse.init(statusCode:)`, `HTTPError.init(.notFound)`.
  - Generic-specialisation base: `ByteBuffer<UInt8>.init(bytes:)`.
  - Nested-type base: `Outer.APIGatewayV2Response.init(statusCode:)`.
  - Precision negatives: `OrderService.init()` stays unclassified,
    `UUID.init()` stays unclassified, `self.init(default:)` stays
    unclassified.
  - Inference-reason parity: `JSONDecoder.init()` reason matches
    bare-form reason string verbatim.
- [x] `swift package clean && swift test` — 2256 tests / 275 suites,
      all green (was 2246 pre-slice; +10 new tests).
- [ ] Follow-up: next adopter road-test confirms the expected drop of
      ~1 diagnostic on framework-response-builder call sites that use
      the `.init(...)` form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)