### PR TITLE
Impure Call in View Body testability rule (+ detector ordering fix)

### DIFF
--- a/Docs/rules/RULES.md
+++ b/Docs/rules/RULES.md
@@ -249,6 +249,7 @@ Rules marked **opt-in** are disabled by default and must be explicitly listed un
 | [Non-Injected Nondeterminism](non-injected-nondeterminism.md) | Warning |
 | [Pure Function Property-Test Candidate](pure-function-candidate.md) | Info |
 | [Missing Equatable on State Type](missing-equatable-on-state-type.md) | Info |
+| [Impure Call in View Body](impure-call-in-view-body.md) | Warning |
 
 ---
 

--- a/Docs/rules/impure-call-in-view-body.md
+++ b/Docs/rules/impure-call-in-view-body.md
@@ -1,0 +1,68 @@
+[← Back to Rules](RULES.md)
+
+## Impure Call in View Body
+
+**Identifier:** `Impure Call in View Body`
+**Category:** Testability
+**Severity:** Warning
+
+### Rationale
+A SwiftUI view's `body` should be a pure function of its state — it builds a view tree and does nothing else. Reaching into persistence, the file system, the network, logging, or the dispatch queue from `body` couples *rendering* to side effects and external mutable state. Two things break:
+
+- **Untestable rendering.** The view renders differently depending on state outside the view, so you can't snapshot- or property-test it by simply rendering it and asserting on the output — the output isn't a function of the inputs you control.
+- **Repeated effects.** SwiftUI may invoke `body` many times per state change; a side effect in `body` re-fires on every render.
+
+Drive the view from state instead: perform effects in an action or `onAppear`, and read external values through `@AppStorage` or injected state.
+
+### Discussion
+`ImpureCallInViewBodyVisitor` mirrors `FormatterInViewBodyVisitor`: on any `struct` conforming to `View`, it scans the getter of the `body` computed property and reports a reference to a known impure API — `UserDefaults`, `FileManager`, `URLSession`, `NotificationCenter`, `DispatchQueue`, `print`, `NSLog`. Each surfaces its marker as a `DeclReferenceExprSyntax` (the member-access base in `UserDefaults.standard.set(…)`, the callee in `print(…)`), so both reads and writes are caught.
+
+Only `body` is scanned — the same API used in a helper method or an action is fine. Value-source nondeterminism (`Date()`, `.random`) is **not** flagged here: the **Non-Injected Nondeterminism** rule already covers it in any computed-property body, so this rule stays focused on side-effecting / external-state calls and avoids double-reporting.
+
+```swift
+// Before — body reads external mutable state on every render
+struct CounterView: View {
+    var body: some View {
+        Text("\(UserDefaults.standard.integer(forKey: "count"))")
+    }
+}
+
+// After — the value is injected as state; rendering is a function of `count`
+struct CounterView: View {
+    @AppStorage("count") private var count = 0
+    var body: some View {
+        Text("\(count)")
+    }
+}
+```
+
+### Non-Violating Examples
+```swift
+// Impure work lives in an action, not in body
+struct ContentView: View {
+    @State private var items: [Item] = []
+    var body: some View {
+        List(items) { Text($0.name) }
+            .onAppear { items = load() }   // effect outside body
+    }
+}
+
+// The same API in a helper method is fine — only `body` is scanned
+struct ProfileView: View {
+    func save() { UserDefaults.standard.set(true, forKey: "seen") }
+    var body: some View { Text("Profile") }
+}
+```
+
+### Violating Examples
+```swift
+struct FeedView: View {
+    var body: some View {
+        let _ = print("rendering feed")                       // logging side effect
+        let cached = FileManager.default.fileExists(atPath: p) // file-system read
+        Text(cached ? "cached" : "fresh")
+    }
+}
+```
+
+---

