### PR TITLE
Slot 18 — parameters.get / queryParameters.get whitelist

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
@@ -241,6 +241,14 @@ public enum FrameworkWhitelist {
     /// `kylebshr/luka-vapor` (2× `app.post` Run A + 1× `app.get` Run B)
     /// and `sinduke/HelloVapor` (1× `app.post` Run A + 5× `app.get`
     /// Run B) — identical rule-path shapes across both corpora.
+    ///
+    /// Hummingbird `queryParameters.get` (slot 18) — structural sibling
+    /// to the existing `(parameters, require)` entry. Hummingbird's
+    /// `request.uri.queryParameters.get(_:as:)` is a URL-parameter
+    /// retrieval-by-name, no more side-effecting than `parameters.get`
+    /// (which ships as part of slot 18's cross-framework table below).
+    /// 1-adopter evidence (prospero: 1 fire); shipped as a Hummingbird-
+    /// gated sibling to keep the parameter-access surface complete.
     private static let idempotentReceiverMethodsByFramework: [String: [String: String]] = [
         "decode": ["request": hummingbird],
         "require": ["parameters": hummingbird],
@@ -249,7 +257,10 @@ public enum FrameworkWhitelist {
             "responseWriter": awsLambdaRuntime,
         ],
         "finish": ["responseWriter": awsLambdaRuntime],
-        "get": ["router": hummingbird, "app": vapor],
+        "get": [
+            "router": hummingbird, "app": vapor,
+            "queryParameters": hummingbird,
+        ],
         "post": ["router": hummingbird, "app": vapor],
         "put": ["router": hummingbird, "app": vapor],
         "patch": ["router": hummingbird, "app": vapor],
@@ -263,6 +274,48 @@ public enum FrameworkWhitelist {
         method: String
     ) -> String? {
         idempotentReceiverMethodsByFramework[method]?[receiver]
+    }
+
+    // MARK: - Cross-framework idempotent receiver/method pairs (slot 18)
+
+    /// Idempotent `(receiver, method)` pairs where the receiver
+    /// identifier is common convention across multiple web frameworks.
+    /// Consulted *after* `idempotentReceiverMethodsByFramework` so the
+    /// framework-specific table (where the receiver name is
+    /// framework-canonical) takes precedence.
+    ///
+    /// `parameters.get` (slot 18) is the motivating pair: both
+    /// Hummingbird (`context.parameters.get(_:as:)`) and Vapor
+    /// (`req.parameters.get("name")`) expose a `parameters` accessor
+    /// on their request object with a `.get(_:)` method that retrieves
+    /// URL path parameters by name. Retrieval is a pure-read — same
+    /// URL produces same value — so silencing is both safe and
+    /// precision-preserving. The receiver identifier `parameters` is
+    /// specific enough in the web-framework-imported context that
+    /// misattribution to user-defined `parameters` variables is
+    /// unlikely.
+    ///
+    /// 2-adopter cross-framework evidence:
+    /// `samalone/prospero` (4× `context.parameters.get`, Hummingbird)
+    /// and `sinduke/HelloVapor` (1× `req.parameters.get("name")`,
+    /// Vapor) — 5 fires silenced across 2 independent adopters,
+    /// different frameworks, identical receiver-method shape.
+    private static let idempotentReceiverMethodsMultiFramework: [String: [String: Set<String>]] = [
+        "get": [
+            "parameters": [hummingbird, vapor],
+        ],
+    ]
+
+    /// Returns the set of frameworks any of which qualifies a given
+    /// idempotent `(receiver, method)` pair as idempotent, or nil when
+    /// the pair isn't listed in the multi-framework table. The caller
+    /// is responsible for checking whether any of the returned
+    /// frameworks is active in the current file's import set.
+    public static func frameworks(
+        forCrossFrameworkIdempotentReceiver receiver: String,
+        method: String
+    ) -> Set<String>? {
+        idempotentReceiverMethodsMultiFramework[method]?[receiver]
     }
 
     // MARK: - Bare-name overrides of the non-idempotent list (framework-gated)

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/HeuristicEffectInferrer.swift
@@ -179,6 +179,20 @@ public enum HeuristicEffectInferrer {
             return .idempotent
         }
 
+        // Cross-framework idempotent (receiver, method) pairs (slot 18).
+        // Receiver identifiers shared across multiple web frameworks —
+        // `parameters.get` being the motivating case (both Hummingbird
+        // and Vapor expose identical-named accessors). Qualifies when
+        // ANY of the pair's candidate frameworks is active.
+        if let receiverName,
+           let candidates = FrameworkWhitelist.frameworks(
+               forCrossFrameworkIdempotentReceiver: receiverName,
+               method: calleeName
+           ),
+           candidates.contains(where: context.isFrameworkActive) {
+            return .idempotent
+        }
+
         // Framework-gated bare-name overrides of the non-idempotent list.
         // TCA's `Send<Action>` closure parameter is the motivating case:
         // `await send(.action)` inside an effect closure is a structural
@@ -301,6 +315,14 @@ public enum HeuristicEffectInferrer {
            ),
            context.isFrameworkActive(framework) {
             return "from the \(framework) primitive `\(receiverName).\(calleeName)`"
+        }
+        if let receiverName,
+           let candidates = FrameworkWhitelist.frameworks(
+               forCrossFrameworkIdempotentReceiver: receiverName,
+               method: calleeName
+           ),
+           let active = candidates.first(where: context.isFrameworkActive) {
+            return "from the \(active) primitive `\(receiverName).\(calleeName)`"
         }
         if receiverName == nil,
            let framework = FrameworkWhitelist.framework(

--- a/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
+++ b/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
@@ -592,6 +592,127 @@ struct FrameworkWhitelistGatingTests {
         ) == .nonIdempotent)
     }
 
+    // MARK: - Cross-framework parameters.get / queryParameters.get (slot 18)
+
+    @Test
+    func slot18_parametersGet_firesUnderHummingbird() throws {
+        // `context.parameters.get("id")` — Hummingbird URL parameter
+        // retrieval. Cross-framework multi-framework table matches
+        // because Hummingbird is in the candidate set.
+        let call = try firstCall(in: "func f() { _ = parameters.get(\"id\") }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Hummingbird"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func slot18_parametersGet_firesUnderVapor() throws {
+        // `req.parameters.get("name")` — Vapor URL parameter
+        // retrieval. Same cross-framework entry as Hummingbird.
+        let call = try firstCall(in: "func f() { _ = parameters.get(\"name\") }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Vapor"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func slot18_parametersGet_firesUnderBothFrameworksImported() throws {
+        // Multi-import — both Hummingbird and Vapor imported. Cross-
+        // framework table qualifies when at least one candidate is
+        // active; having both active must not cause ambiguity.
+        let call = try firstCall(in: "func f() { _ = parameters.get(\"id\") }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Hummingbird", "Vapor"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func slot18_parametersGet_doesNotFireWithoutWebFramework() throws {
+        // `parameters.get(...)` in a file that imports neither
+        // Hummingbird nor Vapor must not match. The cross-framework
+        // whitelist is the precision gate — without one of the listed
+        // imports, a user-defined `parameters` variable stays unclassified.
+        let call = try firstCall(in: "func f() { _ = parameters.get(\"id\") }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["MyApp"], enabledFrameworks: nil
+        ) == nil)
+    }
+
+    @Test
+    func slot18_queryParametersGet_firesUnderHummingbird() throws {
+        // `request.uri.queryParameters.get(...)` — Hummingbird query-
+        // parameter retrieval. Hummingbird-only; ships in the
+        // single-framework table as a sibling to parameters.require.
+        let call = try firstCall(in: "func f() { _ = queryParameters.get(\"page\") }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Hummingbird"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func slot18_queryParametersGet_doesNotFireUnderVaporOnly() throws {
+        // `queryParameters` isn't a Vapor idiom — Vapor uses `req.query`
+        // with a different accessor shape. Under Vapor-only imports,
+        // the queryParameters.get entry must not match.
+        let call = try firstCall(in: "func f() { _ = queryParameters.get(\"page\") }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Vapor"], enabledFrameworks: nil
+        ) == nil)
+    }
+
+    @Test
+    func slot18_parametersGet_configGatedHummingbirdDisabled_stillFiresUnderVapor() throws {
+        // Adopter imports both Hummingbird and Vapor but has disabled
+        // Hummingbird's whitelist via config. Cross-framework table
+        // still qualifies because Vapor (the other candidate) remains
+        // active in `enabledFrameworks`.
+        let call = try firstCall(in: "func f() { _ = parameters.get(\"id\") }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Hummingbird", "Vapor"],
+            enabledFrameworks: ["Vapor"]
+        ) == .idempotent)
+    }
+
+    @Test
+    func slot18_parametersGet_configGatedBothDisabled_doesNotFire() throws {
+        // Both Hummingbird and Vapor disabled via config. Neither
+        // candidate qualifies; cross-framework table doesn't match.
+        let call = try firstCall(in: "func f() { _ = parameters.get(\"id\") }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Hummingbird", "Vapor"],
+            enabledFrameworks: ["Foundation"]
+        ) == nil)
+    }
+
+    @Test
+    func slot18_parametersGet_wrongReceiver_doesNotFire() throws {
+        // A call with `foo.get(...)` receiver in a Hummingbird/Vapor
+        // file must not be silenced — the cross-framework entry is
+        // receiver-scoped to `parameters` only.
+        let call = try firstCall(in: "func f() { _ = foo.get(\"id\") }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Hummingbird", "Vapor"], enabledFrameworks: nil
+        ) == nil)
+    }
+
+    @Test
+    func slot18_parametersGet_inferenceReason_hummingbird() throws {
+        let call = try firstCall(in: "func f() { _ = parameters.get(\"id\") }")
+        let reason = HeuristicEffectInferrer.inferenceReason(
+            for: call, imports: ["Hummingbird"], enabledFrameworks: nil
+        )
+        #expect(reason == "from the Hummingbird primitive `parameters.get`")
+    }
+
+    @Test
+    func slot18_parametersGet_inferenceReason_vapor() throws {
+        let call = try firstCall(in: "func f() { _ = parameters.get(\"id\") }")
+        let reason = HeuristicEffectInferrer.inferenceReason(
+            for: call, imports: ["Vapor"], enabledFrameworks: nil
+        )
+        #expect(reason == "from the Vapor primitive `parameters.get`")
+    }
+
     // MARK: - Vapor routing DSL whitelist (slot 17)
 
     @Test


