### PR TITLE
Naming: exempt test/fixture files from actor-naming rules

### DIFF
--- a/Docs/rules/actor-agent-name.md
+++ b/Docs/rules/actor-agent-name.md
@@ -18,6 +18,13 @@ Agent-noun suffixes (`-er`/`-or`) are the English grammatical marker for "the th
 
 This rule is the semantic floor. Its stricter sibling, **Actor Naming Suffix**, requires the explicit `Actor` suffix on *all* actors regardless of whether the name already conveys agency.
 
+**Test / fixture / example files are exempted** via the
+`BasePatternVisitor.isTestOrFixtureFile()` heuristic (paths under
+`Tests/`, `Examples/`, `Mocks/`, etc.). Test-scoped actors are
+typically 5-10-line fixtures where the verbose suffix doesn't pay
+off at the call site. The sibling **Actor Naming Suffix** rule
+applies the same exemption.
+
 ### Non-Violating Examples
 ```swift
 // Agent-noun name (-er suffix) — conveys agency

--- a/Docs/rules/actor-naming-suffix.md
+++ b/Docs/rules/actor-naming-suffix.md
@@ -12,6 +12,13 @@ Naming actors with an `Actor` suffix makes Swift's concurrency isolation semanti
 ### Discussion
 `NamingConventionVisitor` checks every `actor` declaration. If the name does not end with `Actor`, an issue is reported. Like the protocol naming rule, this is a project-specific convention that prioritizes clarity over brevity.
 
+**Test / fixture / example files are exempted** via the
+`BasePatternVisitor.isTestOrFixtureFile()` heuristic (paths under
+`Tests/`, `Examples/`, `Mocks/`, etc.). Test-scoped actors are
+typically 5-10-line fixtures (`Counter`, `Gate`, `Sequence`) where
+the verbose `Actor` suffix doesn't pay off at the call site. The
+sibling **Actor Agent Name** rule applies the same exemption.
+
 This rule is paired with **Actor Agent Name**, which fires on the narrower case of actor names that give *no* agency signal at all (e.g. `VectorStore`, `KnowledgeGraph`). An actor named `WorkspaceIndexer` satisfies Actor Agent Name (the `-er` suffix conveys agency) but still triggers this rule, since the explicit `Actor` suffix is needed to signal Swift concurrency isolation at call sites.
 
 ### Non-Violating Examples

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/NamingConventionVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/NamingConventionVisitor.swift
@@ -84,6 +84,15 @@ class NamingConventionVisitor: BasePatternVisitor {
     override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
         let actorName = node.name.text
 
+        // Skip test / fixture / example files. Test-scoped actors are
+        // typically short-lived 5-10 line fixtures (Counter, Gate,
+        // Sequence) where an `Actor` suffix is verbose without
+        // payoff at the call site. The same heuristic the protocol-
+        // naming rule uses; see `BasePatternVisitor.isTestOrFixtureFile`.
+        if isTestOrFixtureFile() {
+            return .visitChildren
+        }
+
         // Rule: actorNamingSuffix — explicit "Actor" suffix required
         if !actorName.hasSuffix("Actor") {
             addIssue(

--- a/Tests/CoreTests/CodeQuality/NamingConventionTests.swift
+++ b/Tests/CoreTests/CodeQuality/NamingConventionTests.swift
@@ -218,6 +218,72 @@ struct NamingConventionTests {
         #expect(agentNameIssues.allSatisfy { $0.message.contains("passive") })
     }
 
+    // MARK: - Test-File Exemption (slice B)
+
+    /// Helper: parse + walk source against a specific `filePath`, so the
+    /// `BasePatternVisitor.isTestOrFixtureFile()` heuristic can exercise
+    /// path-based exemptions. The base `detectIssues(in:)` helper sets
+    /// `"TestFile.swift"` (no `s`), which deliberately doesn't match the
+    /// `Tests` substring check — so these tests are isolated.
+    private func detectIssues(in sourceCode: String, filePath: String) -> [LintIssue] {
+        let pattern = SyntaxPattern(
+            name: .protocolNamingSuffix,
+            visitor: NamingConventionVisitor.self,
+            severity: .info,
+            category: .codeQuality,
+            messageTemplate: "",
+            suggestion: "",
+            description: ""
+        )
+        let visitor = NamingConventionVisitor(pattern: pattern)
+        visitor.setFilePath(filePath)
+        let sourceFile = Parser.parse(source: sourceCode)
+        visitor.walk(sourceFile)
+        return visitor.detectedIssues
+    }
+
+    @Test("actorNamingSuffix and actorAgentName silenced under Tests/ path")
+    func actorRulesSilencedInTestFile() {
+        // Both rules would normally fire on these names — passive Counter
+        // (no Actor suffix, no agent-noun suffix) trips both rules in
+        // production code. In a test file, fixture actors are scoped and
+        // verbose suffixes don't pay off. Cross-adopter evidence:
+        // SwiftIdempotency package scan (2026-04-26) showed 13 fires of
+        // these two rules across test fixtures alone.
+        let sourceCode = """
+        actor Counter { }
+        actor Gate { }
+        actor VectorStore { }
+        """
+        let issues = detectIssues(
+            in: sourceCode,
+            filePath: "/path/to/Tests/MyPackageTests/MyTests.swift"
+        )
+        let actorIssues = issues.filter {
+            $0.ruleName == .actorNamingSuffix || $0.ruleName == .actorAgentName
+        }
+        #expect(actorIssues.isEmpty)
+    }
+
+    @Test("actorNamingSuffix and actorAgentName still fire under Sources/ path")
+    func actorRulesFireInProductionFile() {
+        // Regression check — the test-file exemption must not leak into
+        // production paths. Same source as the test-file case above
+        // should still fire both rules.
+        let sourceCode = """
+        actor Counter { }
+        actor VectorStore { }
+        """
+        let issues = detectIssues(
+            in: sourceCode,
+            filePath: "/path/to/Sources/MyPackage/MyType.swift"
+        )
+        let suffixIssues = issues.filter { $0.ruleName == .actorNamingSuffix }
+        let agentIssues = issues.filter { $0.ruleName == .actorAgentName }
+        #expect(suffixIssues.count == 2)  // Both lack Actor suffix
+        #expect(agentIssues.count == 1)   // Counter has -er; only VectorStore is passive
+    }
+
     // MARK: - Non-Actor Agent Suffix Tests (Rule 3, opt-in)
 
     @Test("nonActorAgentSuffix fires for class/struct with agent-noun name")


### PR DESCRIPTION
## Summary

`actorNamingSuffix` and `actorAgentName` now consult the same
`BasePatternVisitor.isTestOrFixtureFile()` heuristic the protocol-
naming rule already uses. Test fixtures like `actor Counter { }`,
`actor Gate { }`, `actor Sequence { }` no longer trigger info-level
fires when declared in `Tests/`, `Examples/`, `Mocks/`, etc.

## Motivation

The existing protocol-naming rule already exempts test files in
the same visitor (`NamingConventionVisitor`). The actor rules were
inconsistent — they applied to test scope where 5-10-line scoped
fixture actors typically use short, situational names (`Counter`,
`Gate`, `Sequence`) without the `Actor` suffix. Verbose renaming
adds no payoff at a 3-line test call site.

Cross-adopter evidence: SwiftIdempotency package scan (2026-04-26)
showed **13 fires** of these two rules across test fixtures alone
— second-largest FP cluster after `Missing Documentation`. Every
fire was on a scoped test actor; zero were on production actors.

## Diff scope

- `NamingConventionVisitor.swift` — early-return on `isTestOrFixtureFile()`
  in the `ActorDeclSyntax` visit, mirroring the existing pattern
  in the protocol visit (line 56).
- `NamingConventionTests.swift` — 2 new tests:
  - `actorRulesSilencedInTestFile` — actors in `Tests/` produce zero
    actor-rule fires
  - `actorRulesFireInProductionFile` — same source in `Sources/`
    still produces 2 + 1 fires (regression check)
- `actor-naming-suffix.md` + `actor-agent-name.md` — Discussion
  section gains a "Test / fixture / example files are exempted" note.

## Verification

- 2 new tests pass; existing 11 naming tests stay green.
- Full linter suite: **2402 / 294 passing** (was 2400 + this slice's
  +2 tests).
- Re-ran linter against SwiftIdempotency:
  - Before: 8 `Actor Naming Suffix` + 5 `Actor Agent Name` = 13 fires
  - After: 0 + 0 = 0 fires
  - Net SwiftIdempotency total: 49 → 36 fires.

## Test plan

- [x] Tests/-pathed actor source produces zero actor-rule issues
- [x] Sources/-pathed regression: same actors still fire normally
- [x] Full linter suite green
- [x] SwiftIdempotency scan: -13 fires confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)