### PR TITLE
Slot 17 — Vapor routing DSL whitelist

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
@@ -32,13 +32,15 @@ public enum FrameworkWhitelist {
     public static let composableArchitecture = "ComposableArchitecture"
     public static let awsLambdaRuntime = "AWSLambdaRuntime"
     public static let httpPipeline = "HttpPipeline"
+    public static let vapor = "Vapor"
 
     /// Every framework this project recognises. Order-insensitive.
     /// Used as the default `enabledFrameworks` set when a project
     /// hasn't opted out of any framework's classifications.
     public static let knownFrameworks: Set<String> = [
         foundation, nio, awsLambdaEvents, logging, osLog, metrics, fluent,
-        hummingbird, composableArchitecture, awsLambdaRuntime, httpPipeline
+        hummingbird, composableArchitecture, awsLambdaRuntime, httpPipeline,
+        vapor
     ]
 
     // MARK: - Idempotent type constructors (bare-identifier call)
@@ -225,6 +227,20 @@ public enum FrameworkWhitelist {
     /// `hummingbird-project/hummingbird-examples/open-telemetry`
     /// (1× `router.post` Run A + 2× `router.get` Run B) — identical
     /// rule-path shapes across both corpora.
+    ///
+    /// Vapor routing DSL (slot 17) — `app.{get,post,put,patch,delete}`
+    /// at route-registration sites. Parallel slice to slot 16 against
+    /// Vapor's `Application`. Vapor adopters that bind handlers via
+    /// inline trailing closures (`app.get("/path") { req in ... }`)
+    /// inside a `func routes(_ app: Application) throws { ... }` helper
+    /// annotated `@lint.context replayable` hit the same registration-
+    /// site-noise pattern as Hummingbird. Note: `app.get` is silent
+    /// under replayable because `get` is idempotent-by-prefix, but
+    /// fires under strict_replayable without this entry; whitelisting
+    /// all 5 verbs silences across both tiers. 2-adopter evidence:
+    /// `kylebshr/luka-vapor` (2× `app.post` Run A + 1× `app.get` Run B)
+    /// and `sinduke/HelloVapor` (1× `app.post` Run A + 5× `app.get`
+    /// Run B) — identical rule-path shapes across both corpora.
     private static let idempotentReceiverMethodsByFramework: [String: [String: String]] = [
         "decode": ["request": hummingbird],
         "require": ["parameters": hummingbird],
@@ -233,11 +249,11 @@ public enum FrameworkWhitelist {
             "responseWriter": awsLambdaRuntime,
         ],
         "finish": ["responseWriter": awsLambdaRuntime],
-        "get": ["router": hummingbird],
-        "post": ["router": hummingbird],
-        "put": ["router": hummingbird],
-        "patch": ["router": hummingbird],
-        "delete": ["router": hummingbird],
+        "get": ["router": hummingbird, "app": vapor],
+        "post": ["router": hummingbird, "app": vapor],
+        "put": ["router": hummingbird, "app": vapor],
+        "patch": ["router": hummingbird, "app": vapor],
+        "delete": ["router": hummingbird, "app": vapor],
     ]
 
     /// Returns the framework that owns a given idempotent

--- a/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
+++ b/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
@@ -592,6 +592,136 @@ struct FrameworkWhitelistGatingTests {
         ) == .nonIdempotent)
     }
 
