### PR TITLE
Slot 22 — Swift Concurrency Task.sleep whitelist

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FrameworkWhitelist.swift
@@ -33,6 +33,7 @@ public enum FrameworkWhitelist {
     public static let awsLambdaRuntime = "AWSLambdaRuntime"
     public static let httpPipeline = "HttpPipeline"
     public static let vapor = "Vapor"
+    public static let swiftConcurrency = "SwiftConcurrency"
 
     /// Every framework this project recognises. Order-insensitive.
     /// Used as the default `enabledFrameworks` set when a project
@@ -40,7 +41,30 @@ public enum FrameworkWhitelist {
     public static let knownFrameworks: Set<String> = [
         foundation, nio, awsLambdaEvents, logging, osLog, metrics, fluent,
         hummingbird, composableArchitecture, awsLambdaRuntime, httpPipeline,
-        vapor
+        vapor, swiftConcurrency
+    ]
+
+    // MARK: - Always-active (stdlib / built-in) frameworks
+
+    /// Frameworks whose "import presence" gate is always satisfied
+    /// because their types are part of Swift's stdlib or a built-in
+    /// runtime and no `import` declaration is typically required.
+    ///
+    /// The `swiftConcurrency` framework name (slot 22) is the
+    /// motivating case: `Task`, `async`, `await`, `AsyncStream`,
+    /// `Actor`, etc. are in stdlib; adopter code never writes `import
+    /// SwiftConcurrency` because there's no such module. The
+    /// `FrameworkContext.isFrameworkActive` gate short-circuits to
+    /// `true` for these names (modulo the config opt-out), so entries
+    /// for `(Task, sleep)` etc. in `idempotentReceiverMethodsByFramework`
+    /// still go through the standard lookup path rather than needing
+    /// a parallel stdlib-specific table.
+    ///
+    /// The config opt-out still applies — a project can set
+    /// `enabled_framework_whitelists: [...]` excluding `SwiftConcurrency`
+    /// to restore pre-slot-22 behaviour.
+    public static let alwaysActiveFrameworks: Set<String> = [
+        swiftConcurrency,
     ]
 
     // MARK: - Import aliases (re-export / meta-package handling)
@@ -308,6 +332,25 @@ public enum FrameworkWhitelist {
     /// `WellKnownController`, `AuthorizeController`, `TokenController`,
     /// `RevokeController`), `kphrx/plc-handle-tracker` (2 sites —
     /// `DidController`, `HandleController`).
+    ///
+    /// Swift Concurrency `Task.sleep` (slot 22) — stdlib
+    /// `Task.sleep(nanoseconds:)` / `Task.sleep(for:)` primitive used
+    /// in retry-backoff loops, rate-limit pacing, scheduler delays,
+    /// and test harnesses. Idempotent by construction — a replay
+    /// incurs additional wall-clock latency but no state mutation.
+    /// The receiver `Task` is a stdlib type, not a framework module,
+    /// so the import gate is satisfied via `alwaysActiveFrameworks`
+    /// rather than a literal `import SwiftConcurrency`. Both modern
+    /// `Task.sleep(for: .seconds(N))` and legacy
+    /// `Task.sleep(nanoseconds: N)` spellings resolve here because the
+    /// `(receiver, method)` lookup is name-based, not signature-based.
+    /// 4-adopter evidence: `hummingbird-examples/open-telemetry`
+    /// (prior 1-adopter), `uitsmijter/Uitsmijter` (5 sites across
+    /// Logger, JWT KeyStorage, JavaScriptProvider, EntityCRDLoader),
+    /// `JulianKahnert/HomeAutomation` (5 sites across CustomActorSystem,
+    /// Timer, WindowOpen), `VernissageApp/VernissageServer` (5+ sites
+    /// across ClearAttachmentsService + PurgeStatusesService backoff
+    /// loops).
     private static let idempotentReceiverMethodsByFramework: [String: [String: String]] = [
         "decode": ["request": hummingbird],
         "require": ["parameters": hummingbird],
@@ -325,6 +368,7 @@ public enum FrameworkWhitelist {
         "patch": ["router": hummingbird, "app": vapor],
         "delete": ["router": hummingbird, "app": vapor],
         "register": ["app": vapor],
+        "sleep": ["Task": swiftConcurrency],
     ]
 
     /// Returns the framework that owns a given idempotent
@@ -446,9 +490,16 @@ public struct FrameworkContext: Sendable {
     }
 
     public func isFrameworkActive(_ framework: String) -> Bool {
+        let enabledOK = enabled?.contains(framework) ?? true
+        // Stdlib / built-in frameworks (slot 22: SwiftConcurrency) bypass
+        // the import gate — adopter code doesn't typically write
+        // `import SwiftConcurrency` because there's no such module.
+        // Config opt-out still applies.
+        if FrameworkWhitelist.alwaysActiveFrameworks.contains(framework) {
+            return enabledOK
+        }
         let aliases = FrameworkWhitelist.importAliases(forFramework: framework)
         let importOK = imports.contains(framework) || !aliases.isDisjoint(with: imports)
-        let enabledOK = enabled?.contains(framework) ?? true
         return importOK && enabledOK
     }
 }

--- a/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
+++ b/Tests/CoreTests/Idempotency/FrameworkWhitelistGatingTests.swift
@@ -1034,6 +1034,109 @@ struct FrameworkWhitelistGatingTests {
         ) == .nonIdempotent)
     }
 
+    // MARK: - Swift Concurrency Task.sleep whitelist (slot 22)
+
+    @Test
+    func stdlib_taskSleep_firesWithoutExplicitImport() throws {
+        // `Task.sleep(nanoseconds:)` — Swift Concurrency stdlib primitive.
+        // Unlike the Vapor / Hummingbird whitelists, SwiftConcurrency is
+        // a stdlib framework (listed in `alwaysActiveFrameworks`) so the
+        // import gate is satisfied by an empty `imports` set — adopter
+        // code never writes `import SwiftConcurrency` because there's
+        // no such module. 4-adopter evidence: hummingbird-examples +
+        // Uitsmijter + HomeAutomation + Vernissage.
+        let call = try firstCall(in: "func f() async throws { try await Task.sleep(nanoseconds: 500_000_000) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: [], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func stdlib_taskSleep_modernForSpelling_firesAlso() throws {
+        // `Task.sleep(for: .seconds(N))` — modern stdlib spelling.
+        // The whitelist lookup is name-based, not signature-based, so
+        // both `sleep(nanoseconds:)` and `sleep(for:)` resolve to the
+        // same `(Task, sleep)` pair.
+        let call = try firstCall(in: "func f() async throws { try await Task.sleep(for: .seconds(2)) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: [], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func stdlib_taskSleep_triedOptional_firesAlso() throws {
+        // `try? await Task.sleep(...)` — the exception-swallow spelling
+        // used for "best-effort delay" calls. The whitelist classification
+        // is on the call site, not the surrounding error handling.
+        let call = try firstCall(in: "func f() async { try? await Task.sleep(for: .seconds(60)) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: [], enabledFrameworks: nil
+        ) == .idempotent)
+    }
+
+    @Test
+    func taskSleep_wrongReceiver_doesNotSilenceBareName() throws {
+        // `.sleep()` on a receiver other than `Task`: the slot-22 pair
+        // must not fire. The bare name `sleep` is not on any existing
+        // idempotent / non-idempotent lexicon, so without the pair the
+        // classification falls through to `nil` (unclassified, which
+        // is the correct behaviour for an unknown method name).
+        let call = try firstCall(in: "func f() async { thread.sleep(forTimeInterval: 1.0) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: [], enabledFrameworks: nil
+        ) == nil)
+    }
+
+    @Test
+    func configGated_swiftConcurrencyDisabled_taskSleepFallsThrough() throws {
+        // Adopter opts out of the `SwiftConcurrency` whitelist via
+        // `enabled_framework_whitelists: [...]`. The always-active gate
+        // still respects the config opt-out — `isFrameworkActive`
+        // short-circuits `importOK` to `true` but returns
+        // `enabledOK && importOK` = `false` because enabled excludes
+        // SwiftConcurrency. With the slot-22 pair off, `sleep` isn't
+        // on any other lexicon, so classification falls through to nil.
+        let call = try firstCall(in: "func f() async throws { try await Task.sleep(for: .seconds(1)) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: call, imports: [], enabledFrameworks: ["Foundation"]
+        ) == nil)
+    }
+
+    @Test
+    func swiftConcurrency_taskSleep_inferenceReason() throws {
+        let call = try firstCall(in: "func f() async throws { try await Task.sleep(for: .seconds(1)) }")
+        let reason = HeuristicEffectInferrer.inferenceReason(
+            for: call, imports: [], enabledFrameworks: nil
+        )
+        #expect(reason == "from the SwiftConcurrency primitive `Task.sleep`")
+    }
+
+    @Test
+    func swiftConcurrency_taskSleep_coexistsWithServerFrameworks() throws {
+        // A real adopter file imports Vapor + FluentKit + uses
+        // Task.sleep. All three whitelists must coexist without
+        // interfering. Also confirms no stdlib-framework false
+        // shadowing — a `Task.sleep` call stays idempotent, a
+        // `model.save(on:)` stays non-idempotent (Fluent ORM verb).
+        let sleepCall = try firstCall(in: "func f() async throws { try await Task.sleep(for: .seconds(1)) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: sleepCall, imports: ["Vapor", "FluentKit"], enabledFrameworks: nil
+        ) == .idempotent)
+
+        let saveCall = try firstCall(in: "func f() async throws { try await model.save(on: db) }")
+        #expect(HeuristicEffectInferrer.infer(
+            call: saveCall, imports: ["Vapor", "FluentKit"], enabledFrameworks: nil
+        ) == .nonIdempotent)
+    }
+
+    @Test
+    func alwaysActiveFrameworks_containsSwiftConcurrency() throws {
+        // Structural assertion — the always-active set is the data
+        // structure that decouples slot 22 from the import gate.
+        // Future stdlib additions go here.
+        #expect(FrameworkWhitelist.alwaysActiveFrameworks.contains(FrameworkWhitelist.swiftConcurrency))
+    }
+
     // MARK: - AWSLambdaRuntime response-writer primitives (framework-gated)
 
     @Test


