### PR TITLE
Name SwiftIdempotency surface in non-idempotent suggestion

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/Visitors/NonIdempotentInRetryContextVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Idempotency/Visitors/NonIdempotentInRetryContextVisitor.swift
@@ -282,7 +282,8 @@ final class NonIdempotentInRetryContextVisitor: BasePatternVisitor, CrossFilePat
             filePath: site.filePath,
             lineNumber: line,
             suggestion: "Replace '\(calleeName)' with an idempotent alternative, or route the call "
-                + "through a deduplication guard or idempotency-key mechanism.",
+                + "through a deduplication guard such as `IdempotencyKey` or "
+                + "`@ExternallyIdempotent(by:)` from the `SwiftIdempotency` package.",
             ruleName: .nonIdempotentInRetryContext
         )
     }

--- a/Tests/CoreTests/Idempotency/NonIdempotentInRetryContextVisitorTests.swift
+++ b/Tests/CoreTests/Idempotency/NonIdempotentInRetryContextVisitorTests.swift
@@ -44,6 +44,34 @@ struct NonIdempotentInRetryContextVisitorTests {
     }
 
     @Test
+    func replayableCallsNonIdempotent_suggestionNamesSwiftIdempotency() throws {
+        // Cross-adopter evidence (matool Cognito + tinyfaces Brevo) showed
+        // adopters consistently hit the email-on-retry-without-idempotency-key
+        // shape and the existing generic "deduplication guard or
+        // idempotency-key mechanism" wording didn't point at a concrete fix.
+        // The suggestion now names the SwiftIdempotency package surface
+        // (IdempotencyKey + @ExternallyIdempotent(by:)) directly so adopters
+        // have a discoverable path from diagnostic to remediation.
+        let source = """
+        /// @lint.effect non_idempotent
+        func sendEmail(_ to: String) async throws {}
+
+        /// @lint.context replayable
+        func sendMagicEmail(_ to: String) async throws {
+            try await sendEmail(to)
+        }
+        """
+
+        let visitor = run(source: source)
+
+        let issue = try #require(visitor.detectedIssues.first)
+        let suggestion = try #require(issue.suggestion)
+        #expect(suggestion.contains("IdempotencyKey"))
+        #expect(suggestion.contains("@ExternallyIdempotent(by:)"))
+        #expect(suggestion.contains("SwiftIdempotency"))
+    }
+
+    @Test
     func retrySafeCallsNonIdempotent_flags() throws {
         let source = """
         /// @lint.effect non_idempotent


### PR DESCRIPTION
## Summary

Update the `nonIdempotentInRetryContext` suggestion text to name
`IdempotencyKey` and `@ExternallyIdempotent(by:)` from the
`SwiftIdempotency` package directly, replacing the generic
"deduplication guard or idempotency-key mechanism" phrasing.

## Why

Cross-adopter evidence from rounds 16 (matool — Cognito
`adminCreateUser` invitation emails) and 17 (tinyfaces — Brevo
`SendInBlue.sendEmail` magic-link emails) put the email-on-retry-
without-idempotency-key shape at 2-adopter slice volume. Both
rounds caught the bug correctly; both produced a suggestion that
named "idempotency-key mechanism" without naming any concrete
mechanism the adopter could go install. The new wording closes
the diagnostic-to-remediation gap.

The "deduplication guard" framing stays because not every adopter
wants to take a `SwiftIdempotency` dependency — but the named
surface (`IdempotencyKey` + `@ExternallyIdempotent(by:)`) is now
discoverable directly from the diagnostic.

## Diff scope

- One suggestion-text change in
  `NonIdempotentInRetryContextVisitor.swift`.
- One new test asserting the new substring
  (`replayableCallsNonIdempotent_suggestionNamesSwiftIdempotency`).

The `.externallyIdempotent` / `.idempotent` paths in
`IdempotencyViolationVisitor` use parallel-but-distinct phrasing —
those handle a different rule shape (a caller's declared effect
contract being violated, not a replayable handler hitting non-
idempotent surface) and stay as-is.

## Verification

- Full linter test suite on a clean `.build/`: **2398 / 294
  passing** (was 2397 / 294 on `main`; the +1 is this slice's
  new test).
- Re-ran linter against the tinyfaces fork
  (`Joseph-Cursio/TinyFaces-idempotency-trial @ trial-tinyfaces`):
  all 6 Run A `[Non-Idempotent In Retry Context]` fires now show
  the new wording, e.g.
  > suggestion: Replace 'sendEmail' with an idempotent alternative,
  > or route the call through a deduplication guard such as
  > \`IdempotencyKey\` or \`@ExternallyIdempotent(by:)\` from the
  > \`SwiftIdempotency\` package.

## Test plan

- [x] New test added: `replayableCallsNonIdempotent_suggestionNamesSwiftIdempotency`
- [x] Full linter suite green on a clean build
- [x] Diagnostic surface re-verified against tinyfaces road-test corpus

🤖 Generated with [Claude Code](https://claude.com/claude-code)