### PR TITLE
Documentation: exempt protocol-required stubs (expansion / encode(to:))

### DIFF
--- a/Docs/rules/missing-documentation.md
+++ b/Docs/rules/missing-documentation.md
@@ -12,6 +12,23 @@ Public APIs without documentation comments force callers to read the implementat
 ### Discussion
 `CodeQualityVisitor` checks for the presence of `///` doc-line-comment or `/** */` doc-block-comment trivia on the leading trivia of `public` struct, class, and function declarations. In the default configuration only `public` symbols are checked. In strict mode (`checkPublicAPIsOnly: false`) all functions are checked regardless of access level. The info severity reflects that internal documentation is valuable but not urgent.
 
+**Protocol-required stubs are exempted.** Documentation for these
+methods belongs at the protocol declaration site (Apple's stdlib
+or SwiftSyntax), not at every conforming type — adopters writing a
+boilerplate stub shouldn't have to copy the protocol's documentation
+into their conformance. Currently exempted:
+
+| Shape | Source protocol |
+|-------|-----------------|
+| `static func expansion(...)` | `Macro` / `PeerMacro` / `MemberMacro` / `ExtensionMacro` / `FreestandingMacro` (SwiftSyntax) |
+| `func encode(to:)` | `Encodable` (Foundation) — single parameter with external label `to` |
+
+Both shapes are receiver-gated to avoid silencing adopter methods
+that coincidentally share a name. `static func expansion(...)` requires
+the `static` modifier (matches the macro protocol family); a non-static
+`expansion()` method still fires. `encode(to:)` requires the `to`
+external parameter label; `encode(_:)` and other shapes still fire.
+
 ### Non-Violating Examples
 ```swift
 /// Fetches the user profile for the given identifier.

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/DocumentationVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/DocumentationVisitor.swift
@@ -57,6 +57,15 @@ class DocumentationVisitor: BasePatternVisitor {
 
     override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
         currentFunctionName = node.name.text
+
+        // Skip protocol-conformance-required methods whose documentation
+        // belongs to the protocol declaration, not the conforming type.
+        // Asking adopters to document boilerplate stubs like
+        // `static func expansion(...)` or `func encode(to:)` is noise.
+        if Self.isProtocolRequiredStub(node) {
+            return .visitChildren
+        }
+
         if configuration.checkPublicAPIsOnly {
             let isPublic = node.modifiers.contains { $0.name.text == "public" }
             if isPublic {
@@ -66,6 +75,42 @@ class DocumentationVisitor: BasePatternVisitor {
             checkMissingDocumentation(for: Syntax(node), name: currentFunctionName)
         }
         return .visitChildren
+    }
+
+    /// Recognises function shapes that are required by widely-used Apple /
+    /// Swift-syntax protocols. Documentation for these belongs at the
+    /// protocol declaration site (Apple's stdlib / SwiftSyntax), not at
+    /// every conforming type.
+    ///
+    /// Currently recognises:
+    /// - `static func expansion(...)` — Macro / PeerMacro / MemberMacro /
+    ///   ExtensionMacro / FreestandingMacro family. All require a static
+    ///   `expansion(...)` method; the body is typically a thin shim.
+    /// - `func encode(to:)` — `Encodable` protocol method. Required signature.
+    private static func isProtocolRequiredStub(_ node: FunctionDeclSyntax) -> Bool {
+        let name = node.name.text
+        let isStatic = node.modifiers.contains { $0.name.text == "static" }
+
+        // Macro protocol family: `static func expansion(...)`. Any of the
+        // `Macro` sub-protocols requires this — receiver-of-name match plus
+        // `static` is specific enough to avoid colliding with adopter
+        // methods coincidentally named `expansion`.
+        if name == "expansion" && isStatic {
+            return true
+        }
+
+        // Encodable: `func encode(to encoder: Encoder)` — single parameter
+        // with external label `to`.
+        if name == "encode" {
+            let parameters = node.signature.parameterClause.parameters
+            if parameters.count == 1,
+               let firstLabel = parameters.first?.firstName.text,
+               firstLabel == "to" {
+                return true
+            }
+        }
+
+        return false
     }
 
     // MARK: - Private helpers

--- a/Tests/CoreTests/CodeQuality/CodeQualityDocumentationTests.swift
+++ b/Tests/CoreTests/CodeQuality/CodeQualityDocumentationTests.swift
@@ -149,4 +149,91 @@ struct CodeQualityDocumentationTests {
         // Then - strict mode on public struct without doc comment should produce an issue
         #expect(visitor.detectedIssues.isEmpty == false)
     }
+
+    // MARK: - Protocol-required stub exemptions (slice C)
+
+    @Test func macroExpansionMethod_isExempt() throws {
+        // Cross-adopter evidence: SwiftIdempotency package scan (2026-04-26)
+        // showed 6 fires across 4 marker macro types — every macro-impl
+        // file pays the documentation-warning toll on protocol-required
+        // boilerplate. The expansion(...) method's documentation belongs
+        // at the SwiftSyntax Macro protocol declaration site, not at every
+        // adopter conformance.
+        let visitor = createVisitor()
+        let sourceCode = """
+        public struct IdempotentMacro: PeerMacro {
+            public static func expansion(
+                of node: AttributeSyntax,
+                providingPeersOf declaration: some DeclSyntaxProtocol,
+                in context: some MacroExpansionContext
+            ) throws -> [DeclSyntax] {
+                []
+            }
+        }
+        """
+        let sourceFile = Parser.parse(source: sourceCode)
+        visitor.walk(sourceFile)
+        let methodIssues = visitor.detectedIssues.filter {
+            $0.ruleName == .missingDocumentation && $0.message.contains("expansion")
+        }
+        #expect(methodIssues.isEmpty)
+    }
+
+    @Test func encodeToEncoderMethod_isExempt() throws {
+        // Encodable-required `encode(to:)`. Documentation lives at the
+        // protocol declaration site (Apple's Foundation), not at the
+        // conforming type.
+        let visitor = createVisitor()
+        let sourceCode = """
+        public struct IdempotencyKey: Encodable {
+            public func encode(to encoder: Encoder) throws {}
+        }
+        """
+        let sourceFile = Parser.parse(source: sourceCode)
+        visitor.walk(sourceFile)
+        let methodIssues = visitor.detectedIssues.filter {
+            $0.ruleName == .missingDocumentation && $0.message.contains("encode")
+        }
+        #expect(methodIssues.isEmpty)
+    }
+
+    @Test func nonStaticExpansionMethod_stillFires() throws {
+        // Receiver-gate: only `static func expansion(...)` is exempt —
+        // adopter-defined non-static `expansion` methods still fire as
+        // missing documentation. Protects the exemption from collisions
+        // with adopter code that coincidentally uses the name `expansion`
+        // for non-macro purposes.
+        let visitor = createVisitor()
+        let sourceCode = """
+        public struct Engine {
+            public func expansion() -> Int { 0 }
+        }
+        """
+        let sourceFile = Parser.parse(source: sourceCode)
+        visitor.walk(sourceFile)
+        let methodIssues = visitor.detectedIssues.filter {
+            $0.ruleName == .missingDocumentation && $0.message.contains("expansion")
+        }
+        #expect(!methodIssues.isEmpty,
+                "non-static expansion(...) should still fire missingDocumentation")
+    }
+
+    @Test func encodeWithoutToLabel_stillFires() throws {
+        // Receiver-gate: only `encode(to:)` (the Encodable shape) is
+        // exempt. Methods named `encode` with different parameter labels
+        // (e.g. `encode(_ value:)`) still fire.
+        let visitor = createVisitor()
+        let sourceCode = """
+        public struct Codec {
+            public func encode(_ value: String) -> Data { Data() }
+        }
+        """
+        let sourceFile = Parser.parse(source: sourceCode)
+        visitor.walk(sourceFile)
+        let methodIssues = visitor.detectedIssues.filter {
+            $0.ruleName == .missingDocumentation && $0.message.contains("encode")
+        }
+        #expect(!methodIssues.isEmpty,
+                "encode(_:) should still fire missingDocumentation")
+    }
 }


### PR DESCRIPTION
## Summary

`Missing Documentation` now exempts function shapes whose
documentation belongs at the protocol declaration site, not at every
conforming type:

- `static func expansion(...)` — Macro / PeerMacro / MemberMacro /
  ExtensionMacro / FreestandingMacro family (SwiftSyntax)
- `func encode(to:)` — `Encodable` protocol method (Foundation)

Both shapes are receiver-gated; adopter-defined methods that
coincidentally share a name (`func expansion()` non-static,
`func encode(_:)` with no `to` label) still fire.

## Motivation

Cross-adopter evidence: SwiftIdempotency package scan (2026-04-26)
showed **7 fires** of Missing Documentation, all on protocol-required
stubs:

- 6× macro `expansion` methods across the four marker macro types
  (Idempotent, NonIdempotent, Observational, ExternallyIdempotent)
- 1× Codable `encode(to:)` on `IdempotencyKey`

The protocol's documentation is the authoritative source for
"what does this method do" — adopters writing a boilerplate stub
shouldn't have to copy it into their conformance. The exemption
matches the spirit of the rule (catch undocumented public surface
adopters need to write themselves) without flagging conformance
plumbing.

## Diff scope

- `DocumentationVisitor.swift` — early-return on
  `isProtocolRequiredStub(node)` in the `FunctionDeclSyntax` visit.
  The helper matches the two shapes by name + signature constraint.
- `CodeQualityDocumentationTests.swift` — 4 new tests:
  - `macroExpansionMethod_isExempt`
  - `encodeToEncoderMethod_isExempt`
  - `nonStaticExpansionMethod_stillFires` — regression check that
    non-static `expansion()` still fires
  - `encodeWithoutToLabel_stillFires` — regression check that
    `encode(_:)` still fires
- `missing-documentation.md` — Discussion section gains a
  "Protocol-required stubs are exempted" subsection with the
  receiver-gating table.

## Verification

- 4 new tests pass; existing 5 documentation tests stay green.
- Full linter suite: **2406 / 294 passing** (was 2402 + this slice's
  +4 tests).
- Re-ran linter against SwiftIdempotency:
  - Before: 7 `Missing Documentation` fires
  - After: 0 fires
  - Net SwiftIdempotency total: 36 → 29 (cumulative 49 → 29 across
    slices A + B + C, -41%).

## Test plan

- [x] `static func expansion(...)` exempt
- [x] `func encode(to:)` exempt
- [x] Non-static `expansion()` still fires (regression)
- [x] `encode(_:)` still fires (regression)
- [x] Full linter suite green
- [x] SwiftIdempotency scan: -7 fires confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)