### PR TITLE
Missing Equatable on State Type testability rule

### DIFF
--- a/Docs/rules/RULES.md
+++ b/Docs/rules/RULES.md
@@ -248,6 +248,7 @@ Rules marked **opt-in** are disabled by default and must be explicitly listed un
 | [Global Mutable State](global-mutable-state.md) | Warning |
 | [Non-Injected Nondeterminism](non-injected-nondeterminism.md) | Warning |
 | [Pure Function Property-Test Candidate](pure-function-candidate.md) | Info |
+| [Missing Equatable on State Type](missing-equatable-on-state-type.md) | Info |
 
 ---
 

--- a/Docs/rules/missing-equatable-on-state-type.md
+++ b/Docs/rules/missing-equatable-on-state-type.md
@@ -1,0 +1,63 @@
+[← Back to Rules](RULES.md)
+
+## Missing Equatable on State Type
+
+**Identifier:** `Missing Equatable on State Type`
+**Category:** Testability
+**Severity:** Info
+
+### Rationale
+Property-based testing asserts on values and shrinks failing cases by comparing them — both require `Equatable`. A value type held in SwiftUI state (`@State`, `@Binding`, `@Published`) that conforms to neither `Equatable` nor `Hashable` therefore can't be a property-test subject: you can't write `#expect(reduce(state, action) == expected)` over generated inputs, and a shrinker can't tell two candidate states apart. Adding the conformance — which the compiler synthesizes for a `struct`/`enum` whose members are themselves `Equatable` — turns untestable view state into a direct SwiftPropertyLaws target.
+
+### Discussion
+`MissingEquatableOnStateTypeVisitor` is a **cross-file** rule (it runs after the whole project is parsed). In one pass it records every `struct`/`enum` declaration and the conformances it declares — both inline (`struct Foo: Equatable`) and via a separate `extension Foo: Equatable {}` in any file — and the value types used in `@State` / `@Binding` / `@Published`. It then emits one issue, at the type's declaration, for each value type used in state that declares neither `Equatable` nor `Hashable` (the latter refines the former, so either satisfies the rule).
+
+Reference-type wrappers (`@StateObject`, `@ObservedObject`, `@EnvironmentObject`) are excluded — they wrap `ObservableObject` classes, where identity rather than value equality is the model. The rule is conservative: a type whose declaration is in another module isn't flagged, since its conformances can't be seen from the scanned sources.
+
+```swift
+// Before — flagged: Settings is held in @State but isn't Equatable
+struct Settings {
+    var volume: Int
+}
+struct ContentView: View {
+    @State private var settings: Settings
+}
+
+// After — synthesized Equatable makes Settings a property-test subject
+struct Settings: Equatable {
+    var volume: Int
+}
+```
+
+### Non-Violating Examples
+```swift
+// Declares Equatable inline
+struct Settings: Equatable { var volume: Int }
+
+// Hashable refines Equatable — also fine
+struct Filter: Hashable { var query: String }
+
+// Conformance added in a separate file / extension is seen (cross-file)
+struct Theme { var accent: Int }
+extension Theme: Equatable {}
+
+// Stdlib state types are already Equatable
+struct V: View { @State var count: Int = 0 }
+
+// Reference-type wrappers are out of scope
+final class Store: ObservableObject {}
+struct W: View { @StateObject var store = Store() }
+```
+
+### Violating Examples
+```swift
+// Non-Equatable struct in @State
+struct DraftPost { var title: String; var body: String }
+struct Editor: View { @State var draft: DraftPost }
+
+// Non-Equatable enum behind @Published
+enum LoadState { case idle, loading, loaded }
+final class Model: ObservableObject { @Published var state: LoadState = .idle }
+```
+
+---

