### PR TITLE
Harden Pure Function Candidate: totality + Equatable-return gating

### DIFF
--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
@@ -114,6 +114,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         let localTypes = Self.collectTypes(LocalTypeCollector.self, from: filePaths)
         let observableTypes = Self.collectTypes(ObservableTypeCollector.self, from: filePaths)
         let protocolTypes = Self.collectTypes(ProtocolTypeCollector.self, from: filePaths)
+        let equatableTypes = Self.collectTypes(EquatableConformanceCollector.self, from: filePaths)
 
         // Resolve the registry once so each task can create its own detector
         var resolvedDetector = detector ?? SourcePatternDetector()
@@ -123,6 +124,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         resolvedDetector.knownLocalTypeNames = localTypes
         resolvedDetector.knownObservableTypes = observableTypes
         resolvedDetector.knownProtocolTypes = protocolTypes
+        resolvedDetector.knownEquatableTypes = equatableTypes
         resolvedDetector.layerPolicies = effectiveConfiguration.architecturalLayers
         resolvedDetector.enabledFrameworkAllowlists =
             effectiveConfiguration.enabledFrameworkAllowlists
@@ -141,6 +143,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
             localTypes: localTypes,
             observableTypes: observableTypes,
             protocolTypes: protocolTypes,
+            equatableTypes: equatableTypes,
             layerPolicies: effectiveConfiguration.architecturalLayers
         )
         let perFileResults = await withTaskGroup(
@@ -324,6 +327,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         let localTypes: Set<String>
         let observableTypes: Set<String>
         let protocolTypes: Set<String>
+        let equatableTypes: Set<String>
         let layerPolicies: [LayerPolicy]
     }
 
@@ -345,6 +349,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
             localTypes: env.localTypes,
             observableTypes: env.observableTypes,
             protocolTypes: env.protocolTypes,
+            equatableTypes: env.equatableTypes,
             layerPolicies: env.layerPolicies
         )
     }
@@ -362,6 +367,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         localTypes: Set<String> = [],
         observableTypes: Set<String> = [],
         protocolTypes: Set<String> = [],