--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
@@ -218,6 +218,7 @@ public enum RuleIdentifier: String, CaseIterable, Codable, Sendable {
     case nonInjectedNondeterminism = "Non-Injected Nondeterminism"
     case pureFunctionCandidate = "Pure Function Property-Test Candidate"
     case missingEquatableOnStateType = "Missing Equatable on State Type"
+    case impureCallInViewBody = "Impure Call in View Body"
 
     // Other/System Rules
     case fileParsingError = "File Parsing Error"
@@ -349,7 +350,7 @@ public enum RuleIdentifier: String, CaseIterable, Codable, Sendable {
 
             // Testability / PBT-readiness Rules
         case .globalMutableState, .nonInjectedNondeterminism, .pureFunctionCandidate,
-             .missingEquatableOnStateType:
+             .missingEquatableOnStateType, .impureCallInViewBody:
             return .testability
 
             // Other/System Rules

--- a/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetector.swift
+++ b/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetector.swift
@@ -157,7 +157,16 @@ public final class SourcePatternDetector: SourcePatternDetectorProtocol, @unchec
 
         var allIssues: [LintIssue] = []
 
-        for (_, entry) in visitorTypeToPatterns {
+        // Iterate visitor groups in a deterministic order. `visitorTypeToPatterns`
+        // is keyed by `ObjectIdentifier`, whose hash (and therefore the dictionary's
+        // iteration order) varies between dictionary instances — so without this
+        // sort, two analyses of the same source can emit issues from different
+        // visitors in different relative order. Sort by the group's first rule name
+        // for a stable, source-independent ordering.
+        let orderedEntries = visitorTypeToPatterns.values.sorted {
+            ($0.patterns.first?.name.rawValue ?? "") < ($1.patterns.first?.name.rawValue ?? "")
+        }
+        for entry in orderedEntries {
             // Initialize the visitor with the first pattern (for visitors that
             // use the pattern's template). The visitor will report issues with
             // specific ruleNames regardless of which pattern was used to init.

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/ImpureCallInViewBody.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/ImpureCallInViewBody.swift
@@ -1,0 +1,27 @@
+import Foundation
+import SwiftProjectLintModels
+import SwiftProjectLintRegistry
+import SwiftProjectLintVisitors
+
+/// Registrar for the Impure Call in View Body rule.
+///
+/// Flags persistence / IO / logging / scheduling API references inside a SwiftUI
+/// view's `body` — `body` should be a pure function of state, so side-effecting
+/// calls make rendering nondeterministic and untestable.
+struct ImpureCallInViewBody: PatternRegistrarProtocol {
+
+    var pattern: SyntaxPattern {
+        SyntaxPattern(
+            name: .impureCallInViewBody,
+            visitor: ImpureCallInViewBodyVisitor.self,
+            severity: .warning,
+            category: .testability,
+            messageTemplate: "Impure call in a SwiftUI view `body` — rendering should be a pure "
+                + "function of state.",
+            suggestion: "Move the side effect / external-state read out of `body` (an action / "
+                + "`onAppear` / `@AppStorage`) and drive the view from state.",
+            description: "Detects persistence / IO / logging / scheduling API references inside a "
+                + "SwiftUI view's body, which make rendering impure and untestable."
+        )
+    }
+}

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/Testability.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/Testability.swift
@@ -47,9 +47,10 @@ class Testability: BasePatternRegistrar {
         ]
         registry.register(patterns: patterns)
 
-        // Cross-file rules get their own single-purpose leaf registrars.
+        // Single-purpose-visitor rules get their own leaf registrars.
         registry.register(registrars: [
-            MissingEquatableOnStateType()
+            MissingEquatableOnStateType(),
+            ImpureCallInViewBody()
         ])
     }
 }

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ImpureCallInViewBodyVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ImpureCallInViewBodyVisitor.swift
@@ -1,0 +1,112 @@
+import SwiftProjectLintModels
+import SwiftProjectLintRegistry
+import SwiftProjectLintVisitors
+import SwiftSyntax
+
+/// Flags impure / side-effecting references inside a SwiftUI view's `body`.
+///
+/// A `body` should be a pure function of state — it builds a view tree and does
+/// nothing else. Reaching into persistence, the file system, the network,
+/// logging, or the dispatch queue from `body` couples *rendering* to side
+/// effects and external mutable state: the view renders differently depending on
+/// outside-the-view state (so it can't be snapshot- or property-tested by simply
+/// rendering it), and SwiftUI may re-invoke `body` many times, re-firing the
+/// effect. Move the work to an action / `onAppear` (for effects) or `@AppStorage`
+/// / injected state (for reads), and drive the view from state.
+///
+/// **Detection:** mirrors `FormatterInViewBodyVisitor` — scans the getter of the
+/// `body` computed property on any `struct` conforming to `View`, reporting any
+/// reference to a known impure API. Value-source nondeterminism (`Date()`,
+/// `.random`) is deliberately *not* flagged here — `NonInjectedNondeterminism`
+/// already covers it in any computed-property body, so this rule stays focused
+/// on side-effecting / external-state calls and avoids double-reporting.
+final class ImpureCallInViewBodyVisitor: BasePatternVisitor {
+
+    /// Persistence / IO / logging / scheduling APIs whose use in `body` makes
+    /// rendering impure. Matched as the bare reference name (`UserDefaults` in
+    /// `UserDefaults.standard.set(...)`, `print` in `print(...)`).
+    private static let impureMarkers: Set<String> = [
+        "UserDefaults",
+        "FileManager",
+        "URLSession",
+        "NotificationCenter",
+        "DispatchQueue",
+        "print",
+        "NSLog"
+    ]
+
+    required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
+        super.init(pattern: pattern, viewMode: viewMode)
+    }
+
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard isSwiftUIView(node) else { return .visitChildren }
+        scanBodyProperty(in: node.memberBlock)
+        return .visitChildren
+    }
+
+    private func scanBodyProperty(in memberBlock: MemberBlockSyntax) {
+        for member in memberBlock.members {
+            guard let varDecl = member.decl.as(VariableDeclSyntax.self) else { continue }
+            for binding in varDecl.bindings {
+                guard let pattern = binding.pattern.as(IdentifierPatternSyntax.self),
+                      pattern.identifier.text == "body",
+                      let accessorBlock = binding.accessorBlock else { continue }
+                scanAccessorBlock(accessorBlock)
+            }
+        }
+    }
+
+    private func scanAccessorBlock(_ accessorBlock: AccessorBlockSyntax) {
+        switch accessorBlock.accessors {
+        case .getter(let items):
+            reportImpureCalls(in: Syntax(items))
+
+        case .accessors(let list):
+            for accessor in list where accessor.accessorSpecifier.text == "get" {
+                if let body = accessor.body {
+                    reportImpureCalls(in: Syntax(body.statements))
+                }
+            }
+        }
+    }
+
+    private func reportImpureCalls(in subtree: Syntax) {
+        let finder = ImpureReferenceFinder(markers: Self.impureMarkers)
+        finder.walk(subtree)
+        for (marker, node) in finder.findings {
+            addIssue(
+                severity: .warning,
+                message: "Impure call in view body — `body` should be a pure function of state, but "
+                    + "`\(marker)` couples rendering to side effects / external mutable state, so the "
+                    + "view renders nondeterministically and can't be tested by rendering it",
+                filePath: getFilePath(for: node),
+                lineNumber: getLineNumber(for: node),
+                suggestion: "Move it out of `body` — an action / `onAppear` for effects, or "
+                    + "`@AppStorage` / injected state for reads — and drive the view from state.",
+                ruleName: .impureCallInViewBody
+            )
+        }
+    }
+
+    /// Walks a subtree collecting references whose name is a known impure marker.
+    /// `UserDefaults.standard` and `print(...)` both surface their marker as a
+    /// `DeclReferenceExprSyntax` (the member-access base / the call callee).
+    private final class ImpureReferenceFinder: SyntaxVisitor {
+        let markers: Set<String>
+        var findings: [(marker: String, node: Syntax)] = []
+
+        init(markers: Set<String>) {
+            self.markers = markers
+            super.init(viewMode: .sourceAccurate)
+        }
+
+        override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
+            let name = node.baseName.text
+            if markers.contains(name) {
+                findings.append((marker: name, node: Syntax(node)))
+            }
+            return .visitChildren
+        }
+    }
+}

