### PR TITLE
Slot 23: store upward inference for context-only-annotated signatures

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/EffectSymbolTable.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/EffectSymbolTable.swift
@@ -309,7 +309,17 @@ public struct EffectSymbolTable: Sendable {
                 // un-annotated signatures; the inferrer already filters by
                 // "no @lint.effect on decl" but a sibling annotated decl
                 // could have added the same signature to `entriesBySignature`.
-                guard entriesBySignature[sig] == nil else { continue }
+                //
+                // Context-only entries (annotated `@lint.context` but no
+                // `@lint.effect`) DO allow upward inference to populate.
+                // Slot 23: a `@lint.context replayable` sub-handler whose
+                // body has non-idempotent calls needs its body-inferred
+                // effect stored so an upward-chain dispatcher caller can
+                // see it. Skipping all annotated entries (including
+                // context-only) was the root cause of the switch-dispatch
+                // deep-chain silent miss surfaced on tinyfaces (round 17)
+                // and unidoc (round 18).
+                guard entriesBySignature[sig]?.effect == nil else { continue }
                 let cappedDepth = min(maxHops, result.depth)
                 let cappedResult = UpwardInference(effect: result.effect, depth: cappedDepth)
                 upwardInferredEffects[sig] = mergedInference(

--- a/Tests/CoreTests/Idempotency/Slot23UpwardInferenceTests.swift
+++ b/Tests/CoreTests/Idempotency/Slot23UpwardInferenceTests.swift
@@ -1,0 +1,104 @@
+import Testing
+@testable import Core
+@testable import SwiftProjectLintRules
+@testable import SwiftProjectLintVisitors
+import SwiftSyntax
+import SwiftParser
+
+/// Tests the slot-23 fix: upward inference must populate `upwardInferredEffects`
+/// even when the signature already has a context-only entry in
+/// `entriesBySignature`. The pre-fix guard `entriesBySignature[sig] == nil`
+/// silently dropped upward inference for `@lint.context replayable`-annotated
+/// sub-handlers, producing the silent miss seen on tinyfaces (round 17) and
+/// unidoc (round 18) when a switch dispatcher's `@lint.context replayable`
+/// annotation called into context-only-annotated sub-handlers.
+@Suite
+struct Slot23UpwardInferenceTests {
+
+    @Test func contextOnlyAnnotated_getsUpwardInference_forNonIdempotentBody() {
+        // A function annotated with @lint.context replayable but no
+        // @lint.effect should still have its body's effect upward-inferred
+        // and stored, so callers can see it.
+        let source = """
+        /// @lint.context replayable
+        func subHandler() async throws {
+            try await db.users.update("x")
+        }
+        """
+        var table = EffectSymbolTable()
+        let parsed = Parser.parse(source: source)
+        table.merge(source: parsed)
+
+        // Sanity: entry exists with context but no effect.
+        let signature = FunctionSignature(name: "subHandler", argumentLabels: [])
+        #expect(table.effect(for: signature) == nil,
+                "no declared effect (context-only)")
+        #expect(table.context(for: signature) == .replayable,
+                "context is recorded")
+
+        // Run upward inference. With multiHop, the sub-handler's
+        // body-inferred non-idempotent should land in upwardInferredEffects.
+        table.applyUpwardInferenceImportAware(
+            to: [parsed],
+            multiHop: true
+        ) { call, _ in
+            // Heuristic: any call to `update` is non-idempotent.
+            if let sig = FunctionSignature.from(call: call), sig.name == "update" {
+                return .nonIdempotent
+            }
+            return nil
+        }
+
+        let upward = table.upwardInference(for: signature)
+        #expect(upward?.effect == .nonIdempotent)
+    }
+
+    @Test func dispatcher_seesSubHandler_viaUpwardInference_throughSwitchCase() {
+        // The end-to-end slot-23 shape: a context-annotated dispatcher
+        // whose body switches into context-annotated sub-handlers should
+        // see the sub-handlers as non-idempotent via upward inference,
+        // letting the dispatcher itself be inferred non-idempotent.
+        let source = """
+        enum Event { case installation(Int), createSomething(Int) }
+
+        /// @lint.context replayable
+        func dispatch(event: Event) async throws {
+            switch event {
+            case .installation(let value):
+                try await sub(installation: value)
+            case .createSomething(let value):
+                try await sub(createSomething: value)
+            }
+        }
+
+        /// @lint.context replayable
+        func sub(installation value: Int) async throws {
+            try await db.users.update(value)
+        }
+
+        /// @lint.context replayable
+        func sub(createSomething value: Int) async throws {
+            try await db.repoFeed.insert(value)
+        }
+        """
+        var table = EffectSymbolTable()
+        let parsed = Parser.parse(source: source)
+        table.merge(source: parsed)
+
+        table.applyUpwardInferenceImportAware(
+            to: [parsed],
+            multiHop: true
+        ) { call, _ in
+            if let sig = FunctionSignature.from(call: call),
+               sig.name == "update" || sig.name == "insert" {
+                return .nonIdempotent
+            }
+            return nil
+        }
+
+        let dispatchSig = FunctionSignature(name: "dispatch", argumentLabels: ["event"])
+        let dispatchUpward = table.upwardInference(for: dispatchSig)
+        #expect(dispatchUpward?.effect == .nonIdempotent)
+        #expect((dispatchUpward?.depth ?? 0) >= 2)
+    }
+}