--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
@@ -217,6 +217,7 @@ public enum RuleIdentifier: String, CaseIterable, Codable, Sendable {
     case globalMutableState = "Global Mutable State"
     case nonInjectedNondeterminism = "Non-Injected Nondeterminism"
     case pureFunctionCandidate = "Pure Function Property-Test Candidate"
+    case missingEquatableOnStateType = "Missing Equatable on State Type"
 
     // Other/System Rules
     case fileParsingError = "File Parsing Error"
@@ -347,7 +348,8 @@ public enum RuleIdentifier: String, CaseIterable, Codable, Sendable {
             return .idempotency
 
             // Testability / PBT-readiness Rules
-        case .globalMutableState, .nonInjectedNondeterminism, .pureFunctionCandidate:
+        case .globalMutableState, .nonInjectedNondeterminism, .pureFunctionCandidate,
+             .missingEquatableOnStateType:
             return .testability
 
             // Other/System Rules

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/MissingEquatableOnStateType.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/MissingEquatableOnStateType.swift
@@ -1,0 +1,28 @@
+import Foundation
+import SwiftProjectLintModels
+import SwiftProjectLintRegistry
+import SwiftProjectLintVisitors
+
+/// Registrar for the Missing Equatable on State Type rule.
+///
+/// A cross-file rule: flags a project value type used in SwiftUI state
+/// (`@State` / `@Binding` / `@Published`) that conforms to neither `Equatable`
+/// nor `Hashable` anywhere in the project — the conformance that would make its
+/// state a property-test subject.
+struct MissingEquatableOnStateType: PatternRegistrarProtocol {
+
+    var pattern: SyntaxPattern {
+        SyntaxPattern(
+            name: .missingEquatableOnStateType,
+            visitor: MissingEquatableOnStateTypeVisitor.self,
+            severity: .info,
+            category: .testability,
+            messageTemplate: "Value type held in SwiftUI state conforms to neither Equatable "
+                + "nor Hashable, so it can't be a property-test subject.",
+            suggestion: "Add `Equatable` (or `Hashable`) so the state can be asserted on and "
+                + "shrunk by property-based tests.",
+            description: "Detects value types used in @State / @Binding / @Published that lack "
+                + "an Equatable/Hashable conformance anywhere in the project."
+        )
+    }
+}

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/Testability.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/Testability.swift
@@ -46,5 +46,10 @@ class Testability: BasePatternRegistrar {
             )
         ]
         registry.register(patterns: patterns)
+
+        // Cross-file rules get their own single-purpose leaf registrars.
+        registry.register(registrars: [
+            MissingEquatableOnStateType()
+        ])
     }
 }

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/MissingEquatableOnStateTypeVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/MissingEquatableOnStateTypeVisitor.swift
@@ -1,0 +1,194 @@
+import Foundation
+import SwiftProjectLintModels
+import SwiftProjectLintRegistry
+import SwiftProjectLintVisitors
+import SwiftSyntax
+
+/// Cross-file visitor: flags a project value type (`struct`/`enum`) that is held
+/// in SwiftUI state (`@State` / `@Binding` / `@Published`) but conforms to
+/// neither `Equatable` nor `Hashable` anywhere in the project.
+///
+/// Why it matters for the pipeline: an `Equatable` state type is a direct
+/// SwiftPropertyLaws target — equality is the precondition for property-test
+/// assertions and shrinking. Surfacing the gap turns "untestable view state"
+/// into "one conformance away from property-testable."
+///
+/// **Phase 1 (walk):** record every `struct`/`enum` declaration site, union the
+/// conformances it declares — inline *and* via a separate `extension Foo:
+/// Equatable {}` — and record the value types used in state property wrappers.
+/// **Phase 2 (`finalizeAnalysis`):** emit one issue per value type that is used
+/// in state yet declares neither `Equatable` nor `Hashable`.
+///
+/// Conservative by design (`info`): a type whose declaration isn't in the scanned
+/// project (another module) is never flagged, since its conformances can't be
+/// seen.
+final class MissingEquatableOnStateTypeVisitor: CrossFileVisitorBase, CrossFilePatternVisitorProtocol {
+
+    /// Property wrappers that carry a *value* type worth making `Equatable`.
+    /// Reference-type wrappers (`@StateObject`, `@ObservedObject`,
+    /// `@EnvironmentObject`) are excluded — they wrap `ObservableObject`
+    /// classes, where identity, not value equality, is the model.
+    private static let valueStateWrappers: Set<String> = ["State", "Binding", "Published"]
+
+    /// Conformances that make a value type usable as a property-test subject.
+    /// `Hashable` refines `Equatable`, so either satisfies the rule.
+    private static let equatableConformances: Set<String> = ["Equatable", "Hashable"]
+
+    private struct Declaration {
+        let file: String
+        let line: Int
+    }
+
+    /// Value-type name → its declaration site (first one wins; partial-type
+    /// re-declarations are rare and a single actionable location is enough).
+    private var valueTypeDecls: [String: Declaration] = [:]
+    /// Type name → every conformance it declares, unioned across the primary
+    /// declaration and all `extension` blocks in any file.
+    private var declaredConformances: [String: Set<String>] = [:]
+    /// Base nominal names of value types observed in a state property wrapper.
+    private var stateUsedTypes: Set<String> = []
+
+    // MARK: - Phase 1: collect
+
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        recordValueType(node.name.text, node.inheritanceClause, Syntax(node))
+        return .visitChildren
+    }
+
+    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+        recordValueType(node.name.text, node.inheritanceClause, Syntax(node))
+        return .visitChildren
+    }
+
+    override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+        // A conformance can be added away from the declaration:
+        // `extension Foo: Equatable {}`. Union it in; we don't yet know whether
+        // `Foo` is a value type, so just accumulate — the finalize step only
+        // consults conformances for names that turned out to be value types.
+        if let name = extendedTypeName(node.extendedType) {
+            mergeConformances(of: name, from: node.inheritanceClause)
+        }
+        return .visitChildren
+    }
+
+    override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard let wrapper = stateWrapperName(node.attributes),
+              Self.valueStateWrappers.contains(wrapper) else {
+            return .visitChildren
+        }
+        for binding in node.bindings {
+            if let name = stateValueTypeName(binding) {
+                stateUsedTypes.insert(name)
+            }
+        }
+        return .visitChildren
+    }
+
+    private func recordValueType(
+        _ name: String,
+        _ inheritance: InheritanceClauseSyntax?,
+        _ node: Syntax
+    ) {
+        if valueTypeDecls[name] == nil {
+            valueTypeDecls[name] = Declaration(file: currentFilePath, line: getLineNumber(for: node))
+        }
+        mergeConformances(of: name, from: inheritance)
+    }
+
+    private func mergeConformances(of name: String, from inheritance: InheritanceClauseSyntax?) {
+        guard let inheritance else { return }
+        for inherited in inheritance.inheritedTypes {
+            if let conformance = conformanceName(inherited.type) {
+                declaredConformances[name, default: []].insert(conformance)
+            }
+        }
+    }
+
+    // MARK: - Phase 2: emit
+
+    func finalizeAnalysis() {
+        for name in stateUsedTypes.sorted() {
+            guard let declaration = valueTypeDecls[name] else { continue } // external type → can't judge
+            let conformances = declaredConformances[name] ?? []
+            guard conformances.isDisjoint(with: Self.equatableConformances) else { continue }
+
+            addIssue(
+                severity: .info,
+                message: "'\(name)' is held in SwiftUI state but conforms to neither Equatable "
+                    + "nor Hashable, so it can't be a property-test subject",
+                filePath: declaration.file,
+                lineNumber: declaration.line,
+                suggestion: "Add `Equatable` (or `Hashable`) to '\(name)' so its state can be "
+                    + "asserted on and shrunk by property-based tests.",
+                ruleName: .missingEquatableOnStateType
+            )
+        }
+    }
+
+    // MARK: - Syntax helpers
+
+    /// The simple name of a property wrapper attribute, e.g. `@State` → `"State"`.
+    private func stateWrapperName(_ attributes: AttributeListSyntax) -> String? {
+        for attribute in attributes {
+            if let attributeSyntax = attribute.as(AttributeSyntax.self),
+               let name = attributeSyntax.attributeName.as(IdentifierTypeSyntax.self)?.name.text {
+                return name
+            }
+        }
+        return nil
+    }
+
+    /// The base nominal type a state binding carries, from its annotation
+    /// (`: Foo`, `: Foo?`, `: [Foo]`) or, lacking one, a simple initializer
+    /// (`= Foo()`). Returns `nil` for closures, tuples, and anything without a
+    /// resolvable nominal base.
+    private func stateValueTypeName(_ binding: PatternBindingSyntax) -> String? {
+        if let annotated = binding.typeAnnotation?.type {
+            return baseTypeName(annotated)
+        }
+        if let call = binding.initializer?.value.as(FunctionCallExprSyntax.self),
+           let callee = call.calledExpression.as(DeclReferenceExprSyntax.self) {
+            return callee.baseName.text
+        }
+        return nil
+    }
+
+    /// Unwraps optionals and arrays to the underlying nominal name: `Foo?` →
+    /// `Foo`, `[Foo]` → `Foo`, `Foo<Bar>` → `Foo`.
+    private func baseTypeName(_ type: TypeSyntax) -> String? {
+        if let optional = type.as(OptionalTypeSyntax.self) {
+            return baseTypeName(optional.wrappedType)
+        }
+        if let implicit = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
+            return baseTypeName(implicit.wrappedType)
+        }
+        if let array = type.as(ArrayTypeSyntax.self) {
+            return baseTypeName(array.element)
+        }
+        if let identifier = type.as(IdentifierTypeSyntax.self) {
+            return identifier.name.text
+        }
+        return nil
+    }
+
+    /// The simple name of a conformance, unwrapping attributes so
+    /// `@retroactive Equatable` resolves to `Equatable`.
+    private func conformanceName(_ type: TypeSyntax) -> String? {
+        if let attributed = type.as(AttributedTypeSyntax.self) {
+            return conformanceName(attributed.baseType)
+        }
+        return type.as(IdentifierTypeSyntax.self)?.name.text
+    }
+
+    /// The simple name of an extended type: `extension Foo` → `Foo`,
+    /// `extension Outer.Inner` → `Inner`.
+    private func extendedTypeName(_ type: TypeSyntax) -> String? {
+        if let identifier = type.as(IdentifierTypeSyntax.self) {
+            return identifier.name.text
+        }
+        if let member = type.as(MemberTypeSyntax.self) {
+            return member.name.text
+        }
+        return nil
+    }
+}

