### PR TITLE
Slot 19 — FluentKit `import Fluent` alias

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
@@ -43,6 +43,46 @@ public enum FrameworkWhitelist {
         vapor
     ]
 
+    // MARK: - Import aliases (re-export / meta-package handling)
+
+    /// Alternate module names that, when imported, qualify as having
+    /// imported the canonical framework. Idiomatic adopter code often
+    /// imports a meta-package that re-exports the concrete module — the
+    /// linter sees the literal import name, so without an alias table
+    /// the framework-gated whitelist silently doesn't fire.
+    ///
+    /// Slot 19 motivating case: Vapor's `Fluent` meta-package
+    /// (`vapor/fluent`) re-exports `FluentKit`, `FluentSQL`, `FluentSQLiteDriver`
+    /// etc. Idiomatic Vapor code imports `Fluent`, not `FluentKit`. The
+    /// linter's FluentKit gate was matching the literal module name, so
+    /// `save()` / query-builder reads on `import Fluent` adopters were
+    /// going unclassified. Evidence from the hellovapor package trial:
+    /// a `save(on:)` call inside an `@ExternallyIdempotent`-marked body
+    /// under `import Fluent` went silent, then fired the expected
+    /// `idempotencyViolation` after swapping to `import FluentKit` —
+    /// confirming the gate, not the classification, was the gap.
+    ///
+    /// Alias sets live alongside the canonical framework name. The
+    /// `isFrameworkActive` check consults both the canonical name and
+    /// any alias when testing import presence. The canonical name
+    /// remains the single identity used throughout — the reason string
+    /// still names `FluentKit`, the `enabledFrameworks` config still
+    /// opts in/out via the canonical name, nested whitelist tables
+    /// still key on canonical. Aliases are purely an import-gate
+    /// convenience.
+    private static let frameworkImportAliases: [String: Set<String>] = [
+        fluent: ["Fluent"],
+    ]
+
+    /// Returns the set of alternate import names that satisfy the
+    /// import gate for `framework`, or an empty set when the framework
+    /// has no aliases. Callers should treat any of these as equivalent
+    /// to the canonical framework name when testing the adopter's
+    /// import set.
+    public static func importAliases(forFramework framework: String) -> Set<String> {
+        frameworkImportAliases[framework] ?? []
+    }
+
     // MARK: - Idempotent type constructors (bare-identifier call)
 
     /// Maps a type-constructor name (as it appears in source) to the
@@ -386,7 +426,8 @@ public struct FrameworkContext: Sendable {
     }
 
     public func isFrameworkActive(_ framework: String) -> Bool {
-        let importOK = imports.contains(framework)
+        let aliases = FrameworkWhitelist.importAliases(forFramework: framework)
+        let importOK = imports.contains(framework) || !aliases.isDisjoint(with: imports)
         let enabledOK = enabled?.contains(framework) ?? true
         return importOK && enabledOK
     }

--- a/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
+++ b/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
@@ -366,6 +366,117 @@ struct FrameworkWhitelistGatingTests {
         #expect(reason == "from the FluentKit query-builder read `all`")
     }
 