### PR DESCRIPTION
## Summary

Fix the switch-dispatch deep-chain silent miss surfaced as slot 23
on tinyfaces (round 17) and confirmed as 2-adopter on unidoc
(round 18). One-line storage-gate change in
`EffectSymbolTable.runInferencePass`.

## Root cause (smaller than predicted)

The slot was originally framed as "the deep-chain inferrer doesn't
walk `SwitchExprSyntax` case bodies as direct callees." Investigation
showed the walker IS already correct (`UpwardEffectInferrer.collect`
recurses through every child node, including switch case bodies).
The actual bug was in the storage gate:

```swift
guard entriesBySignature[sig] == nil else { continue }
```

This was meant to protect declared *effects* from being overwritten
by upward inference. But it also suppressed inference storage for
context-only entries (`@lint.context replayable` with no
`@lint.effect`). Result: a sub-handler annotated only with
`@lint.context replayable` had its body's non-idempotent calls
correctly inferred but never stored — and the dispatcher's lookup
of the sub-handler signature returned nil.

Fix: gate storage on declared *effect* nullness, not entry presence.

```swift
guard entriesBySignature[sig]?.effect == nil else { continue }
```

## Cross-adopter evidence

- **tinyfaces (round 17, 2026-04-26)** — `StripeWebhookController.index`
  silent miss. Switch-dispatcher to context-annotated sub-handlers
  (`subscriptionUpdate`, `checkoutCompleted`, `invoiceUpdate`)
  produced zero diagnostic.
- **unidoc (round 18, 2026-04-26)** — `WebhookOperation.load(with:)`
  silent miss masked by a separate enum-case-pattern FP. The
  dispatcher fired only on the enum-pattern coincidence, never on
  the `handle(...)` calls inside the case bodies.

Both were the same shape: context-annotated dispatcher → switch →
context-annotated sub-handlers with non-idempotent bodies.

## Diff scope

- `EffectSymbolTable.swift` — one-line change in
  `runInferencePass(...)` storage iteration.
- `Slot23UpwardInferenceTests.swift` — 2 targeted tests:
  - `contextOnlyAnnotated_getsUpwardInference_forNonIdempotentBody`
    proves the storage gate directly.
  - `dispatcher_seesSubHandler_viaUpwardInference_throughSwitchCase`
    proves the end-to-end switch-dispatch shape from the trial
    rounds.

## Field verification

Re-ran the linter against the unidoc trial branch
(`Joseph-Cursio/unidoc-idempotency-trial @ trial-unidoc`):

| | Before fix | After fix |
|---|---:|---:|
| Run A fires | 5 | **7** |
| Dispatcher `load(with:)` fires on `handle` (deep chain) | 0 | **2** (lines 75 + 82) |

The 2 new fires both report:
> `'load' is declared @lint.context replayable but calls 'handle',
> whose effect is inferred non_idempotent from its body.`

## Test plan

- [x] Targeted unit test: context-only signature gets upward inference
- [x] End-to-end: switch dispatcher sees sub-handler via upward chain
- [x] Field verification: unidoc Run A regains 2 expected fires
- [x] Full linter suite: 2409 / 295 green (was 2407 + this slice's +2 tests)
- [x] No regressions in the existing 2407 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)