### PR TITLE
Testability category + Global Mutable State rule

### DIFF
--- a/Docs/PBT_TESTABILITY_RULES_SCOPE.md
+++ b/Docs/PBT_TESTABILITY_RULES_SCOPE.md
@@ -1,0 +1,223 @@
+# Scope: Testability / PBT-Readiness Rules for SwiftProjectLint
+
+_Date: 2026-06-27 · Implements Idea #1 from `~/xcode_projects/PBT_ECOSYSTEM_REVIEW.md`_
+
+## Goal
+
+Turn SwiftProjectLint from "linter that drives idempotency" into "linter that tells a
+developer **why their code is hard to property-test and how to refactor it**." Concretely:
+ship a coherent set of rules under a new `.testability` category, ending with a
+machine-readable handoff that seeds `swift-infer discover` (Idea #2).
+
+The thesis rule is **PureFunctionCandidate** (Rule 5): the positive signal that says
+"this function is now pure + total + Equatable — go property-test it." Everything else
+either removes a blocker to that state or feeds the same pipeline.
+
+---
+
+## Architecture decisions
+
+### New category: `.testability`
+Add one case to `PatternCategory`
+(`Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/PatternCategory.swift`,
+the enum at lines 24–36):
+
+```swift
+case testability
+```
+
+Each new `RuleIdentifier` case maps to `.testability` in the `category` switch
+(`RuleIdentifier.swift` lines 231–248 region). This is free in the JSON output —
+`CodableLintIssue.category` is already `String(describing: ruleName.category)`, so
+consumers can filter `category == "testability"` immediately.
+
+### Two tiers by dependency → two implementation homes
+
+| Tier | Needs SwiftEffectInference? | Home |
+|------|------|------|
+| **A — purely syntactic** (Rules 1–4) | No | New `Testability/` group in `SwiftProjectLintRules` (main rules package) |
+| **B — effect-aware** (Rules 5–6) | Yes (`EffectSymbolTable`, `HeuristicEffectInferrer`, `UpwardEffectInferrer`) | Beside the idempotency rules, which already wire SEI: `SwiftProjectLintIdempotencyRules` (or a sibling `SwiftProjectLintTestabilityRules` package that depends on `SwiftProjectLintVisitors`) |
+
+Rationale: only Tier B needs the effect machinery (which lives in
+`SwiftProjectLintVisitors` + `SwiftProjectLintIdempotencyRules`, both already pinned to
+SEI revision `6722e260…`). Keeping Tier A out of that dependency keeps the cheap rules
+cheap. This mirrors the existing split where idempotency rules are their own package.
+
+### Per-rule authoring recipe (verified against current conventions)
+1. Add `case x = "Display Name"` to `RuleIdentifier`; add `x` to the `.testability` arm of the `category` switch.
+2. Visitor: subclass `BasePatternVisitor`, override the relevant `visit(_:)`, call `addIssue(...)`. (Template: `Architecture/Visitors/SingletonUsageVisitor.swift`.)
+3. Registrar: `struct X: PatternRegistrarProtocol { var pattern: SyntaxPattern { … } }`. (Template: `CodeQuality/PatternRegistrars/ForceTry.swift`.)
+4. Wire it into the category registrar's `registry.register(registrars: [ … ])` list, or, for a new package, add a `BasePatternRegistrar` subclass + a `SourcePatternRegistry.registerFactory { … }` in `BuiltInRules.swift`.
+
+`addIssue` direct form (custom message), from `BasePatternVisitor.swift:266`:
+```swift
+addIssue(severity: .warning, message: "…", filePath: getFilePath(for: Syntax(node)),
+         lineNumber: getLineNumber(for: Syntax(node)), suggestion: "…", ruleName: .x)
+```
+
+---
+
+## Rule catalog
+
+### Tier A — purely syntactic (Phase 1)
+
+#### Rule 1 — Non-Injected Nondeterminism  `.nonInjectedNondeterminism`
+- **Category/severity:** `.testability` / `.warning` (start `.info` to gauge noise).
+- **What:** flag a nondeterministic *source* called inline in logic when it is **not injected**.
+- **Source set** (broader than the existing modernization rules): `Date()`, `Date.now`,
+  `UUID()`, `Int/Double/Bool/Float.random(in:)`, `.randomElement()`, `.shuffled()`,
+  `arc4random*`, `CFAbsoluteTimeGetCurrent()`, `DispatchTime.now()`, `ContinuousClock().now`
+  used inline, `Locale.current`, `TimeZone.current`, `ProcessInfo.processInfo.environment`.
+- **"Not injected" heuristic:** the call is inside a function/computed-property body and is
+  **not** in a parameter default-value position. Reuse the parent-walk from
+  `SingletonUsageVisitor.isParameterDefaultValue` (stops at `ClosureExprSyntax`/`CodeBlockSyntax`,
+  matches `FunctionParameterSyntax`). Exempt test/fixture files via `isTestOrFixtureFile()`
+  exactly as the singleton rule does.
+- **Suggestion:** "Inject a clock / UUID / RNG provider (e.g. `() -> Date`, `RandomNumberGenerator`) so this value is controllable in tests."
+- **Overlap to settle:** `DateNowVisitor` (`.dateNow`), `LegacyRandomVisitor` (`.legacyRandom`),
+  `CFAbsoluteTimeVisitor` (`.cfAbsoluteTime`) already fire `.info` on a subset. Decision (open):
+  let this rule co-fire (different category/framing) **or** scope it to the sources those
+  rules *don't* cover (UUID, `.random(in:)`, `Locale.current`, …) to avoid duplicate
+  diagnostics on the same token. Recommendation: co-fire is fine — the framing differs and
+  users can disable per-rule — but exclude the exact `Date()` zero-arg token to avoid two
+  findings on one node.
+- **Effort:** S–M. Single `FunctionCallExprSyntax` / `MemberAccessExprSyntax` visitor.
+
+#### Rule 2 — Global Mutable State  `.globalMutableState`
+- **Category/severity:** `.testability` / `.warning`.
+- **What:** flag stored mutable global state: top-level `var` declarations and `static var`
+  stored properties on types. These defeat PBT isolation (properties can't reset them).
+- **Detection:** visit `VariableDeclSyntax`; require `bindingSpecifier.text == "var"`, a
+  binding with **no accessor block** (stored, not computed), and either parent is
+  `SourceFileSyntax` (top-level) or the decl carries the `static` modifier inside a type body.
+  Exempt `let`, computed `var`, SwiftUI property wrappers (`@State`/`@StateObject`/…), and
+  test files.
+- **Suggestion:** "Move mutable state behind an injected, instance-scoped owner; globals can't be reset between property-test runs."
+- **Effort:** S.
+
+#### Rule 3 — Unabstracted I/O Dependency  `.unabstractedIODependency` *(extend existing)*
+- **Note:** Architecture already registers `UnabstractedFileIO()`. **Audit it first** — it may
+  already cover `FileManager`. Scope here = extend coverage to concrete `URLSession`,
+  `UserDefaults`, `FileManager` appearing as **parameter types or stored-property types**
+  (not behind a protocol), suggesting a protocol seam.
+- **Category/severity:** `.testability` (or keep `.architecture`) / `.warning`.
+- **Detection:** visit `FunctionParameterSyntax` and stored `VariableDeclSyntax`; match the
+  concrete type names; skip if the declared type is a protocol (heuristic: known protocol
+  suffixes or a project-collected protocol set).
+- **Effort:** S if extending `UnabstractedFileIO`; M if new.
+
+### Tier A — cross-file (Phase 1.5)
+
+#### Rule 4 — Missing Equatable on State Value Type  `.missingEquatableOnStateType`
+- **Category/severity:** `.testability` (or `.stateManagement`) / `.info`.
+- **Why it matters most for the pipeline:** every value type made `Equatable` becomes a
+  direct **SwiftPropertyLaws** target and unlocks PBT shrinking/assertions.
+- **What:** flag a value type used in `@State`/`@Published`/`@Binding` (or returned from a
+  candidate-pure function) that has no `Equatable`/`Hashable` conformance found in the project.
+- **Detection:** needs project-wide knowledge → use `CrossFileAnalysisEngine`. Pass 1: collect
+  `struct`/`enum` decls and whether they declare `Equatable`/`Hashable` (including
+  `@PropertyLawSuite`-style derivations). Pass 2: collect state-var types. Flag the gap.
+- **Limitation (document):** can't see conformances declared in other modules; info-severity
+  keeps false positives low-cost.
+- **Effort:** M.
+
+### Tier B — effect-aware (Phase 2)
+
+#### Rule 5 — Pure Function · Property-Test Candidate  `.pureFunctionCandidate`  ⭐ thesis rule
+- **Category/severity:** `.testability` / `.info`, **opt-in** (off by default to avoid noise).
+- **What (positive signal):** "This function looks pure, total, and Equatable-typed — a good
+  property-based-testing candidate."
+- **Detection is a composition** (no single tier suffices — SEI has no `pure` tier):
+  1. Inferred effect ≤ `.observational` via `EffectSymbolTable` / `HeuristicEffectInferrer` /
+     `UpwardEffectInferrer` (same path `IdempotencyViolationVisitor` uses).
+  2. **No** nondeterministic source in the body (reuse Rule 1's detector — observational still
+     permits clock/RNG reads, which disqualify a PBT candidate).
+  3. **Total:** no `try!`, force-unwrap `!`, `as!`, `fatalError`/`precondition`.
+  4. All parameter types + return type are `Equatable`-or-primitive (reuse Rule 4's project
+     conformance index).
+- **Suggestion:** "Run `swift-infer discover` on this function, or add a `PropertyLawKit` test."
+- **This is the Idea #2 seam** — these findings are the seed list. See Handoff below.
+- **Effort:** L (composes four analyses + project index).
+
+#### Rule 6 — Impure Call in View Body  `.impureCallInViewBody`
+- **Category/severity:** `.testability` (or `.performance`) / `.warning`.
+- **What:** inside a SwiftUI `var body` / `@ViewBuilder`, flag calls to functions inferred
+  non-observational (writes / non-idempotent) or to nondeterministic sources — these make the
+  view untestable and re-render nondeterministic.
+- **Detection:** reuse the body-detection from `Performance/Visitors` (`expensiveOperationInViewBody`,
+  `formatterInViewBody` already locate the `body` accessor) + effect inference + Rule 1 detector.
+- **Effort:** M (body-location logic already exists to mirror).
+
+---
+
+## Cross-cutting: the handoff seam (Idea #2)
+
+The candidate rule (5) is only useful downstream if the emitted finding names the **symbol**.
+Today `CodableLintIssue` (`Sources/Core/Export/CodableLintIssue.swift:14`) carries
+`severity, message, locations, suggestion, ruleName, category` — **no function name/signature**.
+
+**Minimal change:** add an optional field:
+```swift
+public let symbol: String?   // e.g. "func reduce(_:_:) -> State"  — nil for most rules
+```
+Populate it for Rule 5 (and any future candidate rules). Then a documented contract emerges
+for free:
+
+> A PBT-candidate seed = any issue in the JSON report with
+> `ruleName == "Pure Function · Property-Test Candidate"`, giving `{file, line, symbol}`.
+
+Optionally add a focused `--format pbt-seeds` to the CLI that projects the report down to
+`[{file, line, symbol}]` so `swift-infer discover --seeds <file>` can consume it directly
+instead of scanning blind. (Defer until SwiftInferProperties grows a `--seeds` input; the
+`category`-filtered JSON is enough to prototype.)
+
+---
+
+## Phasing
+
+1. **Phase 1 (Tier A, no new deps):** category `.testability` + Rules 1, 2, 3. Ships the
+   "why it's hard to test" warnings. ~1–2 sessions.
+2. **Phase 1.5:** Rule 4 (cross-file Equatable gap) — directly feeds SwiftPropertyLaws.
+3. **Phase 2 (Tier B, effect-aware):** Rules 5 + 6. Rule 5 is the thesis rule and the
+   pipeline seam.
+4. **Phase 3 (handoff):** `symbol` field + optional `--format pbt-seeds`; document the seed
+   contract; wire `swift-infer discover --seeds`.
+
+Order rationale: Phase 1 is pure value with zero dependency risk; Rule 5 is deliberately last
+because it composes everything before it.
+
+---
+
+## Testing
+
+- Mirror `Tests/CoreTests/` structure; each rule gets a positive-fixture file (should fire)
+  and a negative-fixture file (injected/total/Equatable cases — should stay quiet), following
+  the idempotency tests under `Tests/CoreTests/Idempotency/`.
+- Dogfood: the repo already adds property-based tests over its own rules (recent commits
+  "Add detector robustness properties"). Add detector-robustness properties for the new
+  visitors (idempotent detection, no crash on malformed input).
+- Exemption coverage: assert test/fixture files are exempt (Rules 1, 2), and parameter
+  default-value positions are exempt (Rule 1).
+- `#expect` style: use `== false` not leading `!`, per CLAUDE.md.
+
+---
+
+## Open decisions (need a call before coding)
+
+1. **New package vs. group:** Tier B in `SwiftProjectLintIdempotencyRules` (reuses wired SEI)
+   vs. a new `SwiftProjectLintTestabilityRules` package. Recommendation: start Tier B inside
+   the idempotency package's neighborhood to avoid new-package wiring; split later if it grows.
+2. **Rule 1 co-fire vs. dedupe** with existing `.dateNow`/`.legacyRandom`/`.cfAbsoluteTime`.
+   Recommendation: co-fire but exclude the exact tokens those already cover.
+3. **Rule 3:** extend `UnabstractedFileIO` vs. new rule. Recommendation: audit + extend.
+4. **`symbol` field** on `CodableLintIssue` — accept the model change now (Phase 1) so the
+   schema is stable before Rule 5, or defer. Recommendation: add it in Phase 1 (cheap, additive).
+5. **Default on/off:** Rule 5 opt-in (info, advisory); Rules 1–2 default-on (warning). Confirm.
+
+---
+
+## First commit (smallest shippable slice)
+
+`.testability` category + **Rule 2 (Global Mutable State)** — it's the simplest end-to-end
+(one `VariableDeclSyntax` visitor, no cross-file, no SEI), so it proves the category wiring
+and the test pattern before the harder rules. Then Rule 1, then the rest per phasing.

--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/PatternCategory.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/PatternCategory.swift
@@ -33,5 +33,6 @@ public enum PatternCategory: CaseIterable, Sendable {
     case animation
     case modernization
     case idempotency
+    case testability
     case other
 }

--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
@@ -213,6 +213,9 @@ public enum RuleIdentifier: String, CaseIterable, Codable, Sendable {
     case tupleEqualityWithUnstableComponents = "Tuple Equality With Unstable Components"
     case nonIdempotentActionName = "Non-Idempotent Action Name"
 
+    // Testability / PBT-readiness Rules
+    case globalMutableState = "Global Mutable State"
+
     // Other/System Rules
     case fileParsingError = "File Parsing Error"
     case unknown = "Unknown"
@@ -340,6 +343,10 @@ public enum RuleIdentifier: String, CaseIterable, Codable, Sendable {
              .onceContractViolation, .unannotatedInStrictReplayableContext,
              .tupleEqualityWithUnstableComponents, .nonIdempotentActionName:
             return .idempotency
+
+            // Testability / PBT-readiness Rules
+        case .globalMutableState:
+            return .testability
 
             // Other/System Rules
         case .fileParsingError, .unknown:

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/BuiltInRules.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/BuiltInRules.swift
@@ -58,6 +58,9 @@ public enum BuiltInRules {
         SourcePatternRegistry.registerFactory { registry, visitorRegistry in
             Modernization(registry: registry, visitorRegistry: visitorRegistry)
         }
+        SourcePatternRegistry.registerFactory { registry, visitorRegistry in
+            Testability(registry: registry, visitorRegistry: visitorRegistry)
+        }
     }
 
     /// Resets registration state. Used by tests to ensure a clean slate.

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/Testability.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/Testability.swift
@@ -1,0 +1,28 @@
+import Foundation
+import SwiftProjectLintModels
+import SwiftProjectLintRegistry
+import SwiftProjectLintVisitors
+
+/// Registers testability / PBT-readiness patterns — code shapes that make
+/// property-based testing harder (global mutable state, non-injected
+/// nondeterminism), plus the positive `pureFunctionCandidate` signal that
+/// seeds the lint → infer → verify pipeline.
+class Testability: BasePatternRegistrar {
+    override func registerPatterns() {
+        let patterns = [
+            SyntaxPattern(
+                name: .globalMutableState,
+                visitor: GlobalMutableStateVisitor.self,
+                severity: .warning,
+                category: .testability,
+                messageTemplate: "Global mutable state — a top-level or `static var` can't be "
+                    + "reset between property-test trials, so it leaks state across runs",
+                suggestion: "Move the mutable state behind an injected, instance-scoped owner "
+                    + "the test can construct fresh.",
+                description: "Detects stored top-level `var` and `static var` declarations, which "
+                    + "defeat property-based-test isolation."
+            )
+        ]
+        registry.register(patterns: patterns)
+    }
+}

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/GlobalMutableStateVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/GlobalMutableStateVisitor.swift
@@ -1,0 +1,58 @@
+import Foundation
+import SwiftProjectLintModels
+import SwiftProjectLintRegistry
+import SwiftProjectLintVisitors
+import SwiftSyntax
+
+/// Detects stored mutable global state — top-level `var` declarations and
+/// `static var` stored properties. Global mutable state defeats
+/// property-based-test isolation: a property runs its body many times and
+/// can't reset shared state between trials, so leaked state makes trials
+/// interdependent and failures non-reproducible.
+///
+/// Only `var` (mutable) stored declarations are flagged. `let`, computed
+/// `var` (with an accessor block), and instance properties are left alone.
+final class GlobalMutableStateVisitor: BasePatternVisitor {
+
+    required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
+        super.init(pattern: pattern, viewMode: viewMode)
+    }
+
+    override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard node.bindingSpecifier.tokenKind == .keyword(.var) else {
+            return .visitChildren
+        }
+        // Stored only — at least one binding without an accessor block.
+        guard node.bindings.contains(where: { $0.accessorBlock == nil }) else {
+            return .visitChildren
+        }
+        guard isStatic(node) || isFileScope(node) else {
+            return .visitChildren
+        }
+        addIssue(
+            severity: .warning,
+            message: "Global mutable state — a top-level or `static var` can't be reset between "
+                + "property-test trials, so it leaks state across runs",
+            filePath: getFilePath(for: Syntax(node)),
+            lineNumber: getLineNumber(for: Syntax(node)),
+            suggestion: "Move the mutable state behind an injected, instance-scoped owner the test "
+                + "can construct fresh.",
+            ruleName: .globalMutableState
+        )
+        return .visitChildren
+    }
+
+    private func isStatic(_ node: VariableDeclSyntax) -> Bool {
+        node.modifiers.contains { $0.name.tokenKind == .keyword(.static) }
+    }
+
+    /// True when the declaration sits directly at file scope:
+    /// `SourceFile > CodeBlockItemList > CodeBlockItem > VariableDecl`.
+    private func isFileScope(_ node: VariableDeclSyntax) -> Bool {
+        guard let item = node.parent?.as(CodeBlockItemSyntax.self),
+              let list = item.parent?.as(CodeBlockItemListSyntax.self) else {
+            return false
+        }
+        return list.parent?.is(SourceFileSyntax.self) == true
+    }
+}

--- a/Sources/App/Models/PatternCategory+LintCategory.swift
+++ b/Sources/App/Models/PatternCategory+LintCategory.swift
@@ -16,6 +16,7 @@ extension PatternCategory: @retroactive LintCategory {
         case .animation: "animation"
         case .modernization: "modernization"
         case .idempotency: "idempotency"
+        case .testability: "testability"
         case .other: "other"
         }
     }
@@ -34,6 +35,7 @@ extension PatternCategory: @retroactive LintCategory {
         case .animation: "Animation"
         case .modernization: "Modernization"
         case .idempotency: "Idempotency"
+        case .testability: "Testability"
         case .other: "Other"
         }
     }

