### PR TITLE
Non-Injected Nondeterminism testability rule

### DIFF
--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
@@ -215,6 +215,7 @@ public enum RuleIdentifier: String, CaseIterable, Codable, Sendable {
 
     // Testability / PBT-readiness Rules
     case globalMutableState = "Global Mutable State"
+    case nonInjectedNondeterminism = "Non-Injected Nondeterminism"
 
     // Other/System Rules
     case fileParsingError = "File Parsing Error"
@@ -345,7 +346,7 @@ public enum RuleIdentifier: String, CaseIterable, Codable, Sendable {
             return .idempotency
 
             // Testability / PBT-readiness Rules
-        case .globalMutableState:
+        case .globalMutableState, .nonInjectedNondeterminism:
             return .testability
 
             // Other/System Rules

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/Testability.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/Testability.swift
@@ -21,6 +21,18 @@ class Testability: BasePatternRegistrar {
                     + "the test can construct fresh.",
                 description: "Detects stored top-level `var` and `static var` declarations, which "
                     + "defeat property-based-test isolation."
+            ),
+            SyntaxPattern(
+                name: .nonInjectedNondeterminism,
+                visitor: NonInjectedNondeterminismVisitor.self,
+                severity: .warning,
+                category: .testability,
+                messageTemplate: "Non-injected nondeterminism — an inline `Date()` / `UUID()` / "
+                    + "`.random` / `Date.now` can't be pinned or reproduced by a property test",
+                suggestion: "Inject the source (a clock, `RandomNumberGenerator`, or UUID provider) "
+                    + "so tests can control it.",
+                description: "Detects nondeterministic sources used inline in logic rather than "
+                    + "injected as a dependency."
             )
         ]
         registry.register(patterns: patterns)

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
@@ -1,0 +1,111 @@
+import Foundation
+import SwiftProjectLintModels
+import SwiftProjectLintRegistry
+import SwiftProjectLintVisitors
+import SwiftSyntax
+
+/// Detects nondeterministic sources used inline in logic rather than injected
+/// as a dependency: `Date()`, `UUID()`, `.random(in:)`, `.randomElement()`,
+/// `.shuffled()`, the legacy C RNG/clock functions, and `Date.now` /
+/// `Locale.current` / `TimeZone.current`.
+///
+/// Inline nondeterminism is the #1 blocker to property-testing pure logic: a
+/// property can't pin the value or reproduce a counterexample, so the function
+/// stops being a function of its inputs. A source supplied as a parameter
+/// default (`init(id: UUID = UUID())`) is the injection seam, not inline use,
+/// and is exempt.
+final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
+
+    private var fileIsTestOrFixture = false
+
+    private static let noArgInitTypes: Set<String> = ["Date", "UUID"]
+    private static let bareFunctions: Set<String> = [
+        "arc4random", "arc4random_uniform", "drand48", "CFAbsoluteTimeGetCurrent"
+    ]
+    private static let randomMembers: Set<String> = ["random", "randomElement", "shuffled"]
+
+    required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
+        super.init(pattern: pattern, viewMode: viewMode)
+    }
+
+    override func setFilePath(_ filePath: String) {
+        super.setFilePath(filePath)
+        fileIsTestOrFixture = isTestOrFixtureFile()
+    }
+
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        guard !fileIsTestOrFixture, !isParameterDefaultValue(Syntax(node)) else {
+            return .visitChildren
+        }
+        if let source = nondeterministicCallSource(node) {
+            flag(source, at: Syntax(node))
+        }
+        return .visitChildren
+    }
+
+    override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
+        guard !fileIsTestOrFixture, !isParameterDefaultValue(Syntax(node)) else {
+            return .visitChildren
+        }
+        guard let base = node.base?.as(DeclReferenceExprSyntax.self)?.baseName.text else {
+            return .visitChildren
+        }
+        let name = node.declName.baseName.text
+        if (base == "Date" && name == "now")
+            || ((base == "Locale" || base == "TimeZone") && name == "current") {
+            flag("\(base).\(name)", at: Syntax(node))
+        }
+        return .visitChildren
+    }
+
+    private func nondeterministicCallSource(_ node: FunctionCallExprSyntax) -> String? {
+        // Bare init / function: `Date()`, `UUID()` (only the no-argument forms
+        // are nondeterministic), `arc4random()`, `CFAbsoluteTimeGetCurrent()`.
+        if let ref = node.calledExpression.as(DeclReferenceExprSyntax.self) {
+            let name = ref.baseName.text
+            if Self.noArgInitTypes.contains(name), node.arguments.isEmpty {
+                return "\(name)()"
+            }
+            if Self.bareFunctions.contains(name) {
+                return "\(name)()"
+            }
+        }
+        // Member call: `Int.random(in:)`, `array.randomElement()`, `.shuffled()`.
+        if let member = node.calledExpression.as(MemberAccessExprSyntax.self),
+           Self.randomMembers.contains(member.declName.baseName.text) {
+            return ".\(member.declName.baseName.text)(…)"
+        }
+        return nil
+    }
+
+    private func flag(_ source: String, at node: Syntax) {
+        addIssue(
+            severity: .warning,
+            message: "Non-injected nondeterminism: `\(source)` makes this code unpredictable, so a "
+                + "property-based test can't pin the value or reproduce a failure",
+            filePath: getFilePath(for: node),
+            lineNumber: getLineNumber(for: node),
+            suggestion: "Inject the source (a clock `() -> Date`, a `RandomNumberGenerator`, a UUID "
+                + "provider) so tests can control it.",
+            ruleName: .nonInjectedNondeterminism
+        )
+    }
+
+    /// True when `node` sits in a function/initializer parameter's default
+    /// value — `init(id: UUID = UUID())` is the injection seam, not inline
+    /// nondeterminism. Stops at a closure / code block so a call inside a
+    /// default closure body is still flagged.
+    private func isParameterDefaultValue(_ node: Syntax) -> Bool {
+        var current = node.parent
+        while let syntax = current {
+            if syntax.is(ClosureExprSyntax.self) || syntax.is(CodeBlockSyntax.self) {
+                return false
+            }
+            if syntax.is(FunctionParameterSyntax.self) {
+                return true
+            }
+            current = syntax.parent
+        }
+        return false
+    }
+}