+    // MARK: - Fluent import alias (slot 19)
+
+    /// Slot 19 — the `Fluent` meta-package (`vapor/fluent`) re-exports
+    /// `FluentKit`, so idiomatic Vapor code imports `Fluent` and the gate
+    /// must treat that as equivalent to `FluentKit`. Mirrors the Fluent
+    /// sections above with `imports: ["Fluent"]` in place of
+    /// `["FluentKit"]`. Evidence from the hellovapor package trial — a
+    /// `save(on:)` call under `import Fluent` went silent until the gate
+    /// was aliased.
+
+    @Test
+    func importGated_fluentMetaPackage_modelSaveFires() throws {
+        let call = try firstCall(in: "func f() { todo.save() }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Fluent"], enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func importGated_fluentMetaPackage_modelUpdateFires() throws {
+        let call = try firstCall(in: "func f() { todo.update() }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Fluent"], enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func importGated_fluentMetaPackage_modelDeleteFires() throws {
+        let call = try firstCall(in: "func f() { todo.delete() }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Fluent"], enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func importGated_fluentMetaPackage_queryFires() throws {
+        let call = try firstCall(in: "func f() { Todo.query(on: db) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Fluent"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_fluentMetaPackage_allFires_onChainedCall() throws {
+        // Same shape as the FluentKit chained-read test — the terminal
+        // `.all()` on a query builder resolves through the idempotent
+        // method gate when the file imports the meta-package.
+        let source = "func f() { _ = Todo.query(on: db).all() }"
+        let call = try memberCall(method: "all", in: source)
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Fluent"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func fluentMetaPackage_inferenceReason_usesCanonicalFrameworkName() throws {
+        // The alias gates import presence; the reason string keeps the
+        // canonical `FluentKit` name so users searching the docs for the
+        // rule reason see the same phrasing regardless of import spelling.
+        let call = try firstCall(in: "func f() { todo.save() }")
+        let reason = HeuristicEffectInferrer.inferenceReason(
+            for: call, imports: ["Fluent"], enabledFrameworks: nil
+        )
+        #expect(reason == "from the FluentKit ORM verb `save`")
+    }
+
+    @Test
+    func fluentMetaPackage_idempotentReadReason_usesCanonicalFrameworkName() throws {
+        let source = "func f() { _ = Todo.query(on: db).all() }"
+        let call = try memberCall(method: "all", in: source)
+        let reason = HeuristicEffectInferrer.inferenceReason(
+            for: call, imports: ["Fluent"], enabledFrameworks: nil
+        )
+        #expect(reason == "from the FluentKit query-builder read `all`")
+    }
+
+    @Test
+    func fluentBothImports_modelSaveFires() throws {
+        // Redundant but legal — some adopters import both the
+        // meta-package and the concrete module. Either alone activates
+        // the gate, and both together should behave identically.
+        let call = try firstCall(in: "func f() { todo.save() }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Fluent", "FluentKit"], enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func configGated_fluentDisabled_metaPackageAliasStillSilenced() throws {
+        // `enabledFrameworks` gates by the canonical name, not by the
+        // import spelling. An adopter opting out of Fluent via config
+        // stays silenced under `import Fluent` just as under
+        // `import FluentKit` — the alias is purely an import-gate
+        // convenience.
+        let call = try firstCall(in: "func f() { todo.save() }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Fluent"], enabledFrameworks: ["Foundation"]
+        ) == nil)
+    }
+
+    @Test
+    func fluentMetaPackage_nonAliasNameDoesNotActivateGate() throws {
+        // Defensive: only the enumerated alias `Fluent` qualifies.
+        // A user-defined module whose name merely prefixes `Fluent`
+        // (e.g. `MyFluentHelpers`) must not activate the gate.
+        let call = try firstCall(in: "func f() { todo.save() }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["MyFluentHelpers"], enabledFrameworks: nil
+        ) == nil)
+    }
+
     // MARK: - Hummingbird primitives (framework-gated)
 
     @Test


### PR DESCRIPTION
## Summary

- Adds an `importAliases(forFramework:)` table in `FrameworkWhitelist` so the FluentKit gate fires under Vapor's `Fluent` meta-package (which re-exports FluentKit). Single alias today: `fluent → ["Fluent"]`.
- Single-site consumer in `FrameworkContext.isFrameworkActive`: import gate now passes when the canonical name OR any alias is in the file's import set. Enabled-frameworks config and all whitelist tables still key on the canonical name — the alias is purely an import-gate convenience.
- Evidence from the hellovapor package trial: a `save(on:)` inside an `@ExternallyIdempotent`-marked body under `import Fluent` went silent until the gate was aliased.

## Measured deltas

Baseline at `db4d576` vs slot-19 tip against `sinduke/HelloVapor` on the `trial-hellovapor` branch:

- **Run A 4 → 5** (+1 correct-catch: `save(on: req.db)` at `routes.swift:34` — the Acronym-uniqueness bug already filed as [HelloVapor#1](https://github.com/sinduke/HelloVapor/pull/1); was previously silent under `import Fluent` because the FluentKit gate didn't match the import spelling).
- **Run B 18 → 18** (rule reclassifies the same line from `[Unannotated In Strict Replayable Context]` fallback to the typed `[Non-Idempotent In Retry Context]` via FluentKit ORM verb — precision uplift, count unchanged).

Other adopters verified unaffected — `luka-vapor`, `myfavquotes-api`, and `prospero` trial clones have 0 files with `import Fluent` (all use `import FluentKit` directly, which the existing gate already handles).

Shape: data-table addition, same as slots 13–18. `+10` tests in `FrameworkWhitelistGatingTests`; suite 2328 → **2338 green**.

## Test plan

- [x] `swift test` full suite green (2338/276).
- [x] New slot-19 tests cover: `save`/`update`/`delete` under `import Fluent`, `query`/`all` (chained) idempotent reads, reason-string uses canonical `FluentKit` name under either import, redundant `[Fluent, FluentKit]` import both active, config-disable via canonical name still silences, non-alias module name (`MyFluentHelpers`) does not activate gate.
- [x] hellovapor re-scan at Run A + Run B (pre-/post-slot-19 diff reviewed for correctness).
- [x] Cross-adopter non-regression verified via `import Fluent` grep across luka-vapor / myfavquotes-api / prospero trial clones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)