### PR TITLE
Slot 21 — Vapor app.register(collection:) whitelist

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
@@ -289,6 +289,25 @@ public enum FrameworkWhitelist {
     /// (which ships as part of slot 18's cross-framework table below).
     /// 1-adopter evidence (prospero: 1 fire); shipped as a Hummingbird-
     /// gated sibling to keep the parameter-access surface complete.
+    ///
+    /// Vapor `app.register(collection:)` (slot 21) — Vapor's
+    /// `Application.register(collection:)` idiom for mounting a
+    /// `RouteCollection` conformer at startup time. Structurally
+    /// sibling to the slot-17 `(app, get|post|...)` entries — same
+    /// receiver, same gating framework, same "startup-time registration
+    /// DSL, not request-scoped" semantics. Ships silent under both
+    /// replayable and strict_replayable because `register` is in the
+    /// `nonIdempotentNames` server-app-verb lexicon (slot 13), so
+    /// without this entry every `app.register(collection:)` in a
+    /// `@lint.context replayable`-annotated `routes(_:)` helper
+    /// mis-fires on adopters who bind their controllers by collection.
+    /// 3-adopter evidence: `sinduke/HelloVapor` (prior 1-adopter),
+    /// `uitsmijter/Uitsmijter` (10 sites — `HealthController`,
+    /// `VersionsController`, `MetricsController`, `LoginController`,
+    /// `LogoutController`, `InterceptorController`,
+    /// `WellKnownController`, `AuthorizeController`, `TokenController`,
+    /// `RevokeController`), `kphrx/plc-handle-tracker` (2 sites —
+    /// `DidController`, `HandleController`).
     private static let idempotentReceiverMethodsByFramework: [String: [String: String]] = [
         "decode": ["request": hummingbird],
         "require": ["parameters": hummingbird],
@@ -305,6 +324,7 @@ public enum FrameworkWhitelist {
         "put": ["router": hummingbird, "app": vapor],
         "patch": ["router": hummingbird, "app": vapor],
         "delete": ["router": hummingbird, "app": vapor],
+        "register": ["app": vapor],
     ]
 
     /// Returns the framework that owns a given idempotent

--- a/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
+++ b/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
@@ -954,6 +954,86 @@ struct FrameworkWhitelistGatingTests {
         ) == .idempotent)
     }
 
+    // MARK: - Vapor `app.register(collection:)` whitelist (slot 21)
+
+    @Test
+    func importGated_vaporPresent_appRegisterCollectionFires() throws {
+        // `app.register(collection: MyController())` — Vapor idiom for
+        // mounting a `RouteCollection` conformer at startup time.
+        // `register` is in `nonIdempotentNames` (slot 13 server-app verbs),
+        // so without the slot-21 receiver-method pair ahead of the bare-
+        // name check, every `app.register(collection:)` inside a
+        // `@lint.context replayable`-annotated `routes(_:)` helper
+        // mis-fires. 3-adopter evidence: HelloVapor + Uitsmijter +
+        // plc-handle-tracker.
+        let call = try firstCall(in: "func f() { try app.register(collection: FooController()) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Vapor"], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func importGated_vaporAbsent_appRegisterFiresAsNonIdempotent() throws {
+        // Without Vapor, the slot-21 pair doesn't match and the bare-
+        // name `register` (slot 13) classification applies. A user-
+        // defined `app` in a non-Vapor module shouldn't pick up the
+        // Vapor classification just because the identifier matches.
+        let call = try firstCall(in: "func f() { try app.register(collection: FooController()) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["MyApp"], enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func vaporAppRegisterPair_wrongReceiver_doesNotSilenceBareName() throws {
+        // `.register()` on a receiver other than `app` in a Vapor-
+        // importing file: the slot-21 pair must not fire, and the bare-
+        // name `register` lexicon path should still classify as
+        // non-idempotent.
+        let call = try firstCall(in: "func f() { registry.register(collection: FooController()) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Vapor"], enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func configGated_vaporDisabled_appRegisterFallsThroughToBareName() throws {
+        // Adopter imports Vapor but opted out of its whitelist via
+        // `enabled_framework_whitelists`. Slot-21 pair should not fire;
+        // the bare-name `register` classification reasserts itself.
+        let call = try firstCall(in: "func f() { try app.register(collection: FooController()) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: ["Vapor"], enabledFrameworks: ["Foundation"]
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func vapor_appRegister_inferenceReason() throws {
+        let call = try firstCall(in: "func f() { try app.register(collection: FooController()) }")
+        let reason = HeuristicEffectInferrer.inferenceReason(
+            for: call, imports: ["Vapor"], enabledFrameworks: nil
+        )
+        #expect(reason == "from the Vapor primitive `app.register`")
+    }
+
+    @Test
+    func vaporAppRegister_coexistsWithFluentImport() throws {
+        // Most Vapor adopters also import Fluent. slot-21's
+        // `app.register(collection:)` must classify idempotent even
+        // when FluentKit is also imported, and `model.register(...)`
+        // on a non-`app` receiver (hypothetical user API) must not
+        // be silenced by the slot-21 pair.
+        let appCall = try firstCall(in: "func f() { try app.register(collection: FooController()) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: appCall, imports: ["Vapor", "FluentKit"], enabledFrameworks: nil
+        ) == .idempotent)
+
+        let modelCall = try firstCall(in: "func f() { try model.register(delegate) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: modelCall, imports: ["Vapor", "FluentKit"], enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
     // MARK: - AWSLambdaRuntime response-writer primitives (framework-gated)
 
     @Test


### PR DESCRIPTION
## Summary
Adds `(app, register) → Vapor` to the `idempotentReceiverMethodsByFramework` table. `register` is in the `nonIdempotentNames` server-app-verb lexicon (slot 13), so Vapor adopters binding controllers via `app.register(collection: Controller())` inside a `@lint.context replayable`-annotated `routes(_ app:)` helper mis-fire without this entry. Shape-identical to slot 17.

## Evidence
3-adopter evidence from the 2026-04-24 trial-adopter lint sweep (see `swiftIdempotency/docs/trial-adopter-lint-sweep-2026-04-24.md`):

- **`sinduke/HelloVapor`** (prior 1-adopter, carried the slot-17 validation)
- **`uitsmijter/Uitsmijter`** — 10 call sites in `Sources/Uitsmijter-AuthServer/routes.swift` mounting Health / Versions / Metrics / Login / Logout / Interceptor / WellKnown / Authorize / Token / Revoke controllers
- **`kphrx/plc-handle-tracker`** — 2 sites in `Sources/registerRoutes.swift` mounting `DidController` + `HandleController`

## Test plan
- [x] `swift test --filter FrameworkWhitelistGatingTests` — 119/119 green (+6 new slot-21 tests: import-gated, import-absent, wrong-receiver, config-gated, inference-reason, Fluent coexistence)
- [x] `swift test` — full suite 2367 green (+6 from 2361)
- [ ] Post-merge: re-run adopter road-tests on Uitsmijter + plc-handle-tracker annotated branches to confirm `app.register` fires silence as predicted

🤖 Generated with [Claude Code](https://claude.com/claude-code)