### PR TITLE
Hummingbird Router DSL whitelist (slot 16)

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
@@ -207,6 +207,24 @@ public enum FrameworkWhitelist {
     /// signatures. The Lambda runtime's at-least-once contract
     /// dedup-guards invocation retries at its own boundary, so these
     /// calls are idempotent-in-replay by the runtime contract.
+    ///
+    /// Hummingbird Router DSL (slot 16) — `router.{get,post,put,patch,delete}`
+    /// at route-registration sites. Hummingbird's `Router` exposes one
+    /// HTTP-verb method per standard method, each of which registers a
+    /// handler closure with the router's internal `TrieRouter`. From the
+    /// retry-context lint's perspective these are startup-time registration
+    /// calls, not request-scoped operations — annotating a `buildRouter()`
+    /// or `addXRoutes(to router:)` helper with `@lint.context replayable`
+    /// is a convenience to walk INTO the registered handler closures; the
+    /// registration calls themselves should stay silent. Gating on the
+    /// bare `router` receiver is the precision mechanism — it keeps the
+    /// whitelist from silencing unrelated `.get` / `.post` / `.delete`
+    /// methods on non-router receivers in the same file. 2-adopter
+    /// evidence: `samalone/prospero` (3× `router.post` Run A + 11×
+    /// `router.get` Run B) and
+    /// `hummingbird-project/hummingbird-examples/open-telemetry`
+    /// (1× `router.post` Run A + 2× `router.get` Run B) — identical
+    /// rule-path shapes across both corpora.
     private static let idempotentReceiverMethodsByFramework: [String: [String: String]] = [
         "decode": ["request": hummingbird],
         "require": ["parameters": hummingbird],
@@ -215,6 +233,11 @@ public enum FrameworkWhitelist {
             "responseWriter": awsLambdaRuntime,
         ],
         "finish": ["responseWriter": awsLambdaRuntime],
+        "get": ["router": hummingbird],
+        "post": ["router": hummingbird],
+        "put": ["router": hummingbird],
+        "patch": ["router": hummingbird],
+        "delete": ["router": hummingbird],
     ]
 
     /// Returns the framework that owns a given idempotent

--- a/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
+++ b/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
@@ -467,6 +467,131 @@ struct FrameworkWhitelistGatingTests {
         #expect(reason == "from the Hummingbird primitive `request.decode`")
     }
 
+    // MARK: - Hummingbird Router DSL whitelist (slot 16)
+
+    @Test
+    func importGated_hummingbirdPresent_routerGetFires() throws {
+        // `router.get("/path") { ... }` — route-registration DSL inside
+        // a `buildRouter()` / `addXRoutes(to router:)` helper. Without
+        // this whitelist, strict mode would flag `get` as unannotated.
+        let call = try firstCall(in: "func f() { router.get(\"/x\") { _, _ in \"\" } }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Hummingbird"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_hummingbirdPresent_routerPostFires() throws {
+        // `router.post` is the motivating slot-16 case — the callee
+        // name `post` is in `nonIdempotentNames`, so without a receiver-
+        // method whitelist ahead of the bare-name check, route
+        // registration helpers annotated `@lint.context replayable`
+        // would mis-fire on every `router.post(...)` DSL call.
+        let call = try firstCall(in: "func f() { router.post(\"/x\") { _, _ in } }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Hummingbird"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_hummingbirdPresent_routerPutFires() throws {
+        let call = try firstCall(in: "func f() { router.put(\"/x\") { _, _ in } }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Hummingbird"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_hummingbirdPresent_routerPatchFires() throws {
+        let call = try firstCall(in: "func f() { router.patch(\"/x\") { _, _ in } }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Hummingbird"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_hummingbirdPresent_routerDeleteFires() throws {
+        let call = try firstCall(in: "func f() { router.delete(\"/x\") { _, _ in } }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Hummingbird"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_hummingbirdAbsent_routerPostFiresAsNonIdempotent() throws {
+        // Without Hummingbird, the slot-16 pair doesn't match and the
+        // bare-name `post` classification at step 9 applies — the
+        // whitelist is what silences the diagnostic, not a structural
+        // override of the bare-name lexicon.
+        let call = try firstCall(in: "func f() { router.post(\"/x\") { _, _ in } }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["MyApp"], enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func importGated_hummingbirdAbsent_routerGetReturnsNil() throws {
+        // `get` is in neither the bare-name idempotent nor non-idempotent
+        // lists, so without the Hummingbird pair match the inferrer has
+        // nothing to say — strict mode would surface it as unannotated.
+        let call = try firstCall(in: "func f() { router.get(\"/x\") { _, _ in \"\" } }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["MyApp"], enabledFrameworks: nil
+        ) == nil)
+    }
+
+    @Test
+    func hummingbirdRouterPair_wrongReceiver_doesNotSilenceBareName() throws {
+        // `.post()` on a receiver other than `router` in a Hummingbird-
+        // importing file: the slot-16 pair must not fire, and the bare-
+        // name `post` lexicon path should still classify as non-idempotent.
+        let call = try firstCall(in: "func f() { mailer.post(email) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Hummingbird"], enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func configGated_hummingbirdDisabled_routerPostFallsThroughToBareName() throws {
+        // Adopter imports Hummingbird but opted out of its whitelist via
+        // `enabled_framework_whitelists`. Slot-16 pair should not fire;
+        // the bare-name `post` classification reasserts itself.
+        let call = try firstCall(in: "func f() { router.post(\"/x\") { _, _ in } }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Hummingbird"], enabledFrameworks: ["Foundation"]
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func hummingbird_routerPost_inferenceReason() throws {
+        let call = try firstCall(in: "func f() { router.post(\"/x\") { _, _ in } }")
+        let reason = HeuristicEffectInferrer.inferenceReason(
+            for: call, imports: ["Hummingbird"], enabledFrameworks: nil
+        )
+        #expect(reason == "from the Hummingbird primitive `router.post`")
+    }
+
+    @Test
+    func hummingbirdRouterDelete_coexistsWithFluentDeleteClassification() throws {
+        // Critical precedence test: `router.delete(...)` must classify
+        // idempotent (slot-16 pair at step 5) even when FluentKit is
+        // also imported — the receiver-method pair fires BEFORE the
+        // framework-gated non-idempotent method path (step 11) where
+        // Fluent's `delete` ORM verb lives.
+        let routerCall = try firstCall(in: "func f() { router.delete(\"/x\") { _, _ in } }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: routerCall, imports: ["Hummingbird", "FluentKit"], enabledFrameworks: nil
+        ) == .idempotent)
+
+        // And in the same hypothetical file, `model.delete(on: db)` on
+        // a non-`router` receiver must still hit Fluent's ORM-verb path
+        // — the slot-16 entry is receiver-scoped to `router` only.
+        let modelCall = try firstCall(in: "func f() { try await model.delete(on: db) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: modelCall, imports: ["Hummingbird", "FluentKit"], enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
     // MARK: - AWSLambdaRuntime response-writer primitives (framework-gated)
 
     @Test


### PR DESCRIPTION
## Summary

Adds 5 receiver-method pairs under the Hummingbird gate to
`idempotentReceiverMethodsByFramework`:

```swift
"get":    ["router": hummingbird],
"post":   ["router": hummingbird],
"put":    ["router": hummingbird],
"patch":  ["router": hummingbird],
"delete": ["router": hummingbird],
```

Route-registration calls inside a `buildRouter()` or `addXRoutes(to router:)` helper annotated `@lint.context replayable` should stay silent — these are startup-time DSL calls, not request-scoped operations. The enclosing-function annotation exists to walk INTO the registered handler closures; the registration calls themselves are what this slice whitelists.

Same-shape slice as existing `(request, decode)` / `(parameters, require)` / `(outputWriter, write)` pairs — no inferrer-core changes, just data-table additions.

## Precedence behaviour

The slot-16 pair lookup (step 5 in `HeuristicEffectInferrer`) fires **before** the bare-name non-idempotent check (step 9), so `router.post` silences cleanly without any change to the bare-name lexicon. Step 11 (FluentKit ORM verbs) is unaffected: `model.delete(on: db)` still classifies non-idempotent because the slot-16 pair is scoped to the `router` receiver. Test `hummingbirdRouterDelete_coexistsWithFluentDeleteClassification` pins this precedence explicitly.

## Evidence (2-adopter)

Re-scans at slot-16 tip vs. main (`698081e`):

| Adopter | Run | Pre slot 16 | Post slot 16 | Delta |
|---|---|---|---|---|
| `samalone/prospero` | Run B (strict_replayable) | 64 errors | 55 errors | **−9** (6× `router.get` + 3× `router.post`) |
| `hummingbird-examples/open-telemetry` | Run B (strict_replayable) | 12 errors | 9 errors | **−3** (2× `router.get` + 1× `router.post`) |
| `hummingbird-examples/open-telemetry` | Run A (replayable) | 1 error | 0 errors | **−1** (1× `router.post`) |

**Total: −12 across Run B scans (+1 in open-telemetry Run A where `router.post` also fired in replayable mode).** Deltas match the DSL-call counts exactly — 9 registration calls in prospero, 3 in open-telemetry.

Note on the prospero count: the original prospero trial-findings reported a 14-fire cluster (`router.get` ×11 + `router.post` ×3). That tally over-counted by lumping `parameters.get("id", as: UUID.self)` and `queryParameters.get("sort")` fires into the "router-DSL cluster" — those are a different (receiver, method) pair. The 9 silenced here are the actual router-DSL calls; the remaining `.get` fires in prospero are on `parameters` / `queryParameters` receivers and stay correctly flagged. SwiftIdempotency's trial-findings for both rounds will be corrected in a follow-up.

**Trial tips for the 2-adopter evidence:**
- `Joseph-Cursio/prospero-idempotency-trial` @ `56d676f` (trial-prospero Run B)
- `Joseph-Cursio/hummingbird-examples-idempotency-trial` @ `674935a` (trial-open-telemetry Run B)

## Tests

**+11 new tests** in `FrameworkWhitelistGatingTests.swift` under a new `// MARK: - Hummingbird Router DSL whitelist (slot 16)` section:

- Import-gated fires — one per verb × 5
- Import-absent `router.post` → non-idempotent (bare-name path still fires; confirms the whitelist is what silences, not a structural override)
- Import-absent `router.get` → nil (not in bare-name lists)
- Wrong-receiver suppression (`mailer.post(...)` with Hummingbird import → still non-idempotent via bare-name)
- Config-gated disable (whitelist off → bare-name path re-fires)
- Inference reason naming (`router.post` → "from the Hummingbird primitive \`router.post\`")
- Fluent coexistence precedence (`router.delete` idempotent even with FluentKit imported; `model.delete` still non-idempotent on non-router receivers)

Suite total: 2295 → **2306** (full suite green).

## Test plan

- [x] `swift test` green (2306/276)
- [x] Re-scan prospero at slot-16 tip → −9 confirmed
- [x] Re-scan open-telemetry at slot-16 tip → Run A −1, Run B −3 confirmed
- [x] Precedence regression: `model.delete(on: db)` still fires as Fluent ORM verb when both FluentKit and Hummingbird are imported (pinned in `hummingbirdRouterDelete_coexistsWithFluentDeleteClassification`)
- [ ] Reviewer: the 5 `router.*` entries duplicate the `router` receiver string 5× in the pair table. Worth a dedicated `routerDslMethods: Set<String>` with a single dictionary entry, or keep the flat key-by-method structure for consistency with `request.decode` / `parameters.require` / `outputWriter.write`?

🤖 Generated with [Claude Code](https://claude.com/claude-code)