### PR TITLE
Non-Injected Nondeterminism: exempt injected using: RNG (dogfood fix)

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
@@ -73,6 +73,12 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
         // Member call: `Int.random(in:)`, `array.randomElement()`, `.shuffled()`.
         if let member = node.calledExpression.as(MemberAccessExprSyntax.self),
            Self.randomMembers.contains(member.declName.baseName.text) {
+            // A `using:` argument injects the RNG — `Int.random(in: r, using: &rng)`
+            // is reproducible from a seed, which is exactly the testable form. Only
+            // the system-RNG forms (no `using:`) are non-injected nondeterminism.
+            if node.arguments.contains(where: { $0.label?.text == "using" }) {
+                return nil
+            }
             return ".\(member.declName.baseName.text)(…)"
         }
         return nil

--- a/Tests/CoreTests/Testability/NonInjectedNondeterminismVisitorTests.swift
+++ b/Tests/CoreTests/Testability/NonInjectedNondeterminismVisitorTests.swift
@@ -72,4 +72,32 @@ struct NonInjectedNondeterminismVisitorTests {
         let source = "func roll() -> Int { Int.random(in: 1...6) }"
         #expect(analyze(source, filePath: "RollTests.swift").isEmpty)
     }
+
+    // MARK: - Injected RNG via `using:` is the testable form, not a finding
+
+    @Test func ignoresRandomWithInjectedRNG() {
+        let source = """
+        func roll(using rng: inout some RandomNumberGenerator) -> Int {
+            Int.random(in: 1...6, using: &rng)
+        }
+        """
+        #expect(analyze(source).isEmpty)
+    }
+
+    @Test func ignoresRandomElementAndShuffledWithInjectedRNG() {
+        let source = """
+        func pick(_ xs: [Int], using rng: inout some RandomNumberGenerator) -> Int? {
+            xs.randomElement(using: &rng)
+        }
+        func mix(_ xs: [Int], using rng: inout some RandomNumberGenerator) -> [Int] {
+            xs.shuffled(using: &rng)
+        }
+        """
+        #expect(analyze(source).isEmpty)
+    }
+
+    @Test func stillFlagsSystemRandomWithoutUsing() {
+        // Regression guard: only the `using:`-injected form is exempt.
+        #expect(analyze("func roll() -> Int { Int.random(in: 1...6) }").count == 1)
+    }
 }


### PR DESCRIPTION
A precision fix surfaced by **dogfooding** the testability rules on SwiftPropertyLaws (a real PBT library).

## The false positive
The rule flagged:
```swift
sample: { rng in Int.random(in: -1024...1024, using: &rng) }   // BinaryFloatingPointLaws.swift:151
```
But `using: &rng` **is** the injection seam — that call is seeded and reproducible, the exact form the rule is trying to steer people toward. Flagging it is wrong.

## The fix
`.random` / `.randomElement` / `.shuffled` calls that carry an explicit `using:` argument are now exempt (the RNG is injected). Calls using the system RNG (no `using:`) are still flagged.

## Validated against real code
Re-running on SwiftPropertyLaws drops the count **5 → 4**:
- ✅ removed: the `using: &rng` false positive.
- ✅ kept (true positives): four `Double.random(in:)` / `Float.random(in:)` calls inside generator `.map` closures that use the **system** RNG, so their generated values aren't reproducible from the `Gen` seed — a genuine reproducibility smell.

3 new tests (`using:` forms exempt for all three members; regression guard that the bare system-RNG form is still flagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)