--- a/Sources/App/Models/PatternConfiguration.swift
+++ b/Sources/App/Models/PatternConfiguration.swift
@@ -115,6 +115,12 @@ struct PatternConfiguration {
                 display: "Idempotency",
                 patterns: convertToDetectionPatterns(patternRegistry.getPatterns(for: .idempotency)),
                 useSwiftSyntax: true
+            ),
+            PatternCategoryInfo(
+                category: .testability,
+                display: "Testability",
+                patterns: convertToDetectionPatterns(patternRegistry.getPatterns(for: .testability)),
+                useSwiftSyntax: true
             )
         ]
     }

--- a/Tests/AppTests/PatternConfigurationTests.swift
+++ b/Tests/AppTests/PatternConfigurationTests.swift
@@ -98,14 +98,15 @@ struct PatternConfigurationTests {
         let mockRegistry = MockPatternRegistry()
         let result = PatternConfiguration.allPatternsByCategory(from: mockRegistry)
 
-        // Should return all 12 user-facing categories even if empty (includes animation, modernization, idempotency)
-        #expect(result.count == 12)
+        // Should return all 13 user-facing categories even if empty (includes
+        // animation, modernization, idempotency, testability)
+        #expect(result.count == 13)
 
         let categories = Set(result.map(\.category))
         let expectedCategories: Set<PatternCategory> = [
             .stateManagement, .performance, .architecture, .codeQuality,
             .security, .accessibility, .memoryManagement, .networking,
-            .uiPatterns, .animation, .modernization, .idempotency
+            .uiPatterns, .animation, .modernization, .idempotency, .testability
         ]
         #expect(categories == expectedCategories)
     }

