### PR TITLE
CouldBePrivateMember: whitelist CompilerPlugin.providingMacros

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/CouldBePrivateMemberVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/CouldBePrivateMemberVisitor.swift
@@ -73,7 +73,14 @@ final class CouldBePrivateMemberVisitor: BasePatternVisitor, CrossFilePatternVis
         // Core Data / SwiftData
         "NSManagedObject", "FetchableRecord", "PersistableRecord",
         // Testing
-        "XCTestCase"
+        "XCTestCase",
+        // SwiftSyntax compiler plugins (macro authors). The
+        // `providingMacros` member on @main CompilerPlugin types is
+        // accessed by the macro host via the compiler-plugin entry
+        // point — there's no Swift-source reference in the package,
+        // so the rule's "only used in this file" check fires even
+        // though making it private would break the protocol witness.
+        "CompilerPlugin"
     ]
 
     required init(fileCache: [String: SourceFileSyntax]) {

--- a/Tests/CoreTests/CrossFileAnalysis/CouldBePrivateMemberVisitorTests.swift
+++ b/Tests/CoreTests/CrossFileAnalysis/CouldBePrivateMemberVisitorTests.swift
@@ -274,4 +274,33 @@ struct CouldBePrivateMemberVisitorTests {
         let flagged = issues.map { $0.message }
         #expect(flagged.contains { $0.contains("uniqueInternalConfig") })
     }
+
+    // MARK: - System framework conformances
+
+    @Test func skipsCompilerPluginProvidingMacros() {
+        // SwiftSyntax compiler plugins (macro authors) declare a
+        // `providingMacros: [Macro.Type]` member that the macro host
+        // accesses via the @main entry point. There's no Swift-source
+        // reference to it in the package, so the rule's "only used in
+        // this file" check would otherwise fire — but making it private
+        // breaks the protocol witness. Cross-adopter evidence: surfaced
+        // on a SwiftIdempotency package scan (2026-04-26) where the
+        // adopter's `SwiftIdempotencyMacrosPlugin` was flagged.
+        let issues = analyze(files: [
+            "Plugin.swift": """
+            import SwiftCompilerPlugin
+            @main
+            struct MyMacrosPlugin: CompilerPlugin {
+                let providingMacros: [Macro.Type] = [MyMacro.self]
+            }
+            struct MyMacro {}
+            """,
+            "Other.swift": """
+            struct Other { }
+            """
+        ])
+
+        let flagged = issues.map(\.message)
+        #expect(flagged.contains { $0.contains("providingMacros") } == false)
+    }
 }


### PR DESCRIPTION
## Summary

Add `CompilerPlugin` (SwiftSyntax) to the
`CouldBePrivateMemberVisitor.systemFrameworkProtocols` whitelist
alongside the existing entries (UIKit lifecycle, AppIntents,
WidgetKit, NSManagedObject, XCTestCase, etc.).

## Motivation

The rule's existing whitelist covers "members called by the
framework, not by app code." `CompilerPlugin.providingMacros`
fits exactly: the macro host accesses it via the @main
compiler-plugin entry point at runtime, not by Swift-source
reference. The rule's "only used in this file" check sees no
in-source usage and suggests `private`, which would break the
protocol witness table.

Cross-adopter evidence: SwiftIdempotency package scan (2026-04-26)
flagged `SwiftIdempotencyMacrosPlugin.providingMacros` as a false
positive. Generalises to every macro author who ships a `@main
CompilerPlugin` entry point.

## Diff scope

- `CouldBePrivateMemberVisitor.swift` — one entry added to
  `systemFrameworkProtocols` with comment explaining the runtime-
  access pattern.
- `CouldBePrivateMemberVisitorTests.swift` — one new test:
  `skipsCompilerPluginProvidingMacros`. Confirms a synthetic
  plugin source with `providingMacros` + an unrelated file does
  not fire the rule.

## Verification

- 15 tests in `CouldBePrivateMemberVisitorTests` (was 14, +1) — green.
- Full linter suite: **2407 / 294 passing** (was 2406 + this
  slice's +1).

## Test plan

- [x] CompilerPlugin's providingMacros doesn't fire
- [x] Existing 14 tests stay green
- [x] Full linter suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)