+    // MARK: - Vapor routing DSL whitelist (slot 17)
+
+    @Test
+    func importGated_vaporPresent_appGetFires() throws {
+        // `app.get("/path") { req in ... }` — Vapor inline-closure
+        // route registration inside a `func routes(_ app:)` helper.
+        // Silent under replayable via prefix-lexicon, but this entry
+        // also covers strict_replayable where the prefix-lexicon path
+        // doesn't short-circuit. 2-adopter evidence: luka-vapor +
+        // HelloVapor.
+        let call = try firstCall(in: "func f() { app.get(\"/x\") { _ in \"\" } }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Vapor"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_vaporPresent_appPostFires() throws {
+        // `app.post` is the motivating slot-17 case — `post` is in
+        // `nonIdempotentNames`, so without the receiver-method pair
+        // ahead of the bare-name check, every `app.post(...)` DSL
+        // registration inside a `@lint.context replayable`-annotated
+        // `routes(_:)` mis-fires.
+        let call = try firstCall(in: "func f() { app.post(\"/x\") { _ in } }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Vapor"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_vaporPresent_appPutFires() throws {
+        let call = try firstCall(in: "func f() { app.put(\"/x\") { _ in } }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Vapor"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_vaporPresent_appPatchFires() throws {
+        let call = try firstCall(in: "func f() { app.patch(\"/x\") { _ in } }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Vapor"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_vaporPresent_appDeleteFires() throws {
+        let call = try firstCall(in: "func f() { app.delete(\"/x\") { _ in } }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Vapor"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_vaporAbsent_appPostFiresAsNonIdempotent() throws {
+        // Without Vapor, the slot-17 pair doesn't match and the bare-
+        // name `post` classification at step 9 applies. A user-defined
+        // `app` in a non-Vapor module shouldn't pick up the Vapor
+        // classification just because the identifier matches.
+        let call = try firstCall(in: "func f() { app.post(\"/x\") { _ in } }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["MyApp"], enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func vaporAppPair_wrongReceiver_doesNotSilenceBareName() throws {
+        // `.post()` on a receiver other than `app` in a Vapor-importing
+        // file: the slot-17 pair must not fire, and the bare-name `post`
+        // lexicon path should still classify as non-idempotent.
+        let call = try firstCall(in: "func f() { mailer.post(email) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Vapor"], enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func configGated_vaporDisabled_appPostFallsThroughToBareName() throws {
+        // Adopter imports Vapor but opted out of its whitelist via
+        // `enabled_framework_whitelists`. Slot-17 pair should not fire;
+        // the bare-name `post` classification reasserts itself.
+        let call = try firstCall(in: "func f() { app.post(\"/x\") { _ in } }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Vapor"], enabledFrameworks: ["Foundation"]
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func vapor_appPost_inferenceReason() throws {
+        let call = try firstCall(in: "func f() { app.post(\"/x\") { _ in } }")
+        let reason = HeuristicEffectInferrer.inferenceReason(
+            for: call, imports: ["Vapor"], enabledFrameworks: nil
+        )
+        #expect(reason == "from the Vapor primitive `app.post`")
+    }
+
+    @Test
+    func vaporAppDelete_coexistsWithFluentDeleteClassification() throws {
+        // Critical precedence test — Vapor adopters almost always import
+        // Fluent too. `app.delete(...)` must classify idempotent (slot-17
+        // pair at step 5) even when FluentKit is also imported, and
+        // `model.delete(on: db)` on a non-`app` receiver must still hit
+        // Fluent's ORM-verb path (step 11).
+        let appCall = try firstCall(in: "func f() { app.delete(\"/x\") { _ in } }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: appCall, imports: ["Vapor", "FluentKit"], enabledFrameworks: nil
+        ) == .idempotent)
+
+        let modelCall = try firstCall(in: "func f() { try await model.delete(on: db) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: modelCall, imports: ["Vapor", "FluentKit"], enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func vaporAndHummingbirdImportedTogether_bothPairsActive() throws {
+        // Multi-framework import — Vapor and Hummingbird co-imported.
+        // Neither whitelist shadows the other; both `router.post` (slot 16)
+        // and `app.post` (slot 17) resolve idempotent.
+        let routerCall = try firstCall(in: "func f() { router.post(\"/x\") { _, _ in } }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: routerCall, imports: ["Vapor", "Hummingbird"], enabledFrameworks: nil
+        ) == .idempotent)
+
+        let appCall = try firstCall(in: "func f() { app.post(\"/x\") { _ in } }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: appCall, imports: ["Vapor", "Hummingbird"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
     // MARK: - AWSLambdaRuntime response-writer primitives (framework-gated)
 
     @Test


### PR DESCRIPTION
## Summary

- Adds 5 receiver-method pairs under the Vapor gate: `(app, get|post|put|patch|delete) → Vapor`. Parallel slice to slot 16 — same rule-path shape, just `\"app\": vapor` alongside `\"router\": hummingbird` on each of the existing 5 verb keys.
- Adds `FrameworkWhitelist.vapor = \"Vapor\"` constant and folds into `knownFrameworks`.
- No inferrer-core changes; pure data-table addition.

## Evidence

Two-adopter corroboration round this session (see SwiftIdempotency companion repo `docs/luka-vapor/` + `docs/hellovapor/` for full per-diagnostic audits):

| Adopter | Run A Δ | Run B Δ |
|---|---|---|
| `kylebshr/luka-vapor` | 4 → 2 (−2 `app.post`) | 52 → 49 (−3; 2 `app.post` carried + 1 `app.get` strict-only) |
| `sinduke/HelloVapor` | 5 → 4 (−1 `app.post`) | 25 → 19 (−6; 1 `app.post` carried + 5 `app.get` strict-only) |

Combined: **9 fires silenced across 2 adopters**, exactly matching the 2-adopter prediction.

Note on scope: `app.get` is already silent under replayable via prefix-lexicon (`get` is idempotent-by-convention), but fires under `strict_replayable` because the prefix-lexicon path doesn't short-circuit there. Whitelisting all 5 verbs silences across both tiers cleanly.

## Also logged (not shipped)

- `(app, register)` — HelloVapor's 4× `app.register(collection:)` fires, 1-adopter. Defer pending second-adopter evidence.
- `(Route, description)` — HelloVapor's 5× `.description(...)` OpenAPI-metadata chain, 1-adopter. Defer.

## Test plan

- [x] `swift test` — 2306 → 2317 green (+11 new in `FrameworkWhitelistGatingTests`).
- [x] Re-scan `luka-vapor` both tiers post-slice — deltas match predicted exactly.
- [x] Re-scan `HelloVapor` both tiers post-slice — deltas match predicted exactly.
- [ ] Merge → update `SwiftIdempotency/docs/next_steps.md` with shipped state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)