--- a/Tests/CoreTests/Testability/GlobalMutableStateVisitorTests.swift
+++ b/Tests/CoreTests/Testability/GlobalMutableStateVisitorTests.swift
@@ -1,0 +1,61 @@
+@testable import Core
+import Foundation
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+@Suite
+struct GlobalMutableStateVisitorTests {
+
+    private func analyze(_ source: String, filePath: String = "TestFile.swift") -> [LintIssue] {
+        let visitor = GlobalMutableStateVisitor(patternCategory: .testability)
+        let syntax = Parser.parse(source: source)
+        let converter = SourceLocationConverter(fileName: filePath, tree: syntax)
+        visitor.setSourceLocationConverter(converter)
+        visitor.setFilePath(filePath)
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == .globalMutableState }
+    }
+
+    @Test func flagsTopLevelVar() throws {
+        let issue = try #require(analyze("var counter = 0").first)
+        #expect(issue.ruleName == .globalMutableState)
+        #expect(issue.severity == .warning)
+    }
+
+    @Test func flagsStaticVar() {
+        let source = """
+        enum Config {
+            static var shared = 0
+        }
+        """
+        #expect(analyze(source).count == 1)
+    }
+
+    @Test func ignoresTopLevelLet() {
+        #expect(analyze("let counter = 0").isEmpty)
+    }
+
+    @Test func ignoresStaticLet() {
+        #expect(analyze("enum Config { static let shared = 0 }").isEmpty)
+    }
+
+    @Test func ignoresInstanceVar() {
+        // Instance stored properties are normal state, not global.
+        #expect(analyze("struct Model { var value = 0 }").isEmpty)
+    }
+
+    @Test func ignoresComputedStaticVar() {
+        let source = """
+        enum Config {
+            static var value: Int { 42 }
+        }
+        """
+        #expect(analyze(source).isEmpty)
+    }
+
+    @Test func ignoresTopLevelComputedVar() {
+        #expect(analyze("var value: Int { 42 }").isEmpty)
+    }
+}


