### PR TITLE
Pure Function Property-Test Candidate testability rule

### DIFF
--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
@@ -215,6 +215,7 @@ public enum RuleIdentifier: String, CaseIterable, Codable, Sendable {
 
     // Testability / PBT-readiness Rules
     case globalMutableState = "Global Mutable State"
+    case pureFunctionCandidate = "Pure Function Property-Test Candidate"
 
     // Other/System Rules
     case fileParsingError = "File Parsing Error"
@@ -345,7 +346,7 @@ public enum RuleIdentifier: String, CaseIterable, Codable, Sendable {
             return .idempotency
 
             // Testability / PBT-readiness Rules
-        case .globalMutableState:
+        case .globalMutableState, .pureFunctionCandidate:
             return .testability
 
             // Other/System Rules

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/Testability.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/Testability.swift
@@ -21,6 +21,16 @@ class Testability: BasePatternRegistrar {
                     + "the test can construct fresh.",
                 description: "Detects stored top-level `var` and `static var` declarations, which "
                     + "defeat property-based-test isolation."
+            ),
+            SyntaxPattern(
+                name: .pureFunctionCandidate,
+                visitor: PureFunctionCandidateVisitor.self,
+                severity: .info,
+                category: .testability,
+                messageTemplate: "Looks pure and total — a good property-based-test candidate",
+                suggestion: "Run `swift-infer discover` on it, or add a PropertyLawKit test.",
+                description: "Surfaces free / `static` functions that take inputs, return a value, "
+                    + "aren't async, and show no obvious impurity — the seeds for the PBT pipeline."
             )
         ]
         registry.register(patterns: patterns)

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/PureFunctionCandidateVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/PureFunctionCandidateVisitor.swift
@@ -1,0 +1,82 @@
+import Foundation
+import SwiftProjectLintModels
+import SwiftProjectLintRegistry
+import SwiftProjectLintVisitors
+import SwiftSyntax
+
+/// The positive testability signal: surfaces free / `static` functions that
+/// look pure and total — they take parameters, return a value, aren't `async`,
+/// and their body shows no obvious impurity (no I/O, logging, randomness, or
+/// global access). These are the low-hanging fruit for property-based testing,
+/// and the seed the lint → infer → verify pipeline (Idea #2) hands to
+/// `swift-infer`.
+///
+/// Conservative by design — it under-suggests rather than flag an impure
+/// function. `info` severity; opt-in.
+final class PureFunctionCandidateVisitor: BasePatternVisitor {
+
+    private var fileIsTestOrFixture = false
+
+    /// Strong impurity markers — any in the body disqualifies the function.
+    private static let impureMarkers: Set<String> = [
+        "print", "NSLog", "FileManager", "URLSession", "UserDefaults",
+        "NotificationCenter", "DispatchQueue",
+        "arc4random", "arc4random_uniform", "drand48",
+        "random", "randomElement", "shuffled"
+    ]
+
+    required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
+        super.init(pattern: pattern, viewMode: viewMode)
+    }
+
+    override func setFilePath(_ filePath: String) {
+        super.setFilePath(filePath)
+        fileIsTestOrFixture = isTestOrFixtureFile()
+    }
+
+    override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard !fileIsTestOrFixture, let body = node.body else { return .visitChildren }
+        // Free or `static` only — instance methods can read mutable `self`.
+        guard isStatic(node) || isFileScope(node) else { return .visitChildren }
+        // Must take inputs and return a value, and run synchronously.
+        guard !node.signature.parameterClause.parameters.isEmpty else { return .visitChildren }
+        guard hasNonVoidReturn(node.signature) else { return .visitChildren }
+        guard node.signature.effectSpecifiers?.asyncSpecifier == nil else { return .visitChildren }
+        guard !bodyLooksImpure(body) else { return .visitChildren }
+
+        addIssue(
+            severity: .info,
+            message: "`\(node.name.text)(…)` looks pure and total — a good property-based-test "
+                + "candidate (a function of its inputs)",
+            filePath: getFilePath(for: Syntax(node)),
+            lineNumber: getLineNumber(for: Syntax(node)),
+            suggestion: "Run `swift-infer discover` on it, or add a PropertyLawKit test that "
+                + "checks a law over generated inputs.",
+            ruleName: .pureFunctionCandidate
+        )
+        return .visitChildren
+    }
+
+    private func isStatic(_ node: FunctionDeclSyntax) -> Bool {
+        node.modifiers.contains { $0.name.tokenKind == .keyword(.static) }
+    }
+
+    private func isFileScope(_ node: FunctionDeclSyntax) -> Bool {
+        guard let item = node.parent?.as(CodeBlockItemSyntax.self),
+              let list = item.parent?.as(CodeBlockItemListSyntax.self) else {
+            return false
+        }
+        return list.parent?.is(SourceFileSyntax.self) == true
+    }
+
+    private func hasNonVoidReturn(_ signature: FunctionSignatureSyntax) -> Bool {
+        guard let returnType = signature.returnClause?.type.trimmedDescription else {
+            return false
+        }
+        return returnType != "Void" && returnType != "()"
+    }
+
+    private func bodyLooksImpure(_ body: CodeBlockSyntax) -> Bool {
+        body.tokens(viewMode: .sourceAccurate).contains { Self.impureMarkers.contains($0.text) }
+    }
+}

