### PR TITLE
Prefix lexicon: add submit|start|complete|register (slot 13)

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
@@ -29,15 +29,20 @@ import SwiftSyntax
 /// - Non-idempotent bare-name triggers: names that are ~universally
 ///   non-idempotent in Swift/database/messaging codebases: `create`,
 ///   `insert`, `append`, `publish`, `enqueue`, `post`, `send`, `stop`,
-///   `destroy`, `update`. The `update` entry catches non-Fluent DB
-///   surfaces (e.g. adopters with `@Dependency(\.database)` styles
-///   calling `database.updateX(...)`) — stdlib mutation APIs with
-///   the same name (`Set.update(with:)`, `Dictionary.updateValue(...)`)
-///   are suppressed via `StdlibExclusions` / the prefix-match stdlib
-///   gate. Names like `store`, `put`, `write` remain deliberately
-///   **not** in this list — they have too many idempotent
-///   interpretations (`put` is idempotent in REST semantics, `write`
-///   could mean atomic file write).
+///   `destroy`, `update`, `submit`, `start`, `complete`, `register`.
+///   The `update` entry catches non-Fluent DB surfaces (e.g. adopters
+///   with `@Dependency(\.database)` styles calling
+///   `database.updateX(...)`) — stdlib mutation APIs with the same
+///   name (`Set.update(with:)`, `Dictionary.updateValue(...)`) are
+///   suppressed via `StdlibExclusions` / the prefix-match stdlib
+///   gate. The server-app verbs — `submit`, `start`, `complete`,
+///   `register` — were added after the isowords round surfaced a
+///   real-bug miss on `startDailyChallenge` (INSERT without
+///   `ON CONFLICT`) that the `start*` prefix would have caught.
+///   Names like `store`, `put`, `write` remain deliberately **not**
+///   in this list — they have too many idempotent interpretations
+///   (`put` is idempotent in REST semantics, `write` could mean
+///   atomic file write).
 ///
 /// - Framework-gated non-idempotent triggers: `save`, `delete` fire
 ///   only when the file imports `FluentKit`. These are canonical