### PR DESCRIPTION
## Summary

- Adds `(parameters, get) → {Hummingbird, Vapor}` as the first entry in a new cross-framework receiver-method table (`idempotentReceiverMethodsMultiFramework`). `parameters` is a common-convention request-accessor name shared across both frameworks; the cross-framework entry qualifies when ANY candidate framework is active in the file's imports.
- Adds `(queryParameters, get) → Hummingbird` to the existing single-framework table, sibling to `(parameters, require)`. `queryParameters` isn't a Vapor idiom (Vapor uses `req.query` with a different accessor shape), so this one stays Hummingbird-scoped.
- Inferrer gets one new lookup site (post the existing single-framework check) and one new reason-string site.

## Evidence

Re-scans at slot-18 tip vs slot-17 tip (strict_replayable):

| Adopter | Pre | Post | Δ |
|---|---|---|---|
| `samalone/prospero` (Hummingbird) | 53 | 48 | **−5** (4× `context.parameters.get` + 1× `request.uri.queryParameters.get`) |
| `sinduke/HelloVapor` (Vapor) | 19 | 18 | **−1** (1× `req.parameters.get(\"name\")`) |

Combined: **6 fires silenced across 2 adopters, cross-framework coverage**. Deltas match per-adopter fire counts exactly.

Both are structural siblings to the existing `(parameters, require) → Hummingbird` entry — the parameter-access surface is now complete across by-name retrieval (`get`), required retrieval (`require`), and query-string retrieval (`queryParameters.get`).

## Design note

The two-table approach keeps the existing single-framework `[String: [String: String]]` table untouched and adds a parallel `[String: [String: Set<String>]]` table specifically for cross-framework-shared receiver names. Simpler diff than widening all existing entries to `[String]`, and makes the cross-framework intent explicit at the data-structure level. The inferrer does two lookups (old table first, new table second) which is cheap.

## Test plan

- [x] `swift test` — 2317 → 2328 green (+11 new in `FrameworkWhitelistGatingTests`): per-framework fires, cross-framework multi-import, config-gate with one framework disabled, config-gate with both disabled, Hummingbird-only `queryParameters.get` not firing under Vapor-only imports, wrong-receiver suppression, inference-reason phrasing for both frameworks.
- [x] Re-scan prospero + HelloVapor at slot-18 tip → deltas match prediction exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)