--- a/Tests/CoreTests/Testability/PureFunctionCandidateVisitorTests.swift
+++ b/Tests/CoreTests/Testability/PureFunctionCandidateVisitorTests.swift
@@ -1,0 +1,72 @@
+@testable import Core
+import Foundation
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+@Suite
+struct PureFunctionCandidateVisitorTests {
+
+    private func analyze(_ source: String, filePath: String = "Logic.swift") -> [LintIssue] {
+        let visitor = PureFunctionCandidateVisitor(patternCategory: .testability)
+        let syntax = Parser.parse(source: source)
+        let converter = SourceLocationConverter(fileName: filePath, tree: syntax)
+        visitor.setSourceLocationConverter(converter)
+        visitor.setFilePath(filePath)
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == .pureFunctionCandidate }
+    }
+
+    @Test func flagsFreePureFunction() throws {
+        let issue = try #require(analyze("func add(_ a: Int, _ b: Int) -> Int { a + b }").first)
+        #expect(issue.severity == .info)
+        #expect(issue.message.contains("add"))
+    }
+
+    @Test func flagsStaticPureFunction() {
+        let source = """
+        enum Math {
+            static func square(_ x: Int) -> Int { x * x }
+        }
+        """
+        #expect(analyze(source).count == 1)
+    }
+
+    // MARK: - Not candidates
+
+    @Test func ignoresVoidReturn() {
+        #expect(analyze("func log(_ x: Int) { }").isEmpty)
+    }
+
+    @Test func ignoresNoParameters() {
+        #expect(analyze("func make() -> Int { 42 }").isEmpty)
+    }
+
+    @Test func ignoresAsync() {
+        #expect(analyze("func load(_ id: Int) async -> Int { id }").isEmpty)
+    }
+
+    @Test func ignoresImpureBody() {
+        // print is an impurity marker.
+        #expect(analyze("func add(_ a: Int, _ b: Int) -> Int { print(a); return a + b }").isEmpty)
+    }
+
+    @Test func ignoresRandomness() {
+        #expect(analyze("func roll(_ n: Int) -> Int { Int.random(in: 0...n) }").isEmpty)
+    }
+
+    @Test func ignoresInstanceMethod() {
+        // Instance methods can read mutable self — not a clean candidate.
+        let source = """
+        struct Calc {
+            func add(_ a: Int, _ b: Int) -> Int { a + b }
+        }
+        """
+        #expect(analyze(source).isEmpty)
+    }
+
+    @Test func ignoresTestFiles() {
+        #expect(analyze("func add(_ a: Int, _ b: Int) -> Int { a + b }", filePath: "MathTests.swift").isEmpty)
+    }
+}


### PR DESCRIPTION
Reopened against `main` (the original #38 was auto-closed when its base slice branch was deleted on #36's merge).

The **positive** testability signal and the seam to the lint → infer → verify pipeline: surfaces free / `static` functions that look pure and total (≥1 param, non-`Void` return, not `async`, body shows no I/O / logging / randomness markers). These are the seeds `swift-infer` will consume. Conservative by design; `info` severity; instance methods, Void/no-arg/async functions, and test files excluded. 9 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)