+        equatableTypes: Set<String> = [],
         layerPolicies: [LayerPolicy] = []
     ) -> (file: ProjectFile, issues: [LintIssue], parsedAST: SourceFileSyntax)? {
         guard !Task.isCancelled else { return nil }
@@ -382,6 +388,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         det.knownLocalTypeNames = localTypes
         det.knownObservableTypes = observableTypes
         det.knownProtocolTypes = protocolTypes
+        det.knownEquatableTypes = equatableTypes
         det.layerPolicies = layerPolicies
 
         let rawIssues: [LintIssue]

--- a/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetector.swift
+++ b/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetector.swift
@@ -32,6 +32,10 @@ public final class SourcePatternDetector: SourcePatternDetectorProtocol, @unchec
     /// Set by `ProjectLinter` after a pre-scan phase and passed through to visitors.
     public var knownProtocolTypes: Set<String> = []
 
+    /// Type names known to be `Equatable` across the project. Set by
+    /// `ProjectLinter` after a pre-scan phase and passed through to visitors.
+    public var knownEquatableTypes: Set<String> = []
+
     /// Architectural layer policies, set from `LintConfiguration.architecturalLayers`.
     /// Passed through to visitors that need them (e.g. ArchitecturalBoundaryVisitor).
     public var layerPolicies: [LayerPolicy] = []
@@ -166,6 +170,7 @@ public final class SourcePatternDetector: SourcePatternDetectorProtocol, @unchec
             visitor.knownLocalTypeNames = knownLocalTypeNames
             visitor.knownObservableTypes = knownObservableTypes
             visitor.knownProtocolTypes = knownProtocolTypes
+            visitor.knownEquatableTypes = knownEquatableTypes
             visitor.layerPolicies = layerPolicies
             visitor.enabledFrameworkAllowlists = enabledFrameworkAllowlists
             visitor.walk(sourceFile)

--- a/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetectorProtocol.swift
+++ b/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetectorProtocol.swift
@@ -35,6 +35,10 @@ public protocol SourcePatternDetectorProtocol {
     /// Type names known to be declared as protocols across the project.
     var knownProtocolTypes: Set<String> { get set }
 
+    /// Type names known to be `Equatable` across the project (Equatable /
+    /// Hashable / Comparable, declared inline or via an extension).
+    var knownEquatableTypes: Set<String> { get set }
+
     /// Architectural layer policies for the Architectural Boundary rule.
     var layerPolicies: [LayerPolicy] { get set }
 

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/PureFunctionCandidateVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/PureFunctionCandidateVisitor.swift
@@ -35,18 +35,7 @@ final class PureFunctionCandidateVisitor: BasePatternVisitor {
     }
 
     override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
-        guard !fileIsTestOrFixture, let body = node.body else { return .visitChildren }
-        // Free or `static` only — instance methods can read mutable `self`.
-        guard isStatic(node) || isFileScope(node) else { return .visitChildren }
-        // Must take inputs and return a value, and run synchronously.
-        guard !node.signature.parameterClause.parameters.isEmpty else { return .visitChildren }
-        guard hasNonVoidReturn(node.signature) else { return .visitChildren }
-        guard node.signature.effectSpecifiers?.asyncSpecifier == nil else { return .visitChildren }
-        // Total: a `throws` function (or one whose body can trap) isn't a function
-        // of its inputs alone — there are inputs for which it has no return value.
-        guard node.signature.effectSpecifiers?.throwsClause == nil else { return .visitChildren }
-        guard !bodyLooksImpure(body) else { return .visitChildren }
-        guard bodyIsTotal(body) else { return .visitChildren }
+        guard let body = node.body, isCandidate(node, body: body) else { return .visitChildren }
 
         addIssue(
             severity: .info,
@@ -60,6 +49,31 @@ final class PureFunctionCandidateVisitor: BasePatternVisitor {
             symbol: node.name.text
         )
         return .visitChildren
+    }
+
+    /// A function is a candidate when it is free/`static`, takes inputs, is total
+    /// (synchronous, non-throwing, no trapping body, no impurity), and returns an
+    /// `Equatable` value. Split into grouped predicates to keep each one simple.
+    private func isCandidate(_ node: FunctionDeclSyntax, body: CodeBlockSyntax) -> Bool {
+        guard !fileIsTestOrFixture else { return false }
+        // Free or `static` only — instance methods can read mutable `self`.
+        guard isStatic(node) || isFileScope(node) else { return false }
+        return signatureQualifies(node.signature) && bodyQualifies(body)
+    }
+
+    /// Takes inputs, returns an `Equatable` value, and is synchronous + total at
+    /// the signature level (no `async`, no `throws`).
+    private func signatureQualifies(_ signature: FunctionSignatureSyntax) -> Bool {
+        !signature.parameterClause.parameters.isEmpty
+            && hasNonVoidReturn(signature)
+            && signature.effectSpecifiers?.asyncSpecifier == nil
+            && signature.effectSpecifiers?.throwsClause == nil
+            && returnTypeIsEquatable(signature)
+    }
+
+    /// The body shows no impurity and can't trap (is total).
+    private func bodyQualifies(_ body: CodeBlockSyntax) -> Bool {
+        !bodyLooksImpure(body) && bodyIsTotal(body)
     }
 
     private func isStatic(_ node: FunctionDeclSyntax) -> Bool {
@@ -79,6 +93,54 @@ final class PureFunctionCandidateVisitor: BasePatternVisitor {
             return false
         }
         return returnType != "Void" && returnType != "()"
+    }
+
+    /// Standard-library types whose values are `Equatable` out of the box. The
+    /// container names (`Array`, `Set`, …) are `Equatable` when their elements
+    /// are; `baseTypeName` unwraps `[T]` to `T` so a custom element is still
+    /// checked against the project's conformance index.
+    private static let equatableStdlibTypes: Set<String> = [
+        "Int", "Int8", "Int16", "Int32", "Int64",
+        "UInt", "UInt8", "UInt16", "UInt32", "UInt64",
+        "Double", "Float", "Float16", "CGFloat", "Decimal",
+        "Bool", "String", "Character", "Substring", "StaticString",
+        "Date", "UUID", "URL", "Data", "TimeInterval",
+        "Array", "Set", "Dictionary", "Range", "ClosedRange"
+    ]
+
+    /// True when the return type can be compared for equality — a stdlib
+    /// `Equatable` type, or a project type the pre-scan found declaring
+    /// `Equatable`/`Hashable`/`Comparable`. Tuples and closures (no nominal
+    /// base) are treated as non-assertable and drop the candidate.
+    private func returnTypeIsEquatable(_ signature: FunctionSignatureSyntax) -> Bool {
+        guard let returnType = signature.returnClause?.type,
+              let base = baseTypeName(returnType) else {
+            return false
+        }
+        return Self.equatableStdlibTypes.contains(base) || knownEquatableTypes.contains(base)
+    }
+
+    /// The underlying nominal name of a type, unwrapping optionals and arrays:
+    /// `Foo?` → `Foo`, `[Foo]` → `Foo`, `Foo<Bar>` → `Foo`. `[K: V]` resolves to
+    /// `Dictionary`. Returns `nil` for tuples, closures, and other non-nominal
+    /// types.
+    private func baseTypeName(_ type: TypeSyntax) -> String? {
+        if let optional = type.as(OptionalTypeSyntax.self) {
+            return baseTypeName(optional.wrappedType)
+        }
+        if let implicit = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
+            return baseTypeName(implicit.wrappedType)
+        }
+        if let array = type.as(ArrayTypeSyntax.self) {
+            return baseTypeName(array.element)
+        }
+        if type.is(DictionaryTypeSyntax.self) {
+            return "Dictionary"
+        }
+        if let identifier = type.as(IdentifierTypeSyntax.self) {
+            return identifier.name.text
+        }
+        return nil
     }
 
     private func bodyLooksImpure(_ body: CodeBlockSyntax) -> Bool {

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/PureFunctionCandidateVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/PureFunctionCandidateVisitor.swift
@@ -42,7 +42,11 @@ final class PureFunctionCandidateVisitor: BasePatternVisitor {
         guard !node.signature.parameterClause.parameters.isEmpty else { return .visitChildren }
         guard hasNonVoidReturn(node.signature) else { return .visitChildren }
         guard node.signature.effectSpecifiers?.asyncSpecifier == nil else { return .visitChildren }
+        // Total: a `throws` function (or one whose body can trap) isn't a function
+        // of its inputs alone — there are inputs for which it has no return value.
+        guard node.signature.effectSpecifiers?.throwsClause == nil else { return .visitChildren }
         guard !bodyLooksImpure(body) else { return .visitChildren }
+        guard bodyIsTotal(body) else { return .visitChildren }
 
         addIssue(
             severity: .info,
@@ -79,5 +83,61 @@ final class PureFunctionCandidateVisitor: BasePatternVisitor {
 
     private func bodyLooksImpure(_ body: CodeBlockSyntax) -> Bool {
         body.tokens(viewMode: .sourceAccurate).contains { Self.impureMarkers.contains($0.text) }
+    }
+
+    /// True when nothing in the body can trap (crash) at runtime — the property
+    /// that lets us treat the function as total. Force-unwrap (`!`), `try!`,
+    /// `as!`, and the `fatalError` / `precondition` / `assert` family all
+    /// introduce inputs for which there is no return value, so a property test
+    /// over generated inputs would hit a crash rather than a falsified law.
+    private func bodyIsTotal(_ body: CodeBlockSyntax) -> Bool {
+        let checker = TotalityChecker(viewMode: .sourceAccurate)
+        checker.walk(body)
+        return checker.isTotal
+    }
+}
+
+/// Walks a function body looking for any runtime trap that breaks totality.
+private final class TotalityChecker: SyntaxVisitor {
+
+    private(set) var isTotal = true
+
+    /// Standard-library trap functions: reaching them means the function has no
+    /// return value for some inputs.
+    private static let trapFunctions: Set<String> = [
+        "fatalError", "preconditionFailure", "precondition",
+        "assert", "assertionFailure"
+    ]
+
+    override func visit(_ node: ForceUnwrapExprSyntax) -> SyntaxVisitorContinueKind {
+        _ = node
+        isTotal = false
+        return .skipChildren
+    }
+
+    override func visit(_ node: TryExprSyntax) -> SyntaxVisitorContinueKind {
+        if node.questionOrExclamationMark?.text == "!" { isTotal = false }
+        return .visitChildren
+    }
+
+    override func visit(_ node: AsExprSyntax) -> SyntaxVisitorContinueKind {
+        if node.questionOrExclamationMark?.text == "!" { isTotal = false }
+        return .visitChildren
+    }
+
+    // Raw (unfolded) parse trees represent `x as! T` as an `UnresolvedAsExprSyntax`
+    // inside a `SequenceExprSyntax`; the folded `AsExprSyntax` form only appears
+    // after operator-precedence folding, which the linter doesn't run.
+    override func visit(_ node: UnresolvedAsExprSyntax) -> SyntaxVisitorContinueKind {
+        if node.questionOrExclamationMark?.text == "!" { isTotal = false }
+        return .visitChildren
+    }
+
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        if let callee = node.calledExpression.as(DeclReferenceExprSyntax.self)?.baseName.text,
+           Self.trapFunctions.contains(callee) {
+            isTotal = false
+        }
+        return .visitChildren
     }
 }

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/BasePatternVisitor.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/BasePatternVisitor.swift
@@ -57,6 +57,14 @@ open class BasePatternVisitor: SyntaxVisitor, PatternVisitorProtocol {
     /// not end in `Protocol`/`Type`/`Interface`.
     public var knownProtocolTypes: Set<String> = []
 
+    /// Type names known to be `Equatable` (declaring `Equatable`, `Hashable`, or
+    /// `Comparable`, inline or via an extension in any file). Populated by a
+    /// pre-scan phase in `ProjectLinter` so that per-file visitors can tell
+    /// whether a type's values can be compared — e.g. the Pure Function
+    /// Property-Test Candidate rule requires an `Equatable` return type so the
+    /// result can be asserted on by a property test.
+    public var knownEquatableTypes: Set<String> = []
+
     /// Architectural layer policies for the Architectural Boundary rule.
     /// Injected by `SourcePatternDetector` after loading from `LintConfiguration`.
     /// Empty by default — the rule is a no-op when no layers are defined.

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/EquatableConformanceCollector.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/EquatableConformanceCollector.swift
@@ -1,0 +1,80 @@
+import SwiftSyntax
+
+/// A project-wide pre-scan that collects the names of types known to be
+/// `Equatable` — i.e. those declaring `Equatable`, `Hashable`, or `Comparable`
+/// (each of the latter refines `Equatable`), whether inline
+/// (`struct Foo: Equatable`) or via a separate `extension Foo: Equatable {}` in
+/// any file.
+///
+/// Per-file visitors can't see conformances declared elsewhere, so this set is
+/// built once and injected. The Pure Function Property-Test Candidate rule uses
+/// it to gate seeds: a candidate is only useful to `swift-infer` if its result
+/// can be asserted on, which requires the return type to be `Equatable`.
+public final class EquatableConformanceCollector: SyntaxVisitor, TypeCollectorProtocol {
+
+    public var collectedTypes: Set<String> { equatableTypes }
+
+    private var equatableTypes: Set<String> = []
+
+    /// Conformances that make a type `Equatable`. `Hashable` and `Comparable`
+    /// both refine it, so declaring any one suffices.
+    private static let equatableConformances: Set<String> = ["Equatable", "Hashable", "Comparable"]
+
+    public init() {
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override public func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        record(node.name.text, node.inheritanceClause)
+        return .visitChildren
+    }
+
+    override public func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+        record(node.name.text, node.inheritanceClause)
+        return .visitChildren
+    }
+
+    override public func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+        record(node.name.text, node.inheritanceClause)
+        return .visitChildren
+    }
+
+    override public func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+        if let name = extendedTypeName(node.extendedType) {
+            record(name, node.inheritanceClause)
+        }
+        return .visitChildren
+    }
+
+    private func record(_ name: String, _ inheritance: InheritanceClauseSyntax?) {
+        guard let inheritance else { return }
+        for inherited in inheritance.inheritedTypes {
+            if let conformance = conformanceName(inherited.type),
+               Self.equatableConformances.contains(conformance) {
+                equatableTypes.insert(name)
+                return
+            }
+        }
+    }
+
+    /// The simple name of a conformance, unwrapping attributes so
+    /// `@retroactive Equatable` resolves to `Equatable`.
+    private func conformanceName(_ type: TypeSyntax) -> String? {
+        if let attributed = type.as(AttributedTypeSyntax.self) {
+            return conformanceName(attributed.baseType)
+        }
+        return type.as(IdentifierTypeSyntax.self)?.name.text
+    }
+
+    /// The simple name of an extended type: `extension Foo` → `Foo`,
+    /// `extension Outer.Inner` → `Inner`.
+    private func extendedTypeName(_ type: TypeSyntax) -> String? {
+        if let identifier = type.as(IdentifierTypeSyntax.self) {
+            return identifier.name.text
+        }
+        if let member = type.as(MemberTypeSyntax.self) {
+            return member.name.text
+        }
+        return nil
+    }
+}

--- a/Tests/CoreTests/EquatableConformanceCollectorTests.swift
+++ b/Tests/CoreTests/EquatableConformanceCollectorTests.swift
@@ -1,0 +1,58 @@
+@testable import Core
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftProjectLintVisitors
+import SwiftSyntax
+import Testing
+
+@Suite
+struct EquatableConformanceCollectorTests {
+
+    private func collect(from source: String) -> Set<String> {
+        let syntax = Parser.parse(source: source)
+        let collector = EquatableConformanceCollector()
+        collector.walk(syntax)
+        return collector.collectedTypes
+    }
+
+    @Test func collectsInlineEquatableStruct() {
+        #expect(collect(from: "struct Point: Equatable { var x: Int }") == ["Point"])
+    }
+
+    @Test func collectsHashableAndComparableAsEquatable() {
+        let source = """
+        struct A: Hashable { var x: Int }
+        struct B: Comparable { var y: Int }
+        """
+        #expect(collect(from: source) == ["A", "B"])
+    }
+
+    @Test func collectsEnumAndClassConformers() {
+        let source = """
+        enum E: Equatable { case a }
+        final class C: Equatable { static func == (l: C, r: C) -> Bool { true } }
+        """
+        #expect(collect(from: source) == ["E", "C"])
+    }
+
+    @Test func collectsConformanceAddedViaExtension() {
+        let source = """
+        struct Theme { var accent: Int }
+        extension Theme: Equatable {}
+        """
+        #expect(collect(from: source) == ["Theme"])
+    }
+
+    @Test func ignoresNonEquatableConformances() {
+        let source = """
+        struct Plain { var x: Int }
+        struct Coded: Codable { var y: Int }
+        protocol P: Sendable {}
+        """
+        #expect(collect(from: source).isEmpty)
+    }
+
+    @Test func collectsTypeWithMixedConformances() {
+        #expect(collect(from: "struct M: Codable, Equatable, Sendable { var x: Int }") == ["M"])
+    }
+}

--- a/Tests/CoreTests/Testability/PureFunctionCandidateVisitorTests.swift
+++ b/Tests/CoreTests/Testability/PureFunctionCandidateVisitorTests.swift
@@ -69,4 +69,46 @@ struct PureFunctionCandidateVisitorTests {
     @Test func ignoresTestFiles() {
         #expect(analyze("func add(_ a: Int, _ b: Int) -> Int { a + b }", filePath: "MathTests.swift").isEmpty)
     }
+
+    // MARK: - Totality (not a function of inputs alone if it can trap or throw)
+
+    @Test func ignoresThrowingFunction() {
+        #expect(analyze("func parse(_ s: String) throws -> Int { Int(s) ?? 0 }").isEmpty)
+    }
+
+    @Test func ignoresForceUnwrapInBody() {
+        #expect(analyze("func first(_ xs: [Int]) -> Int { xs.first! }").isEmpty)
+    }
+
+    @Test func ignoresForceTryInBody() {
+        let source = """
+        func decode(_ data: Data) -> Model {
+            try! JSONDecoder().decode(Model.self, from: data)
+        }
+        """
+        #expect(analyze(source).isEmpty)
+    }
+
+    @Test func ignoresForceCastInBody() {
+        #expect(analyze("func cast(_ x: Any) -> Int { x as! Int }").isEmpty)
+    }
+
+    @Test func ignoresFatalErrorInBody() {
+        let source = """
+        func pick(_ flag: Bool) -> Int {
+            if flag { return 1 }
+            fatalError("unreachable")
+        }
+        """
+        #expect(analyze(source).isEmpty)
+    }
+
+    @Test func ignoresPreconditionInBody() {
+        #expect(analyze("func half(_ x: Int) -> Int { precondition(x >= 0); return x / 2 }").isEmpty)
+    }
+
+    @Test func allowsOptionalChainingAndNilCoalescing() {
+        // `?.` and `??` are total — these stay candidates.
+        #expect(analyze("func len(_ s: String?) -> Int { s?.count ?? 0 }").count == 1)
+    }
 }

--- a/Tests/CoreTests/Testability/PureFunctionCandidateVisitorTests.swift
+++ b/Tests/CoreTests/Testability/PureFunctionCandidateVisitorTests.swift
@@ -8,8 +8,13 @@ import Testing
 @Suite
 struct PureFunctionCandidateVisitorTests {
 
-    private func analyze(_ source: String, filePath: String = "Logic.swift") -> [LintIssue] {
+    private func analyze(
+        _ source: String,
+        filePath: String = "Logic.swift",
+        equatableTypes: Set<String> = []
+    ) -> [LintIssue] {
         let visitor = PureFunctionCandidateVisitor(patternCategory: .testability)
+        visitor.knownEquatableTypes = equatableTypes
         let syntax = Parser.parse(source: source)
         let converter = SourceLocationConverter(fileName: filePath, tree: syntax)
         visitor.setSourceLocationConverter(converter)
@@ -110,5 +115,45 @@ struct PureFunctionCandidateVisitorTests {
     @Test func allowsOptionalChainingAndNilCoalescing() {
         // `?.` and `??` are total — these stay candidates.
         #expect(analyze("func len(_ s: String?) -> Int { s?.count ?? 0 }").count == 1)
+    }
+
+    // MARK: - Equatable return gate (a seed's result must be assertable)
+
+    @Test func keepsStdlibEquatableReturns() {
+        #expect(analyze("func flag(_ x: Int) -> Bool { x > 0 }").count == 1)
+        #expect(analyze("func name(_ x: Int) -> String { \"\\(x)\" }").count == 1)
+        #expect(analyze("func half(_ x: Int) -> Double { Double(x) / 2 }").count == 1)
+    }
+
+    @Test func keepsOptionalAndArrayOfEquatable() {
+        #expect(analyze("func maybe(_ x: Int) -> Int? { x > 0 ? x : nil }").count == 1)
+        #expect(analyze("func dupe(_ x: Int) -> [Int] { [x, x] }").count == 1)
+    }
+
+    @Test func dropsNonEquatableCustomReturn() {
+        // Widget isn't known-Equatable → result can't be asserted on → not a seed.
+        let source = """
+        struct Widget {}
+        func makeWidget(_ x: Int) -> Widget { Widget() }
+        """
+        #expect(analyze(source).isEmpty)
+    }
+
+    @Test func keepsCustomReturnWhenKnownEquatable() {
+        let source = "func makeWidget(_ x: Int) -> Widget { Widget(x) }"
+        #expect(analyze(source, equatableTypes: ["Widget"]).count == 1)
+    }
+
+    @Test func dropsCustomReturnArrayWhenElementNotEquatable() {
+        #expect(analyze("func widgets(_ n: Int) -> [Widget] { [] }").isEmpty)
+    }
+
+    @Test func keepsCustomReturnArrayWhenElementEquatable() {
+        #expect(analyze("func widgets(_ n: Int) -> [Widget] { [] }", equatableTypes: ["Widget"]).count == 1)
+    }
+
+    @Test func dropsTupleReturn() {
+        // A tuple has no nominal base to look up — treated as non-assertable.
+        #expect(analyze("func pair(_ x: Int) -> (Int, Int) { (x, x) }").isEmpty)
     }
 }


### PR DESCRIPTION
The "harden seeds" half of the Rule 4 + seed-precision direction. Two upgrades to the existing **Pure Function Property-Test Candidate** rule so the seeds it hands `swift-infer` are genuinely property-testable — fewer, higher-confidence seeds.

## 1. Totality (commit 1, purely syntactic)
A property test runs the candidate over generated inputs and expects a *falsified law*, not a crash. So a candidate must be total. New disqualifiers:
- `throws` in the signature, and
- a body that can trap: force-unwrap (`!`), `try!`, `as!`, or `fatalError` / `preconditionFailure` / `precondition` / `assert` / `assertionFailure`.

`?.` and `??` stay total, so optional-handling candidates still qualify. (`as!` is matched as `UnresolvedAsExprSyntax` — the raw, unfolded form — since the linter doesn't run operator folding.)

## 2. Equatable-return gating (commit 2, cross-file index)
A seed is only useful if the result can be **asserted on** — the return type must be `Equatable`.
- New `EquatableConformanceCollector` pre-scan (mirrors `ObservableTypeCollector`) collects types declaring `Equatable`/`Hashable`/`Comparable`, **inline or via `extension Foo: Equatable {}` in any file**.
- Threaded as `knownEquatableTypes` through the established channel (`BasePatternVisitor` → `SourcePatternDetector(Protocol)` → `ProjectLinter` pre-scan).
- A candidate is kept only when its return type is a stdlib `Equatable` type or a project type in the index. `[T]`/`T?` unwrap to `T`; tuples/closures drop.

```swift
struct Money: Equatable { let cents: Int }
struct Opaque { let raw: Int }
func addMoney(_ a: Money, _ b: Money) -> Money { … }   // ✅ seeded (Equatable return)
func wrap(_ x: Int) -> Opaque { … }                    // ⛔️ dropped (non-Equatable return)
```

## Why this composes with Rule 4 (#41)
Making a type `Equatable` both silences *Missing Equatable on State Type* **and** turns functions returning it into valid seeds — the two rules pull in the same direction (more property-testable surface).

## Verification
- 20 visitor tests (7 totality + 7 gating + originals) + 6 collector tests.
- Cross-binary e2e: `--format pbt-seeds` on a fixture excludes the non-Equatable-returning function and the trapping/throwing ones.
- Full suite green locally: CoreTests 2468, AppTests 184, CLITests 49 — the gating fires the rule *less* but shifted no integration counts.

Independent of #41 (different files), so it merges cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)