### PR DESCRIPTION
## Summary
Adds `(Task, sleep) → SwiftConcurrency` to `idempotentReceiverMethodsByFramework`, plus the supporting infrastructure (`alwaysActiveFrameworks` set + `FrameworkContext.isFrameworkActive` short-circuit) for stdlib-gated whitelists. `Task.sleep` is idempotent by construction — replay adds wall-clock latency but no state mutation. Used pervasively in retry-backoff loops, rate-limit pacing, scheduler delays.

## Evidence
4-adopter evidence from the 2026-04-24 trial-adopter lint sweep (see `swiftIdempotency/docs/trial-adopter-lint-sweep-2026-04-24.md`):

- **`hummingbird-examples/open-telemetry`** (prior 1-adopter)
- **`uitsmijter/Uitsmijter`** — 5 sites: `Logger/LogWriter.swift:428`, `JWT/KeyStorage+RedisImpl.swift:321`, `ScriptingProvider/JavaScriptProvider.swift:228`, `Entities/ResourceLoader/EntityCRDLoader.swift:162,267`
- **`JulianKahnert/HomeAutomation`** — 5 sites: `SharedDistributedCluster/CustomActorSystem.swift:133,219`, `Server/entrypoint.swift:44`, `Shared/Timer.swift:23`, `HAImplementations/Automations/WindowOpen.swift:57`
- **`VernissageApp/VernissageServer`** — 5+ sites: `Services/ClearAttachmentsService.swift:129,147,251,269`, `Services/PurgeStatusesService.swift:85` (adaptive-delay backoff loops)

Both `Task.sleep(nanoseconds:)` and modern `Task.sleep(for: .seconds(N))` spellings resolve to the same pair because lookup is name-based.

## Design
`SwiftConcurrency` is a pseudo-framework — adopters never write `import SwiftConcurrency` because `Task` is stdlib. The new `alwaysActiveFrameworks` set decouples stdlib entries from the import gate while preserving the config opt-out (`enabled_framework_whitelists: [...]`). Future stdlib additions (`AsyncStream`, `Actor`, `TaskGroup`) drop into the same table + set — no parallel data structure.

## Test plan
- [x] `swift test --filter FrameworkWhitelistGatingTests` — 127/127 green (+8 new slot-22 tests: stdlib-no-import-fire, modern for:.seconds(N) spelling, try?-await spelling, wrong-receiver fallthrough, config-opt-out, inference-reason, multi-framework coexistence, data-structure presence)
- [x] `swift test` — full suite 2375 green (+8 from 2367)
- [ ] Post-merge: re-run adopter road-tests on Uitsmijter / HomeAutomation / Vernissage annotated branches to confirm `Task.sleep` silence under replayable + strict_replayable

🤖 Generated with [Claude Code](https://claude.com/claude-code)