--- a/Tests/CoreTests/Testability/NonInjectedNondeterminismVisitorTests.swift
+++ b/Tests/CoreTests/Testability/NonInjectedNondeterminismVisitorTests.swift
@@ -1,0 +1,75 @@
+@testable import Core
+import Foundation
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+@Suite
+struct NonInjectedNondeterminismVisitorTests {
+
+    private func analyze(_ source: String, filePath: String = "Logic.swift") -> [LintIssue] {
+        let visitor = NonInjectedNondeterminismVisitor(patternCategory: .testability)
+        let syntax = Parser.parse(source: source)
+        let converter = SourceLocationConverter(fileName: filePath, tree: syntax)
+        visitor.setSourceLocationConverter(converter)
+        visitor.setFilePath(filePath)
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == .nonInjectedNondeterminism }
+    }
+
+    @Test func flagsInlineDateInit() {
+        let source = "func stamp() -> Date { return Date() }"
+        #expect(analyze(source).count == 1)
+    }
+
+    @Test func flagsInlineUUID() {
+        #expect(analyze("func make() -> UUID { UUID() }").count == 1)
+    }
+
+    @Test func flagsRandomCall() {
+        #expect(analyze("func roll() -> Int { Int.random(in: 1...6) }").count == 1)
+    }
+
+    @Test func flagsRandomElementAndShuffled() {
+        let source = """
+        func pick(_ xs: [Int]) -> Int? { xs.randomElement() }
+        func mix(_ xs: [Int]) -> [Int] { xs.shuffled() }
+        """
+        #expect(analyze(source).count == 2)
+    }
+
+    @Test func flagsLegacyCFunctions() {
+        #expect(analyze("func r() -> UInt32 { arc4random() }").count == 1)
+    }
+
+    @Test func flagsDateNowAndCurrentLocale() {
+        let source = """
+        func a() -> Date { Date.now }
+        func b() -> Locale { Locale.current }
+        """
+        #expect(analyze(source).count == 2)
+    }
+
+    // MARK: - Not flagged
+
+    @Test func ignoresParameterDefaultValue() {
+        // The injection seam — not inline use.
+        let source = "func make(id: UUID = UUID(), at: Date = Date()) {}"
+        #expect(analyze(source).isEmpty)
+    }
+
+    @Test func ignoresDeterministicInitializers() {
+        // Given their input, these are deterministic.
+        let source = """
+        func a() -> Date { Date(timeIntervalSince1970: 0) }
+        func b() -> UUID { UUID(uuidString: "x")! }
+        """
+        #expect(analyze(source).isEmpty)
+    }
+
+    @Test func ignoresTestFiles() {
+        let source = "func roll() -> Int { Int.random(in: 1...6) }"
+        #expect(analyze(source, filePath: "RollTests.swift").isEmpty)
+    }
+}


### PR DESCRIPTION
Second testability rule (stacked on #36). Flags nondeterministic sources used **inline in logic** rather than injected as a dependency — the #1 blocker to property-testing pure logic, since a property can't pin the value or reproduce a counterexample.

## Flagged
- `Date()`, `UUID()` (no-argument forms only)
- `Int.random(in:)`, `array.randomElement()`, `array.shuffled()`
- legacy C: `arc4random`, `arc4random_uniform`, `drand48`, `CFAbsoluteTimeGetCurrent`
- `Date.now`, `Locale.current`, `TimeZone.current`

## Exempt (deliberately)
- **Parameter defaults** — `init(id: UUID = UUID())` is the injection seam, not inline use.
- **Deterministic initializers** — `Date(timeIntervalSince1970:)`, `UUID(uuidString:)`.
- **Test files.**

Severity `.warning`; suggestion: inject a clock / `RandomNumberGenerator` / UUID provider. 9 visitor tests.

> Co-fires with the existing `Date Now` / `Legacy Random` modernization rules — different framing (testability vs. style), as planned in the scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)