### PR TITLE
HttpPipeline framework whitelist (slot 14)

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
@@ -31,13 +31,14 @@ public enum FrameworkWhitelist {
     public static let hummingbird = "Hummingbird"
     public static let composableArchitecture = "ComposableArchitecture"
     public static let awsLambdaRuntime = "AWSLambdaRuntime"
+    public static let httpPipeline = "HttpPipeline"
 
     /// Every framework this project recognises. Order-insensitive.
     /// Used as the default `enabledFrameworks` set when a project
     /// hasn't opted out of any framework's classifications.
     public static let knownFrameworks: Set<String> = [
         foundation, nio, awsLambdaEvents, logging, osLog, metrics, fluent,
-        hummingbird, composableArchitecture, awsLambdaRuntime
+        hummingbird, composableArchitecture, awsLambdaRuntime, httpPipeline
     ]
 
     // MARK: - Idempotent type constructors (bare-identifier call)
@@ -113,23 +114,68 @@ public enum FrameworkWhitelist {
     /// either interpretation, so a cross-framework false positive
     /// would only change the *reason* string, not the effect.
     ///
+    /// HttpPipeline (slot 14) is the second framework on this table.
+    /// `writeStatus`, `respond` etc. are freestanding curried functions
+    /// in `pointfreeco/swift-web`'s HttpPipeline module, called via
+    /// the `|>` and `>=>` pipe operators — `conn |> writeStatus(.ok)`
+    /// reads as `writeStatus(.ok)(conn)`. They mutate `Conn<I, J, A>`
+    /// state in a value-typed pipeline (each call returns a new `Conn`),
+    /// so re-invocation with the same input yields the same response —
+    /// observably idempotent at the response-builder boundary.
+    /// 2-adopter evidence: isowords (12 fires) + pointfreeco www
+    /// (4 fires) on `writeStatus` alone, plus `respond` shared shape.
+    ///
     /// Unlike type-constructor whitelists, these are ordinary
     /// method-call names — they can appear as `.method()` on any
     /// receiver, or bare-style when chained after another call.
     /// The gate therefore does not require a receiver; the import
     /// presence is the load-bearing signal.
     private static let idempotentMethodsByFramework: [String: String] = [
+        // FluentKit — query-builder reads.
         "db": fluent,
         "query": fluent,
         "all": fluent,
         "first": fluent,
         "filter": fluent,
+
+        // HttpPipeline — response-pipeline primitives (pointfreeco/swift-web).
+        // Both adopters use these via `|>` / `>=>` pipe-forward operators
+        // on `Conn` state; each call is a value-typed mutation.
+        "writeStatus": httpPipeline,
+        "respond": httpPipeline,
     ]
 
     /// Returns the framework that owns a given idempotent method
     /// name, or nil when the name isn't on any framework's list.
     public static func framework(forIdempotentMethod name: String) -> String? {
         idempotentMethodsByFramework[name]
+    }
+
+    // MARK: - Per-framework reason phrasing (for diagnostic strings)
+
+    /// Per-framework noun phrase used in the diagnostic reason string
+    /// when a callee resolves through `idempotentMethodsByFramework`.
+    /// Default (`"framework primitive"`) is generic and safe for any
+    /// framework added without explicit phrasing.
+    ///
+    /// Existing per-framework phrasings:
+    /// - FluentKit: `"query-builder read"` — matches the original
+    ///   round-14 wording before slot 14 generalised the table.
+    /// - HttpPipeline: `"pipeline primitive"` — accurate for
+    ///   response-builder-pattern modules where the same name maps
+    ///   to a curried `(Conn) -> Conn` primitive.
+    private static let idempotentMethodPhrasingByFramework: [String: String] = [
+        fluent: "query-builder read",
+        httpPipeline: "pipeline primitive",
+    ]
+
+    /// Returns the per-framework noun phrase for the
+    /// `idempotentMethodsByFramework` reason string. Falls back to
+    /// `"framework primitive"` for any framework without an explicit
+    /// override, so adding a new framework to the table doesn't
+    /// require touching the inferrer.
+    public static func idempotentMethodPhrasing(forFramework framework: String) -> String {
+        idempotentMethodPhrasingByFramework[framework] ?? "framework primitive"
     }
 
     // MARK: - Idempotent receiver/method pairs (framework-gated)

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
@@ -53,11 +53,13 @@ import SwiftSyntax
 ///   See `FrameworkWhitelist.framework(forNonIdempotentMethod:)`.
 ///
 /// - Framework-gated idempotent triggers: Fluent's query-builder
-///   read verbs (`db`, `query`, `all`, `first`, `filter`) fire as
-///   `idempotent` when the file imports `FluentKit`. These are the
-///   read-only counterparts to the save/update/delete gate above —
-///   same import signal, opposite classification. Silences strict-
-///   mode diagnostics on typical `Model.query(on: db).filter(...).all()`
+///   read verbs (`db`, `query`, `all`, `first`, `filter`) and
+///   HttpPipeline's response-pipeline primitives (`writeStatus`,
+///   `respond`) fire as `idempotent` when the file imports the
+///   relevant module. These cover both the chained-method shape
+///   (`Model.query(on: db).filter(...).all()`) and the pipe-forward
+///   composition shape (`conn |> writeStatus(.ok)`) where receivers
+///   aren't AST-bindable. Silences strict-mode diagnostics on these
 ///   chains without requiring per-callee annotations.
 ///   See `FrameworkWhitelist.framework(forIdempotentMethod:)`.
 ///
@@ -213,12 +215,13 @@ public enum HeuristicEffectInferrer {
             return .nonIdempotent
         }
 
-        // Framework-gated idempotent methods (Fluent's query-builder reads).
-        // No receiver requirement: these commonly appear as chained
-        // calls like `Todo.query(on: db).filter(...).all()` where the
-        // AST walker can't bind a simple receiver identifier to the
-        // terminal call. The FluentKit import presence is the
-        // load-bearing signal.
+        // Framework-gated idempotent methods. No receiver requirement:
+        // these commonly appear as chained calls like
+        // `Todo.query(on: db).filter(...).all()` (FluentKit) or pipe-
+        // forward composition like `conn |> writeStatus(.ok)`
+        // (HttpPipeline) where the AST walker can't bind a simple
+        // receiver identifier to the terminal call. The framework
+        // import presence is the load-bearing signal.
         if let framework = FrameworkWhitelist.framework(
                forIdempotentMethod: calleeName
            ),
@@ -328,7 +331,8 @@ public enum HeuristicEffectInferrer {
                forIdempotentMethod: calleeName
            ),
            context.isFrameworkActive(framework) {
-            return "from the \(framework) query-builder read `\(calleeName)`"
+            let phrase = FrameworkWhitelist.idempotentMethodPhrasing(forFramework: framework)
+            return "from the \(framework) \(phrase) `\(calleeName)`"
         }
         // Prefix-matched calls credit the matched verb explicitly so the
         // user can see which heuristic fired and why.

--- a/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
+++ b/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
@@ -648,6 +648,97 @@ struct FrameworkWhitelistGatingTests {
         #expect(reason == "from the ComposableArchitecture closure-parameter primitive `send`")
     }
 
+    // MARK: - HttpPipeline pipeline primitives (framework-gated, slot 14)
+
+    @Test
+    func importGated_httpPipelinePresent_writeStatusFires() throws {
+        // `writeStatus` is a freestanding curried function in HttpPipeline
+        // (`pointfreeco/swift-web`), typically called via
+        // `conn |> writeStatus(.ok)` pipe-forward composition.
+        // Each call is a value-typed `Conn` mutation; observably
+        // idempotent at the response-builder boundary.
+        let call = try firstCall(in: "func f() { _ = writeStatus(.ok) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["HttpPipeline"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_httpPipelineAbsent_writeStatusDoesNotFire() throws {
+        // A user-defined `writeStatus(...)` in a module without
+        // HttpPipeline shouldn't pick up the slot 14 classification
+        // just because the identifier matches.
+        let call = try firstCall(in: "func f() { _ = writeStatus(.ok) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["MyApp"], enabledFrameworks: nil
+        ) == nil)
+    }
+
+    @Test
+    func importGated_httpPipelinePresent_respondFires() throws {
+        // `respond(html:)` / `respond(json:)` / `respond(text:)` —
+        // curried response-builder primitive in HttpPipeline,
+        // composed via `>=>` Kleisli.
+        let call = try firstCall(in: "func f() { _ = respond(html: index) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["HttpPipeline"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_httpPipelineAbsent_respondDoesNotFire() throws {
+        let call = try firstCall(in: "func f() { _ = respond(html: index) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["MyApp"], enabledFrameworks: nil
+        ) == nil)
+    }
+
+    @Test
+    func configGated_httpPipelineDisabled_writeStatusDoesNotFire() throws {
+        // Adopter imports HttpPipeline but opted out via
+        // `enabled_framework_whitelists`. Whitelist does not fire;
+        // the un-classified callee remains `unknown`.
+        let call = try firstCall(in: "func f() { _ = writeStatus(.ok) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["HttpPipeline"], enabledFrameworks: ["Foundation"]
+        ) == nil)
+    }
+
+    @Test
+    func httpPipeline_writeStatus_inferenceReason_namesFramework() throws {
+        let call = try firstCall(in: "func f() { _ = writeStatus(.ok) }")
+        let reason = HeuristicEffectInferrer.inferenceReason(
+            for: call, imports: ["HttpPipeline"], enabledFrameworks: nil
+        )
+        #expect(reason == "from the HttpPipeline pipeline primitive `writeStatus`")
+    }
+
+    @Test
+    func httpPipeline_respond_inferenceReason_namesFramework() throws {
+        let call = try firstCall(in: "func f() { _ = respond(html: index) }")
+        let reason = HeuristicEffectInferrer.inferenceReason(
+            for: call, imports: ["HttpPipeline"], enabledFrameworks: nil
+        )
+        #expect(reason == "from the HttpPipeline pipeline primitive `respond`")
+    }
+
+    @Test
+    func httpPipelineMethodPhrasing_hasOverride() {
+        // Both per-framework phrasings on the slot 14 table should
+        // resolve to their explicit overrides, not the generic default.
+        #expect(FrameworkWhitelist.idempotentMethodPhrasing(forFramework: "FluentKit") == "query-builder read")
+        #expect(FrameworkWhitelist.idempotentMethodPhrasing(forFramework: "HttpPipeline") == "pipeline primitive")
+    }
+
+    @Test
+    func methodPhrasing_unknownFramework_fallsBackToGeneric() {
+        // Slot 14 added a per-framework phrasing hook with a
+        // `"framework primitive"` fallback — adding a new framework
+        // to `idempotentMethodsByFramework` without specifying
+        // phrasing should still produce a sensible reason string.
+        #expect(FrameworkWhitelist.idempotentMethodPhrasing(forFramework: "PhantomFramework") == "framework primitive")
+    }
+
     // MARK: - ImportCollector
 
     @Test


### PR DESCRIPTION
## Summary

- Adds `writeStatus` and `respond` to `idempotentMethodsByFramework` gated on `import HttpPipeline`. Both are freestanding curried `(Conn) -> Conn` primitives in pointfreeco/swift-web's HttpPipeline module, called via `|>` / `>=>` pipe-forward composition.
- Introduces a per-framework reason-phrasing hook so the diagnostic reason string names each framework's own primitive shape (FluentKit `"query-builder read"`, HttpPipeline `"pipeline primitive"`, default `"framework primitive"`). Existing FluentKit reason-string assertion at `FrameworkWhitelistGatingTests.swift:366` preserved exactly.
- Same-shape slice as commit `6c611c7` (Lambda response-writer, slot 10) and `040f186` (Hummingbird primitives) — no inferrer-core changes; just data tables + one phrasing hook.

## Evidence (2-adopter)

Re-scans against the existing trial corpora at SwiftIdempotency `2fbb171`:

| Adopter | Pre slot 14 (Run B) | Post slot 14 (Run B) | Delta | Notes |
|---|---|---|---|---|
| isowords | 162 | 152 | **−10** | Exactly matches the 10 `writeStatus` diagnostic count |
| pointfreeco www | 38 | 23 | **−15** | 9 direct (5 `writeStatus` + 4 `respond`) + 6 multiplier — helper functions `stripeHookFailure` ×3, `validateStripeSignature` ×2, `fetchGift` ×1 resolve to idempotent once their bodies' calls classify cleanly |

The pointfreeco multiplier is a real benefit of the slice: silencing direct fires unblocks transitive inference up the call graph.

## Tests

- **+9 new tests** in `FrameworkWhitelistGatingTests.swift`:
  - import-gated fires (`writeStatus`, `respond`) ×2
  - import-absent silence (`writeStatus`, `respond`) ×2
  - config-gated disable ×1
  - inference-reason naming (writeStatus, respond) ×2
  - per-framework phrasing override + fallback ×2
- Suite total: 2286 → **2295** (full suite green).

## Test plan

- [x] `swift test` green (2295/276)
- [x] Re-scan isowords at slot 14 tip → −10 confirmed
- [x] Re-scan pointfreeco at slot 14 tip → −15 confirmed
- [x] FluentKit reason-string regression check (existing test at line 366 unchanged, still passes)
- [ ] Reviewer: spot-check `FrameworkWhitelist.idempotentMethodPhrasing` — is the per-framework phrasing hook the right factoring, or should the inferrer always use the generic `"framework primitive"` for all entries?

🤖 Generated with [Claude Code](https://claude.com/claude-code)