### PR DESCRIPTION
First rule of the new **testability / PBT-readiness** category — Idea #1 from the PBT ecosystem review (`PBT_TESTABILITY_RULES_SCOPE.md`). The aim: lint that tells a developer *why their code is hard to property-test, and how to refactor it*.

## What it flags

**Global Mutable State** — stored mutable global state:
- top-level `var` declarations, and
- `static var` stored properties.

Global mutable state defeats property-based-test **isolation**: a property runs its body across many generated inputs and can't reset shared state between trials, so leaked state makes trials interdependent and failures non-reproducible.

Severity `.warning`. Suggestion: move the state behind an injected, instance-scoped owner the test can construct fresh.

### Flagged
```swift
var counter = 0                       // top-level var
enum Config { static var shared = 0 } // static var
```
### Not flagged
`let` (top-level or static), computed `var` (accessor block), and instance stored properties — those aren't global mutable state.

## Changes
- New `.testability` `PatternCategory` + `globalMutableState` `RuleIdentifier`.
- `GlobalMutableStateVisitor` (var + stored + (`static` | file-scope)), `Testability` registrar, wired into `BuiltInRules`.
- App: `PatternCategory` display/rawValue arms + `allPatternsByCategory` entry.
- 7 visitor tests; updated the user-facing-category count test (12 → 13).

First in a per-rule slice series for the testability category.

🤖 Generated with [Claude Code](https://claude.com/claude-code)