@@ -466,7 +471,14 @@ public enum HeuristicEffectInferrer {
         "send",
         "stop",
         "destroy",
-        "update"
+        "update",
+        // Server-app verbs — added from the isowords round (slot 13).
+        // `startDailyChallenge` was a real `INSERT` without `ON CONFLICT`
+        // that the prior lexicon missed on the default `replayable` tier.
+        "submit",
+        "start",
+        "complete",
+        "register"
     ]
 
     private static let idempotentNames: Set<String> = [

--- a/Tests/CoreTests/Idempotency/HeuristicInferenceTests.swift
+++ b/Tests/CoreTests/Idempotency/HeuristicInferenceTests.swift
@@ -135,6 +135,126 @@ struct HeuristicInferenceUnitTests {
         #expect(HeuristicEffectInferrer.infer(call: call) == nil)
     }
 
+    // MARK: - Server-app verbs (slot 13 — isowords round)
+    //
+    // The isowords round surfaced a real-bug miss on
+    // `startDailyChallenge` (INSERT without `ON CONFLICT`) because
+    // `start*` wasn't in the prefix list. `submit`, `start`,
+    // `complete`, `register` are now bare + prefix-matched alongside
+    // the original CRUD verbs. `send` was already there; these are
+    // the four net additions.
+
+    @Test
+    func bareSubmit_infersNonIdempotent() throws {
+        let call = try firstCall(in: "func f() { submit(form) }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .nonIdempotent)
+    }
+
+    @Test
+    func memberSubmit_infersNonIdempotent() throws {
+        let call = try firstCall(in: "func f() { form.submit() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .nonIdempotent)
+    }
+
+    @Test
+    func submitLeaderboardScore_infersNonIdempotent_viaPrefix() throws {
+        // Isowords canonical case. Closure property on `DatabaseClient`
+        // spelled `database.submitLeaderboardScore(...)`. Without this
+        // prefix, Run A silently classified it as idempotent.
+        let call = try firstCall(
+            in: "func f() { database.submitLeaderboardScore(request) }"
+        )
+        #expect(HeuristicEffectInferrer.infer(call: call) == .nonIdempotent)
+    }
+
+    @Test
+    func bareStart_infersNonIdempotent() throws {
+        let call = try firstCall(in: "func f() { start() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .nonIdempotent)
+    }
+
+    @Test
+    func memberStart_infersNonIdempotent() throws {
+        // `service.start()` — natural complement to `service.stop()`.
+        let call = try firstCall(in: "func f() { service.start() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .nonIdempotent)
+    }
+
+    @Test
+    func startDailyChallenge_infersNonIdempotent_viaPrefix() throws {
+        // The real-bug miss from the isowords round. SQL: INSERT
+        // without ON CONFLICT against `dailyChallengePlays` — retry
+        // creates a duplicate play row.
+        let call = try firstCall(
+            in: "func f() { database.startDailyChallenge(id, playerId) }"
+        )
+        #expect(HeuristicEffectInferrer.infer(call: call) == .nonIdempotent)
+    }
+
+    @Test
+    func bareComplete_infersNonIdempotent() throws {
+        let call = try firstCall(in: "func f() { complete() }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .nonIdempotent)
+    }
+
+    @Test
+    func completeDailyChallenge_infersNonIdempotent_viaPrefix() throws {
+        // Isowords state-transition write. SQL has a
+        // `WHERE completedAt IS NULL` guard, so the catch is
+        // defensible-by-design — but the prefix should still fire and
+        // prompt the adopter to annotate `@lint.effect idempotent`.
+        let call = try firstCall(
+            in: "func f() { database.completeDailyChallenge(id, playerId) }"
+        )
+        #expect(HeuristicEffectInferrer.infer(call: call) == .nonIdempotent)
+    }
+
+    @Test
+    func bareRegister_infersNonIdempotent() throws {
+        let call = try firstCall(in: "func f() { register(token) }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == .nonIdempotent)
+    }
+
+    @Test
+    func registerPushToken_infersNonIdempotent_viaPrefix() throws {
+        // Isowords `registerPushTokenMiddleware` calls. Defensible-by-
+        // design via SNS idempotent ARN resolution + DB upsert, but
+        // the prefix fires so the adopter can annotate.
+        let call = try firstCall(
+            in: "func f() { snsClient.registerPushToken(request) }"
+        )
+        #expect(HeuristicEffectInferrer.infer(call: call) == .nonIdempotent)
+    }
+
+    // Camel-case gate negative cases for the new verbs — confirm the
+    // participle / noun forms stay silent.
+
+    @Test
+    func started_doesNotMatch_lowercaseNextCharacter() throws {
+        // Past participle / past tense; not a mutation verb.
+        let call = try firstCall(in: "func f() { started(service) }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == nil)
+    }
+
+    @Test
+    func submitted_doesNotMatch_lowercaseNextCharacter() throws {
+        let call = try firstCall(in: "func f() { submitted(form) }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == nil)
+    }
+
+    @Test
+    func completion_doesNotMatch_lowercaseNextCharacter() throws {
+        // Common callback-style noun form — `completion(result)`.
+        let call = try firstCall(in: "func f() { completion(result) }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == nil)
+    }
+
+    @Test
+    func registered_doesNotMatch_lowercaseNextCharacter() throws {
+        let call = try firstCall(in: "func f() { registered(device) }")
+        #expect(HeuristicEffectInferrer.infer(call: call) == nil)
+    }
+
     // MARK: - Idempotent name triggers
 
     @Test


### PR DESCRIPTION
## Summary

Closes **slot 13** from the swiftIdempotency `next_steps.md` — adds
`submit`, `start`, `complete`, `register` to
`HeuristicEffectInferrer.nonIdempotentNames`. `send` was already
present; these are the four net additions.

Triggering evidence: **isowords round (production adopter #2)**
surfaced a real-bug miss on `startDailyChallenge` — an `INSERT`
without `ON CONFLICT` against `dailyChallengePlays` that the prior
lexicon silently classified as idempotent on the default
`replayable` tier. `start*` now catches it. `submit*` has
two-adopter evidence (isowords + Penny Q3); `complete*` and
`register*` have one-adopter evidence (isowords) plus unambiguous
non-idempotent semantics (`complete` = state-transition,
`register` = client-side write).

## Isowords Run A delta

5 → 8 diagnostics, 4/5 → **5/5 handlers fire**:
- **+1 correct catch**: `startDailyChallenge` at
  `DailyChallengeMiddleware.swift:117` (missed real bug recovered).
- **+2 defensible**: `submitLeaderboardScore` at
  `SubmitGameMiddleware.swift:112` (SQL upsert) and
  `completeDailyChallenge` at `SubmitGameMiddleware.swift:149`
  (WHERE IS NULL guard). Both closed by adopter annotation
  (`@lint.effect idempotent`).

See
[`isowords/trial-findings.md`](https://github.com/Joseph-Cursio/SwiftIdempotency/blob/main/docs/isowords/trial-findings.md)
§"Newly surfaced actionable slice — slot 13" for the full SQL
ground-truth analysis.

## Regression check — TCA

13 strict diagnostics → **13 strict** (zero change). No TCA
annotated handler (`Todos`, `Search`, `03-Effects-Basics`) calls
a `submit*` / `start*` / `complete*` / `register*` method in its
transitive call graph. Per-example counts:
- `Examples/Todos`: 5 (unchanged)
- `Examples/Search`: 4 (unchanged)
- `Examples/CaseStudies`: 4 (unchanged)

## Test plan

- [x] **Unit tests**: 2272 → 2286 tests (+14). Coverage:
  - Bare-name positive: `submit()`, `start()`, `complete()`,
    `register()` (4 tests).
  - Member-call positive: `form.submit()`, `service.start()` (2).
  - Canonical real-world prefix fixtures: `submitLeaderboardScore`,
    `startDailyChallenge`, `completeDailyChallenge`,
    `registerPushToken` (4).
  - CamelCase-gate negative cases: `started()`, `submitted()`,
    `completion()`, `registered()` — participle / noun forms stay
    silent (4).
- [x] **Full suite**: `swift test` → 2286 / 276 green on macOS.
- [x] **Isowords Run A**: fresh fork clone + scan at
  `trial-isowords@a71c993`; 5 → 8 diagnostics as predicted.
- [x] **TCA regression**: per-example scan on
  `trial-tca@50ca268`; 13 strict diagnostics confirmed unchanged.

## Notes

- Name-only classification is the coarse tier of
  `HeuristicEffectInferrer`; adopters who annotate
  (`@lint.effect idempotent` on `DatabaseClient` closure
  properties that dedup via SQL upsert) get the precision back
  immediately. Defensible-noise is acceptable; missed real bugs
  are not.
- `send` was already in the list. The docstring update spells out
  which verbs are net-new so future PR archaeology matches the
  actual diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)