### PR TITLE
Closure-binding cross-reference — typeless-binding lookup + upward inference

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/EffectSymbolTable.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/EffectSymbolTable.swift
@@ -99,9 +99,21 @@ public struct EffectSymbolTable: Sendable {
         // callable `search(query:)`; the linter can consume user
         // annotations on these via the same signature-keyed table
         // without having to run the macro.
+        //
+        // Closure-literal bindings without a type annotation
+        // (`let sender = { (msg: String) in ... }`) are also registered
+        // when `FunctionSignature.from(declaration:)` can derive an
+        // arity from the closure literal's explicit parameter clause —
+        // see its fallback path.
+        //
+        // Function-local bindings (anything under a `func`, `init`,
+        // `deinit`, or accessor body) are skipped: they can't be called
+        // by name from outside their enclosing scope, so registering
+        // them risks cross-scope aliasing on common identifiers.
         let propCollector = ClosurePropertyDeclCollector()
         propCollector.walk(source)
         for varDecl in propCollector.properties {
+            guard !isFunctionLocal(varDecl) else { continue }
             guard let signature = FunctionSignature.from(declaration: varDecl) else {
                 continue
             }
@@ -430,6 +442,27 @@ public struct OnceReachInference: Sendable, Equatable {
     public init(depth: Int) {
         self.depth = depth
     }
+}
+
+/// `true` when `decl` appears inside a function-like body (`func`, `init`,
+/// `deinit`, `get`/`set`/`willSet`/`didSet` accessor) somewhere up its
+/// ancestor chain. Such bindings are not externally callable by name —
+/// registering them as symbol-table entries would let same-named identifiers
+/// elsewhere in the project silently bind to a scope-local closure.
+/// Top-level decls, type-member stored properties, and bindings inside
+/// top-level closure captures all return `false`.
+public func isFunctionLocal(_ decl: VariableDeclSyntax) -> Bool {
+    var current = Syntax(decl).parent
+    while let node = current {
+        if node.is(FunctionDeclSyntax.self)
+            || node.is(InitializerDeclSyntax.self)
+            || node.is(DeinitializerDeclSyntax.self)
+            || node.is(AccessorDeclSyntax.self) {
+            return true
+        }
+        current = node.parent
+    }
+    return false
 }
 
 /// Collects every `FunctionDeclSyntax` in a source file that does NOT

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FunctionSignature.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FunctionSignature.swift
@@ -87,29 +87,60 @@ public extension FunctionSignature {
     static func from(declaration: VariableDeclSyntax) -> FunctionSignature? {
         guard let binding = declaration.bindings.first,
               declaration.bindings.count == 1,
-              let pattern = binding.pattern.as(IdentifierPatternSyntax.self),
-              let typeAnnotation = binding.typeAnnotation else {
+              let pattern = binding.pattern.as(IdentifierPatternSyntax.self) else {
             return nil
         }
-        guard let fnType = unwrapFunctionType(typeAnnotation.type) else {
+        let name = pattern.identifier.text
+
+        // Primary path: explicit function-typed annotation. Preserves Path A
+        // re-labelling for the macro-friendly `@DependencyClient`-style shape.
+        if let typeAnnotation = binding.typeAnnotation,
+           let fnType = unwrapFunctionType(typeAnnotation.type) {
+            let labels = fnType.parameters.map { element -> String in
+                let first = element.firstName?.text ?? ""
+                let second = element.secondName?.text ?? ""
+                // Path A: `_ internalName:` → re-expose the internal name.
+                if first == "_" && !second.isEmpty {
+                    return second
+                }
+                if first.isEmpty || first == "_" {
+                    return "_"
+                }
+                return first
+            }
+            return FunctionSignature(name: name, argumentLabels: labels)
+        }
+
+        // Fallback: typeless binding with a closure-literal initialiser.
+        // Arity comes from the closure signature's parameter clause; labels
+        // are always `_` (Swift closures are positional at the call site).
+        // Requires an explicit parameter list — anonymous-arg closures
+        // (`{ $0 + $1 }`) can't be signed without scanning the body, so
+        // they stay unregistered.
+        if let closure = binding.initializer?.value.as(ClosureExprSyntax.self) {
+            guard let arity = closureParameterArity(closure) else { return nil }
+            return FunctionSignature(
+                name: name,
+                argumentLabels: Array(repeating: "_", count: arity)
+            )
+        }
+
+        return nil
+    }
+
+    /// Arity of a closure literal's explicit parameter list, or `nil` when
+    /// the closure has no `in`-delimited signature (anonymous-arg closures
+    /// like `{ $0 + $1 }` can't be signed without body analysis).
+    private static func closureParameterArity(_ closure: ClosureExprSyntax) -> Int? {
+        guard let parameterClause = closure.signature?.parameterClause else {
             return nil
         }
-        let labels = fnType.parameters.map { element -> String in
-            let first = element.firstName?.text ?? ""
-            let second = element.secondName?.text ?? ""
-            // Path A: `_ internalName:` → re-expose the internal name.
-            if first == "_" && !second.isEmpty {
-                return second
-            }
-            if first.isEmpty || first == "_" {
-                return "_"
-            }
-            return first
+        switch parameterClause {
+        case .simpleInput(let list):
+            return list.count
+        case .parameterClause(let clause):
+            return clause.parameters.count
         }
-        return FunctionSignature(
-            name: pattern.identifier.text,
-            argumentLabels: labels
-        )
     }
 
     /// Peels `AttributedTypeSyntax` wrappers (`@Sendable`, `@MainActor`,

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/UpwardEffectInferrer.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/UpwardEffectInferrer.swift
@@ -76,16 +76,45 @@ public enum UpwardEffectInferrer {
         for decl in collector.functions {
             guard let body = decl.body else { continue }
             let calleeResults = collectResults(in: Syntax(body), resolve: resolveCalleeEffect)
-            guard let lub = leastUpperBound(of: calleeResults.map { $0.effect }) else { continue }
-            let lubRank = rank(of: lub)
-            let contributingDepths = calleeResults
-                .filter { rank(of: $0.effect) == lubRank }
-                .map { $0.depth }
-            let depth = 1 + (contributingDepths.max() ?? 0)
+            guard let inference = combine(calleeResults: calleeResults) else { continue }
             let signature = FunctionSignature.from(declaration: decl)
-            results[signature] = UpwardInference(effect: lub, depth: depth)
+            results[signature] = inference
         }
+
+        // Closure-literal bindings (`let handler = { ... }`) participate
+        // in upward inference on the same terms as `func` declarations.
+        // Only unannotated, not-function-local bindings with a derivable
+        // signature are inferred; all three filters mirror the declared-
+        // effect registration path in `EffectSymbolTable.merge`.
+        let bindingCollector = UnannotatedClosureBindingCollector()
+        bindingCollector.walk(source)
+        for varDecl in bindingCollector.bindings {
+            guard !isFunctionLocal(varDecl),
+                  let closure = varDecl.closureInitializer,
+                  let signature = FunctionSignature.from(declaration: varDecl) else {
+                continue
+            }
+            let calleeResults = collectResults(
+                in: Syntax(closure.statements),
+                resolve: resolveCalleeEffect
+            )
+            guard let inference = combine(calleeResults: calleeResults) else { continue }
+            results[signature] = inference
+        }
+
         return results
+    }
+
+    private static func combine(calleeResults: [UpwardInference]) -> UpwardInference? {
+        guard let lub = leastUpperBound(of: calleeResults.map { $0.effect }) else {
+            return nil
+        }
+        let lubRank = rank(of: lub)
+        let contributingDepths = calleeResults
+            .filter { rank(of: $0.effect) == lubRank }
+            .map { $0.depth }
+        let depth = 1 + (contributingDepths.max() ?? 0)
+        return UpwardInference(effect: lub, depth: depth)
     }
 
     /// Returns the single effect corresponding to the most permissive
@@ -177,6 +206,39 @@ public enum UpwardEffectInferrer {
         "withThrowingDiscardingTaskGroup",
         "task"
     ]
+}
+
+/// Collects every `VariableDeclSyntax` with a closure-literal initialiser
+/// that has no `@lint.effect` annotation. Paired with
+/// `UnannotatedFunctionCollector` for upward inference: a closure binding
+/// whose body calls non-idempotent work becomes itself inferred
+/// non-idempotent, surfacing cross-reference violations that would
+/// otherwise stay silent.
+///
+/// The collector skips descent into closure expressions — the body walk
+/// for the lub calculation happens separately via `collectResults`, which
+/// enforces the escape-closure policy at the right granularity.
+/// `@lint.context`-only bindings are still collected (context-only decls
+/// can have their body's effect inferred); the check is specifically on
+/// the presence of a declared *effect* annotation.
+final class UnannotatedClosureBindingCollector: SyntaxVisitor {
+    var bindings: [VariableDeclSyntax] = []
+
+    init() {
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+        if node.closureInitializer != nil,
+           EffectAnnotationParser.parseEffect(declaration: node) == nil {
+            bindings.append(node)
+        }
+        return .visitChildren
+    }
+
+    override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
+        .skipChildren
+    }
 }
 
 /// Collects every un-annotated `FunctionDeclSyntax` in a source file.

--- a/Tests/CoreTests/Idempotency/ClosureBindingCrossReferenceTests.swift
+++ b/Tests/CoreTests/Idempotency/ClosureBindingCrossReferenceTests.swift
@@ -1,0 +1,335 @@
+import Testing
+@testable import Core
+@testable import SwiftProjectLintRules
+@testable import SwiftProjectLintVisitors
+import SwiftSyntax
+import SwiftParser
+
+/// Cross-reference lookup for closure-bound bindings called by name from
+/// elsewhere in the project. The original closure-handler annotation slice
+/// (PR #19, commit `0be2d36`) made the body of `let handler: Type = { ... }`
+/// walkable under its own annotation. This suite covers the two follow-on
+/// gaps captured in `docs/ideas/closure-binding-cross-reference.md`:
+///
+/// 1. **External-caller lookup.** A `let sender = { (msg: String) in ... }`
+///    declared `@lint.effect non_idempotent` should flag `sender(msg)` calls
+///    from an `@lint.effect idempotent` function — same as if `sender` were
+///    a `func`.
+/// 2. **Upward inference through unannotated closure bindings.** A `let
+///    helper = { try await db.insert(x) }` with no annotation should have
+///    its body inferred `non_idempotent`, so callers in `@lint.context
+///    replayable` functions fire `nonIdempotentInRetryContext`.
+///
+/// Both pieces route through `FunctionSignature.from(declaration:
+/// VariableDeclSyntax)`, which now derives arity from the closure literal's
+/// explicit parameter clause when a type annotation is absent. Function-
+/// local bindings are filtered at registration time — they aren't externally
+/// callable by name, so registering them would alias unrelated identifiers.
+@Suite
+struct ClosureBindingCrossReferenceTests {
+
+    /// Uses the `fileCache:` constructor so `applyUpwardInferenceImportAware`
+    /// receives a non-empty source list. Upward-inference-dependent tests
+    /// require this path; the simpler `pattern:`-only harness leaves
+    /// `allSources` empty and silently skips inference.
+    private func runEffect(_ source: String) -> IdempotencyViolationVisitor {
+        let path = "Test.swift"
+        let cache: [String: SourceFileSyntax] = [path: Parser.parse(source: source)]
+        let visitor = IdempotencyViolationVisitor(fileCache: cache)
+        visitor.setFilePath(path)
+        visitor.setSourceLocationConverter(
+            SourceLocationConverter(fileName: path, tree: cache[path]!)
+        )
+        visitor.walk(cache[path]!)
+        visitor.finalizeAnalysis()
+        return visitor
+    }
+
+    private func runContext(_ source: String) -> NonIdempotentInRetryContextVisitor {
+        let path = "Test.swift"
+        let cache: [String: SourceFileSyntax] = [path: Parser.parse(source: source)]
+        let visitor = NonIdempotentInRetryContextVisitor(fileCache: cache)
+        visitor.setFilePath(path)
+        visitor.setSourceLocationConverter(
+            SourceLocationConverter(fileName: path, tree: cache[path]!)
+        )
+        visitor.walk(cache[path]!)
+        visitor.finalizeAnalysis()
+        return visitor
+    }
+
+    // MARK: - External-caller lookup (missing piece 1)
+
+    @Test
+    func idempotentFunction_callsNonIdempotentTypedBinding_flags() throws {
+        // Baseline: typed binding path — already handled by the existing
+        // `FunctionSignature.from(VariableDeclSyntax)`. Asserted here to
+        // document that the follow-on work preserves it.
+        let source = """
+        func rawSMTPSend(_ msg: String) {}
+
+        /// @lint.effect non_idempotent
+        let sender: (String) -> Void = { msg in
+            rawSMTPSend(msg)
+        }
+
+        /// @lint.effect idempotent
+        func process(_ msg: String) {
+            sender(msg)
+        }
+        """
+        let issues = runEffect(source).detectedIssues
+        #expect(issues.count == 1)
+        let issue = try #require(issues.first)
+        #expect(issue.message.contains("process"))
+        #expect(issue.message.contains("sender"))
+    }
+
+    @Test
+    func idempotentFunction_callsNonIdempotentTypelessBinding_flags() throws {
+        // Missing-piece-1 exemplar: no type annotation on the binding.
+        // Arity comes from the closure literal's `(msg: String)` clause.
+        let source = """
+        func rawSMTPSend(_ msg: String) {}
+
+        /// @lint.effect non_idempotent
+        let sender = { (msg: String) in
+            rawSMTPSend(msg)
+        }
+
+        /// @lint.effect idempotent
+        func process(_ msg: String) {
+            sender(msg)
+        }
+        """
+        let issues = runEffect(source).detectedIssues
+        #expect(issues.count == 1)
+        let issue = try #require(issues.first)
+        #expect(issue.message.contains("process"))
+        #expect(issue.message.contains("sender"))
+    }
+
+    @Test
+    func idempotentFunction_callsNonIdempotentShorthandBinding_flags() throws {
+        // Same as above, but with `{ msg in ... }` shorthand form.
+        let source = """
+        func rawSMTPSend(_ msg: String) {}
+
+        /// @lint.effect non_idempotent
+        let sender = { msg in
+            rawSMTPSend(msg)
+        }
+
+        /// @lint.effect idempotent
+        func process(_ msg: String) {
+            sender(msg)
+        }
+        """
+        #expect(runEffect(source).detectedIssues.count == 1)
+    }
+
+    @Test
+    func replayableFunction_callsRetrySafeTypelessBinding_noFire() {
+        // Tier-permitting path: `@lint.effect idempotent` callee on a
+        // `@lint.context replayable` caller is benign. Also confirms the
+        // registered closure-binding entry is consulted in the context-
+        // rule pathway, not just the effect rule.
+        let source = """
+        func readRow(_ id: Int) -> Int { 0 }
+
+        /// @lint.effect idempotent
+        let fetcher = { (id: Int) in
+            _ = readRow(id)
+        }
+
+        /// @lint.context replayable
+        func handle(_ id: Int) {
+            fetcher(id)
+        }
+        """
+        #expect(runContext(source).detectedIssues.isEmpty)
+    }
+
+    // MARK: - Upward inference through unannotated closure bindings (missing piece 2)
+
+    @Test
+    func replayableCaller_callsUnannotatedClosureWithNonIdempotentBody_fires() throws {
+        // Missing-piece-2 exemplar. `helper` has no annotation but its
+        // body reaches a non-idempotent call via the `insert` prefix
+        // heuristic. Upward inference should credit `helper` as
+        // non-idempotent and flag the replayable caller.
+        let source = """
+        struct DB { func insert(_ id: Int) {} }
+        let db = DB()
+
+        let helper = { (id: Int) in
+            db.insert(id)
+        }
+
+        /// @lint.context replayable
+        func handle(_ id: Int) {
+            helper(id)
+        }
+        """
+        let issues = runContext(source).detectedIssues
+        #expect(issues.count == 1)
+        let issue = try #require(issues.first)
+        #expect(issue.message.contains("helper"))
+    }
+
+    @Test
+    func idempotentCaller_callsUnannotatedClosureWithNonIdempotentBody_fires() throws {
+        // Effect-rule sibling of the above. `logger` has no annotation;
+        // its body calls `createRow`, heuristically non-idempotent by
+        // prefix.
+        let source = """
+        func createRow(_ id: Int) {}
+
+        let writer = { (id: Int) in
+            createRow(id)
+        }
+
+        /// @lint.effect idempotent
+        func process(_ id: Int) {
+            writer(id)
+        }
+        """
+        let issues = runEffect(source).detectedIssues
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("writer") == true)
+    }
+
+    @Test
+    func replayableCaller_callsUnannotatedClosureWithBenignBody_noFire() {
+        // Negative: closure body contains only benign calls. Upward
+        // inference produces no non-idempotent propagation.
+        let source = """
+        func readRow(_ id: Int) -> Int { 0 }
+
+        let inspector = { (id: Int) in
+            _ = readRow(id)
+        }
+
+        /// @lint.context replayable
+        func handle(_ id: Int) {
+            inspector(id)
+        }
+        """
+        #expect(runContext(source).detectedIssues.isEmpty)
+    }
+
+    // MARK: - Scope discipline
+
+    @Test
+    func functionLocalClosureBinding_notRegistered_externalCallerSilent() {
+        // A closure bound inside `outer()` isn't externally callable by
+        // name. Even though `process` references the same identifier,
+        // it shouldn't pick up the annotation — the symbol-table entry
+        // is withheld.
+        let source = """
+        func rawSMTPSend(_ msg: String) {}
+
+        func outer() {
+            /// @lint.effect non_idempotent
+            let sender = { (msg: String) in
+                rawSMTPSend(msg)
+            }
+            _ = sender
+        }
+
+        /// @lint.effect idempotent
+        func process(_ msg: String) {
+            sender(msg)
+        }
+        """
+        // The call `sender(msg)` in `process`'s body has no matching
+        // declaration (function-local bindings aren't registered) and
+        // `sender` doesn't match any heuristic. Silent.
+        #expect(runEffect(source).detectedIssues.isEmpty)
+    }
+
+    @Test
+    func typeMemberClosureProperty_registered_externalCallerFlags() throws {
+        // Counterpoint: a stored property on a type IS externally
+        // callable via an instance; it stays registered.
+        let source = """
+        func rawSMTPSend(_ msg: String) {}
+
+        struct Mailer {
+            /// @lint.effect non_idempotent
+            let sender = { (msg: String) in
+                rawSMTPSend(msg)
+            }
+        }
+
+        /// @lint.effect idempotent
+        func process(_ msg: String) {
+            let mailer = Mailer()
+            mailer.sender(msg)
+        }
+        """
+        let issues = runEffect(source).detectedIssues
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("sender") == true)
+    }
+
+    // MARK: - Collision policy
+
+    @Test
+    func twoClosureBindings_sameSignature_conflictingEffects_withdraw() {
+        // Two annotated closure bindings share the signature `send(_:)`
+        // with conflicting effects. OI-4 collision policy applies
+        // uniformly — entry withdrawn, caller stays silent.
+        let source = """
+        func publish(_ msg: String) {}
+        func readBack(_ msg: String) -> String { msg }
+
+        struct A {
+            /// @lint.effect non_idempotent
+            let send = { (msg: String) in publish(msg) }
+        }
+        struct B {
+            /// @lint.effect idempotent
+            let send = { (msg: String) in _ = readBack(msg) }
+        }
+
+        /// @lint.effect idempotent
+        func process() {
+            let a = A()
+            a.send("hi")
+        }
+        """
+        #expect(runEffect(source).detectedIssues.isEmpty)
+    }
+
+    // MARK: - Typed + typeless parity
+
+    @Test
+    func typedAndTypelessBinding_sameSignature_produceSameDiagnostic() throws {
+        // Regression guard: the two forms produce identical signatures
+        // (`sender(_:)`), so their callers fire identically. If the
+        // typeless path ever drifts arity handling, this breaks.
+        let typedSource = """
+        func rawSMTPSend(_ msg: String) {}
+
+        /// @lint.effect non_idempotent
+        let sender: (String) -> Void = { msg in rawSMTPSend(msg) }
+
+        /// @lint.effect idempotent
+        func process(_ msg: String) { sender(msg) }
+        """
+        let typelessSource = """
+        func rawSMTPSend(_ msg: String) {}
+
+        /// @lint.effect non_idempotent
+        let sender = { (msg: String) in rawSMTPSend(msg) }
+
+        /// @lint.effect idempotent
+        func process(_ msg: String) { sender(msg) }
+        """
+        let typedIssues = runEffect(typedSource).detectedIssues
+        let typelessIssues = runEffect(typelessSource).detectedIssues
+        #expect(typedIssues.count == typelessIssues.count)
+        #expect(typedIssues.count == 1)
+    }
+}

--- a/Tests/CoreTests/Idempotency/SignatureAwareCollisionTests.swift
+++ b/Tests/CoreTests/Idempotency/SignatureAwareCollisionTests.swift
@@ -153,10 +153,44 @@ struct SignatureAwareCollisionTests {
     }
 
     @Test
-    func closureProperty_untypedBinding_returnsNil() throws {
-        // Inferred-type bindings don't declare the call-site shape — can't
-        // extract a signature without the type annotation.
+    func closureProperty_untypedBinding_typedClosureSignature_extractsFromArity() throws {
+        // Typeless binding with an explicit closure-literal parameter clause.
+        // Closures are positional at the call site, so all labels are `_`;
+        // only arity is derived.
         let decl = try varDecl("var f = { (x: Int) in print(x) }")
+        let signature = try #require(FunctionSignature.from(declaration: decl))
+        #expect(signature.description == "f(_:)")
+    }
+
+    @Test
+    func closureProperty_untypedBinding_shorthandClosureSignature_extractsFromArity() throws {
+        // Shorthand `a, b in` form. Arity still visible in the signature.
+        let decl = try varDecl("var f = { a, b in print(a, b) }")
+        let signature = try #require(FunctionSignature.from(declaration: decl))
+        #expect(signature.description == "f(_:_:)")
+    }
+
+    @Test
+    func closureProperty_untypedBinding_emptyParameterClause_returnsZeroArity() throws {
+        // `{ () in ... }` — explicit empty parameter clause, arity 0.
+        let decl = try varDecl("var f = { () in print(\"hi\") }")
+        let signature = try #require(FunctionSignature.from(declaration: decl))
+        #expect(signature.description == "f()")
+    }
+
+    @Test
+    func closureProperty_untypedBinding_anonymousArgs_returnsNil() throws {
+        // `{ $0 + $1 }` — no explicit parameter list, arity only visible
+        // via body analysis. Staying nil keeps the fallback conservative.
+        let decl = try varDecl("var f = { $0 + $1 }")
+        #expect(FunctionSignature.from(declaration: decl) == nil)
+    }
+
+    @Test
+    func closureProperty_untypedBinding_nonClosureInitializer_returnsNil() throws {
+        // Non-closure initializers stay nil — only closure literals are a
+        // callable pseudo-method.
+        let decl = try varDecl("var count = 42")
         #expect(FunctionSignature.from(declaration: decl) == nil)
     }
 


### PR DESCRIPTION
## Summary

Closes the two silent gaps from [`docs/ideas/closure-binding-cross-reference.md`](https://github.com/Joseph-Cursio/swiftIdempotency/blob/main/docs/ideas/closure-binding-cross-reference.md) in the SwiftIdempotency companion repo.

- **External-caller lookup (missing piece 1).** Typeless bindings now get registered in the symbol table. `let sender = { (msg: String) in ... }` annotated `@lint.effect non_idempotent` flags calls from `@lint.effect idempotent` functions identically to `func sender(_:)`. Signature derives from the closure literal's explicit parameter clause — labels are always `_` (Swift closures are positional at the call site), arity is `count`. Anonymous-arg closures (`{ $0 + $1 }`) stay unregistered, as the design sketch recommended.
- **Upward inference through unannotated closure bindings (missing piece 2).** `UpwardEffectInferrer.inferEffects` iterates `VariableDeclSyntax` nodes with closure initializers alongside `FunctionDeclSyntax`. Unannotated closure bindings whose body reaches a non-idempotent call now propagate upward through the fixed-point loop. New `UnannotatedClosureBindingCollector` mirrors `UnannotatedFunctionCollector`.

## Scope discipline

Function-local bindings aren't externally callable by name. Registering them would let same-named identifiers in unrelated scopes silently alias a scope-local closure. Both registration paths (`EffectSymbolTable.merge` and the new collector) skip bindings whose ancestor chain includes a `FunctionDeclSyntax`, `InitializerDeclSyntax`, `DeinitializerDeclSyntax`, or `AccessorDeclSyntax`. Shared `isFunctionLocal(_:)` helper.

This is the only behavioural change to the existing typed-binding path. `ClosureBindingRuleTests` (annotation-site body walks on function-local closures) continues to pass because the rule visitor adds analysis sites directly from the annotation — the symbol-table entry was only useful for external callers, and those don't exist for function-local bindings.

## Test plan

- [x] New suite `ClosureBindingCrossReferenceTests` (11 tests): typed + typeless + shorthand cross-reference fires, unannotated body upward-inference fires on `@lint.context replayable` and `@lint.effect idempotent` callers, benign body stays silent, function-local bindings stay silent from external callers, type-member stored properties still resolve, collision withdraws, typed/typeless parity regression guard.
- [x] `SignatureAwareCollisionTests` extended: typeless binding with typed closure sig, shorthand closure sig, explicit-empty `()` sig, anonymous-arg closure (returns nil), non-closure initializer (returns nil). Old `closureProperty_untypedBinding_returnsNil` updated to reflect the new behaviour.
- [x] Full suite: 2375 → **2390 green** (+15, 278 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)