--- a/Tests/CoreTests/Testability/ImpureCallInViewBodyVisitorTests.swift
+++ b/Tests/CoreTests/Testability/ImpureCallInViewBodyVisitorTests.swift
@@ -1,0 +1,119 @@
+@testable import Core
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+@Suite
+struct ImpureCallInViewBodyVisitorTests {
+
+    private func analyze(_ source: String) -> [LintIssue] {
+        let visitor = ImpureCallInViewBodyVisitor(patternCategory: .testability)
+        let syntax = Parser.parse(source: source)
+        visitor.setSourceLocationConverter(SourceLocationConverter(fileName: "View.swift", tree: syntax))
+        visitor.setFilePath("View.swift")
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == .impureCallInViewBody }
+    }
+
+    @Test
+    func flagsUserDefaultsReadInBody() {
+        let issues = analyze("""
+        struct ContentView: View {
+            var body: some View {
+                Text("\\(UserDefaults.standard.integer(forKey: "count"))")
+            }
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("UserDefaults") == true)
+    }
+
+    @Test
+    func flagsPrintInBody() {
+        let issues = analyze("""
+        struct ContentView: View {
+            var body: some View {
+                print("rendering")
+                Text("x")
+            }
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("print") == true)
+    }
+
+    @Test
+    func flagsFileManagerAndURLSession() {
+        let issues = analyze("""
+        struct ContentView: View {
+            var body: some View {
+                let exists = FileManager.default.fileExists(atPath: "/tmp/x")
+                let task = URLSession.shared.dataTask(with: url)
+                Text("\\(exists)")
+            }
+        }
+        """)
+        #expect(issues.count == 2)
+    }
+
+    @Test
+    func ignoresImpureCallOutsideBody() {
+        // Only `body` is scanned — a helper method using UserDefaults is fine.
+        let issues = analyze("""
+        struct ContentView: View {
+            func persist() {
+                UserDefaults.standard.set(1, forKey: "k")
+            }
+            var body: some View {
+                Text("x")
+            }
+        }
+        """)
+        #expect(issues.isEmpty)
+    }
+
+    @Test
+    func ignoresPureBody() {
+        let issues = analyze("""
+        struct ContentView: View {
+            let title: String
+            var body: some View {
+                VStack {
+                    Text(title)
+                    Image(systemName: "star")
+                }
+            }
+        }
+        """)
+        #expect(issues.isEmpty)
+    }
+
+    @Test
+    func ignoresNonViewStructWithBody() {
+        // A non-View struct that happens to have a `body` property is not a SwiftUI view.
+        let issues = analyze("""
+        struct Response {
+            var body: String {
+                UserDefaults.standard.string(forKey: "cached") ?? ""
+            }
+        }
+        """)
+        #expect(issues.isEmpty)
+    }
+
+    @Test
+    func flagsEachMarkerOccurrence() {
+        let issues = analyze("""
+        struct ContentView: View {
+            var body: some View {
+                let _ = print("a")
+                let _ = NSLog("b")
+                DispatchQueue.main.async { }
+                Text("x")
+            }
+        }
+        """)
+        #expect(issues.count == 3)
+    }
+}