--- a/Tests/CoreTests/CrossFileAnalysis/MissingEquatableOnStateTypeVisitorTests.swift
+++ b/Tests/CoreTests/CrossFileAnalysis/MissingEquatableOnStateTypeVisitorTests.swift
@@ -1,0 +1,199 @@
+@testable import Core
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+@Suite
+struct MissingEquatableOnStateTypeVisitorTests {
+
+    private func analyze(files: [String: String]) -> [LintIssue] {
+        var cache: [String: SourceFileSyntax] = [:]
+        for (name, source) in files {
+            cache[name] = Parser.parse(source: source)
+        }
+        let pattern = MissingEquatableOnStateType().pattern
+        let visitor = MissingEquatableOnStateTypeVisitor(fileCache: cache)
+        visitor.setPattern(pattern)
+
+        for (name, ast) in cache {
+            visitor.setFilePath(name)
+            visitor.setSourceLocationConverter(SourceLocationConverter(fileName: name, tree: ast))
+            visitor.walk(ast)
+        }
+        visitor.finalizeAnalysis()
+        return visitor.detectedIssues.filter { $0.ruleName == .missingEquatableOnStateType }
+    }
+
+    @Test
+    func flagsNonEquatableStateType() {
+        let issues = analyze(files: [
+            "Source.swift": """
+            struct Settings {
+                var volume: Int
+            }
+            struct ContentView {
+                @State private var settings: Settings
+            }
+            """
+        ])
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("'Settings'") == true)
+    }
+
+    @Test
+    func ignoresEquatableStateType() {
+        let issues = analyze(files: [
+            "Source.swift": """
+            struct Settings: Equatable {
+                var volume: Int
+            }
+            struct ContentView {
+                @State private var settings: Settings
+            }
+            """
+        ])
+        #expect(issues.isEmpty)
+    }
+
+    @Test
+    func ignoresHashableStateType() {
+        let issues = analyze(files: [
+            "Source.swift": """
+            struct Settings: Hashable {
+                var volume: Int
+            }
+            struct ContentView {
+                @Binding var settings: Settings
+            }
+            """
+        ])
+        #expect(issues.isEmpty)
+    }
+
+    @Test
+    func seesEquatableAddedViaExtensionInAnotherFile() {
+        let issues = analyze(files: [
+            "Model.swift": """
+            struct Settings {
+                var volume: Int
+            }
+            """,
+            "Conformance.swift": """
+            extension Settings: Equatable {}
+            """,
+            "View.swift": """
+            struct ContentView {
+                @State var settings: Settings
+            }
+            """
+        ])
+        #expect(issues.isEmpty)
+    }
+
+    @Test
+    func flagsAcrossFilesWhenConformanceIsAbsent() {
+        let issues = analyze(files: [
+            "Model.swift": """
+            struct Settings {
+                var volume: Int
+            }
+            """,
+            "View.swift": """
+            struct ContentView {
+                @State var settings: Settings
+            }
+            """
+        ])
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("'Settings'") == true)
+    }
+
+    @Test
+    func flagsPublishedAndEnumStateTypes() {
+        let issues = analyze(files: [
+            "Source.swift": """
+            enum LoadState {
+                case idle
+                case loading
+            }
+            class ViewModel {
+                @Published var state: LoadState = .idle
+            }
+            """
+        ])
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("'LoadState'") == true)
+    }
+
+    @Test
+    func unwrapsOptionalAndArrayStateTypes() {
+        let issues = analyze(files: [
+            "Source.swift": """
+            struct Item {
+                var id: Int
+            }
+            struct ListView {
+                @State var selected: Item?
+                @State var items: [Item]
+            }
+            """
+        ])
+        // Both bindings reference the same non-Equatable `Item`; one issue at its decl.
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("'Item'") == true)
+    }
+
+    @Test
+    func ignoresExternalOrPrimitiveStateTypes() {
+        let issues = analyze(files: [
+            "Source.swift": """
+            struct ContentView {
+                @State var count: Int
+                @State var name: String
+                @State var external: SomeThirdPartyType
+            }
+            """
+        ])
+        // Int/String are Equatable stdlib types; SomeThirdPartyType isn't declared
+        // in the project, so it can't be judged. No flags.
+        #expect(issues.isEmpty)
+    }
+
+    @Test
+    func ignoresReferenceWrappers() {
+        let issues = analyze(files: [
+            "Source.swift": """
+            struct Model {
+                var x: Int
+            }
+            struct ContentView {
+                @StateObject var model: Model
+                @ObservedObject var other: Model
+            }
+            """
+        ])
+        // @StateObject / @ObservedObject wrap reference types; not in scope.
+        #expect(issues.isEmpty)
+    }
+
+    @Test
+    func emitsOneIssuePerTypeNotPerUsage() {
+        let issues = analyze(files: [
+            "A.swift": """
+            struct Shared {
+                var v: Int
+            }
+            struct ViewA {
+                @State var shared: Shared
+            }
+            """,
+            "B.swift": """
+            struct ViewB {
+                @Binding var shared: Shared
+            }
+            """
+        ])
+        #expect(issues.count == 1)
+    }
+}