### PR DESCRIPTION
The fifth `.testability` rule — plus a pre-existing detector non-determinism the rule's test run surfaced.

## Rule: Impure Call in View Body (warning)
A SwiftUI view's `body` should be a pure function of state. Reaching into persistence / IO / logging / scheduling from `body` couples *rendering* to side effects and external mutable state:
- **Untestable rendering** — output isn't a function of inputs you control, so you can't snapshot- or property-test it by rendering.
- **Repeated effects** — SwiftUI invokes `body` many times per change, re-firing the effect.

```swift
struct CounterView: View {
    var body: some View {
        Text("\(UserDefaults.standard.integer(forKey: "count"))")  // ⚠ external read in body
    }
}
```

**Detection** mirrors `FormatterInViewBodyVisitor`: on any `struct: View`, scan the `body` getter and flag references to `UserDefaults` / `FileManager` / `URLSession` / `NotificationCenter` / `DispatchQueue` / `print` / `NSLog` (each surfaces as a `DeclReferenceExpr`, so reads and writes both count). Only `body` is scanned — the same API in a helper or action is fine.

**No overlap:** value-source nondeterminism (`Date()`, `.random`) is left to **Non-Injected Nondeterminism** (which already fires in any computed-property body), so the two rules don't double-report. 7 tests + bundled doc + RULES.md entry.

## Bonus: detector ordering fix (commit 1)
While running the rule's CoreTests, the `detection_isDeterministic` robustness property test failed intermittently (~3/5). The counterexample was **rule-agnostic** (Force Try / Non-Actor Agent Suffix / Multiple Types Per File): `SourcePatternDetector` grouped visitors in an `[ObjectIdentifier: …]` dictionary whose iteration order varies between instances, so two analyses of the same source could order issues from different visitors differently. Fixed by sorting the visitor groups by rule name before iterating — the determinism test now passes 6/6. Adding a rule just made the random fixtures hit the latent flake more often.

Full suite green: CoreTests 2489, AppTests 184, CLITests 50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)