### PR DESCRIPTION
The fourth `.testability` rule and the most pipeline-aligned of the remaining set: it **expands the property-testable surface** by surfacing view-state value types that are one conformance away from being SwiftPropertyLaws targets.

## What it flags (cross-file, info)
A project `struct`/`enum` that is:
- held in `@State` / `@Binding` / `@Published`, and
- conforms to **neither `Equatable` nor `Hashable`** anywhere in the project.

```swift
struct DraftPost { var title: String; var body: String }   // ⚠ used in @State, not Equatable
struct Editor: View { @State var draft: DraftPost }
```

Equality is the precondition for property-test assertions (`#expect(reduce(s, a) == expected)`) and shrinking — without it, the state can't be a test subject.

## How it works
A cross-file visitor (same machinery as `DuplicateStructShape`). One walk collects:
- every `struct`/`enum` decl + the conformances it declares — **inline and via a separate `extension Foo: Equatable {}` in any file**, and
- the value types used in the three value-semantic state wrappers.

`finalizeAnalysis()` emits one issue **per type, at its declaration** (not per usage).

## Deliberately conservative
- Reference-type wrappers (`@StateObject`/`@ObservedObject`/`@EnvironmentObject`) are excluded — identity, not value equality, is their model.
- A type declared in **another module** is never flagged (its conformances aren't visible). `info` severity keeps the cost of any residual false positive low.

## Tests / docs
10 visitor tests (cross-file extension conformance, optional/array unwrapping, enum + `@Published`, one-issue-per-type, reference-wrapper exclusion, external/primitive exclusion). Bundled `Docs/rules/missing-equatable-on-state-type.md` + `RULES.md` entry included so the AppTests doc-coverage contract stays green on merge. Full suite green locally (CoreTests 2458, AppTests 184, CLITests 49).

🤖 Generated with [Claude Code](https://claude.com/claude-code)