### PR TITLE
Unify the effect vocabulary: thread `Effect.pure` through SwiftProjectLint

### DIFF
--- a/Docs/rules/idempotency-violation.md
+++ b/Docs/rules/idempotency-violation.md
@@ -10,12 +10,13 @@
 A function can declare its effect contract via `/// @lint.effect` in its doc comment. Once declared, callers depend on that contract — a function trusted as idempotent is trusted because of its annotation, and silent violations of the annotation undermine the entire annotation layer. This rule verifies that a function's body respects the effect it claims.
 
 ### Discussion
-`IdempotencyViolationVisitor` walks each function declaration in the project, reads its `@lint.effect` annotation, and — for callers declared `idempotent` or `observational` — checks every direct call in the body against the project-wide `EffectSymbolTable`. The visitor resolves callees by full function signature (name + argument labels), so overloads that Swift distinguishes resolve independently. Unannotated callees are silent (Phase 1 does not infer); callees whose symbol-table entry was withdrawn by a collision are also silent.
+`IdempotencyViolationVisitor` walks each function declaration in the project, reads its `@lint.effect` annotation, and — for callers declared `pure`, `idempotent`, or `observational` — checks every direct call in the body against the project-wide `EffectSymbolTable`. The visitor resolves callees by full function signature (name + argument labels), so overloads that Swift distinguishes resolve independently. Unannotated callees are silent (Phase 1 does not infer); callees whose symbol-table entry was withdrawn by a collision are also silent.
 
-The rule covers five combinations:
+The rule covers these combinations:
 
 | Caller effect | Callee effect | Fires? |
 |---|---|:-:|
+| `pure` | `observational` / `idempotent` / `externally_idempotent` / `non_idempotent` | ✓ (Phase 3) |
 | `idempotent` | `non_idempotent` | ✓ |
 | `observational` | `idempotent` | ✓ |
 | `observational` | `non_idempotent` | ✓ |
@@ -23,6 +24,8 @@ The rule covers five combinations:
 | `externally_idempotent` | `non_idempotent` | ✓ (Phase 2) |
 
 All other combinations are permissible. In particular, `idempotent` can freely call `observational` (logging inside an idempotent function is fine), and either can call unannotated callees without a diagnostic.
+
+**A note on `pure` callers (Phase 3).** `pure` is the bottom of the effect lattice — referential transparency: no side effects, deterministic, total. It is *strictly stronger* than `observational`, so a function declared `@lint.effect pure` (or `@Pure`) may call **only other pure functions**. Every `pure → non-pure` pairing fires, including `pure → observational` — the case that separates the purity axis from the retry-safety axis. An `observational` caller calling another `observational` helper is fine (logging is retry-safe), but a `pure` caller doing the same breaks referential transparency. This is the `Effect.pure` tier introduced in [SwiftEffectInference](https://github.com/Joseph-Cursio/SwiftEffectInference); the testability rules infer it, this rule enforces it when declared.
 
 **A note on `externally_idempotent` callees.** The tier models functions that are idempotent *only* when routed through a caller-supplied deduplication key (Stripe, SES, Mailgun, SNS). When an `idempotent`, `externally_idempotent`, or retry-context caller calls an `externally_idempotent` function, this rule stays silent — it trusts the caller to route the key. Whether the key actually reaches the callee is a separate check that a future rule (`missingIdempotencyKey`) will verify. Until then, the keyed path is trusted at the point it's declared.
 
@@ -66,6 +69,16 @@ func appendAudit(_ event: String) async throws {}
 func chargeWithAudit(idempotencyKey: String, amount: Int) async throws {
     try await appendAudit("charge \(idempotencyKey)")           // flagged
     try await charge(idempotencyKey: idempotencyKey, amount: amount)
+}
+
+// Phase 3 — a pure caller may call only pure callees
+/// @lint.effect observational
+func logHit(_ key: String) {}
+
+/// @lint.effect pure
+func normalize(_ key: String) -> String {
+    logHit(key)                                                 // pure → observational, flagged
+    return key.lowercased()
 }
 ```
 

--- a/Package.swift
+++ b/Package.swift
@@ -62,7 +62,7 @@ let package = Package(
         // swift-syntax exact 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "6722e260f011c89c9f0334e5189a2c42590e41e4"
+            revision: "7dc9673ff814baec8ac368dd18f57d6f74a0a727"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintIdempotencyRules/Package.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // root and SwiftProjectLintVisitors pins.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "6722e260f011c89c9f0334e5189a2c42590e41e4"
+            revision: "7dc9673ff814baec8ac368dd18f57d6f74a0a727"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Visitors/IdempotencyViolationVisitor.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Visitors/IdempotencyViolationVisitor.swift
@@ -246,7 +246,7 @@ final class IdempotencyViolationVisitor: CrossFileVisitorBase, CrossFilePatternV
     /// callees, so there is nothing to violate.
     private func isTriageableCaller(_ effect: DeclaredEffect) -> Bool {
         switch effect {
-        case .idempotent, .observational, .externallyIdempotent: return true
+        case .pure, .idempotent, .observational, .externallyIdempotent: return true
         case .nonIdempotent: return false
         }
     }
@@ -270,8 +270,23 @@ final class IdempotencyViolationVisitor: CrossFileVisitorBase, CrossFilePatternV
     ///   the keyed guarantee is broken.
     /// - `externally_idempotent → idempotent / observational / externally_idempotent`:
     ///   **OK.** Composition holds.
+    ///
+    /// Phase 3 added the `pure` caller rows. `pure` is the lattice bottom —
+    /// referential transparency — so a function declared `@lint.effect pure`
+    /// may call *only* other pure functions. Any callee at a higher tier
+    /// (`observational` and up) introduces a side effect or an observation the
+    /// pure contract forbids, so every `pure → non-pure` pairing violates.
     private func violates(caller: DeclaredEffect, callee: DeclaredEffect) -> Bool {
         switch (caller, callee) {
+        // Phase 3: a pure caller may call only pure callees; anything else
+        // (observational/idempotent/externallyIdempotent/nonIdempotent) breaks
+        // referential transparency.
+        case (.pure, .pure):
+            return false
+
+        case (.pure, _):
+            return true
+
         // Phase 1 cases
         case (.idempotent, .nonIdempotent):
             return true
@@ -330,6 +345,15 @@ final class IdempotencyViolationVisitor: CrossFileVisitorBase, CrossFilePatternV
         let headline: String
         let suggestion: String
         switch site.effect {
+        case .pure:
+            headline = "Purity violation: '\(callerName)' is declared "
+                + "`@lint.effect pure` but calls '\(calleeName)', \(calleeClaim). "
+                + "A pure function must be referentially transparent — no side effects, no I/O, "
+                + "no observation — so it may call only other pure functions."
+                + overrideHint
+            suggestion = "Either call only `pure` helpers from '\(callerName)', or weaken its "
+                + "declared effect to `observational` / `idempotent` / `non_idempotent`."
+
         case .observational:
             headline = "Observational contract violation: '\(callerName)' is declared "
                 + "`@lint.effect observational` but calls '\(calleeName)', \(calleeClaim). "
@@ -375,6 +399,7 @@ final class IdempotencyViolationVisitor: CrossFileVisitorBase, CrossFilePatternV
 
     private func effectLabel(_ effect: DeclaredEffect) -> String {
         switch effect {
+        case .pure: return "pure"
         case .idempotent: return "idempotent"
         case .observational: return "observational"
         case .externallyIdempotent: return "externally_idempotent"   // tier-only label; (by:) is a visitor-level detail

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/PureFunctionCandidateVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/PureFunctionCandidateVisitor.swift
@@ -17,13 +17,10 @@ final class PureFunctionCandidateVisitor: BasePatternVisitor {
 
     private var fileIsTestOrFixture = false
 
-    /// Strong impurity markers — any in the body disqualifies the function.
-    private static let impureMarkers: Set<String> = [
-        "print", "NSLog", "FileManager", "URLSession", "UserDefaults",
-        "NotificationCenter", "DispatchQueue",
-        "arc4random", "arc4random_uniform", "drand48",
-        "random", "randomElement", "shuffled"
-    ]
+    /// Shared purity inference on `SwiftEffectInference.Effect`. A function is
+    /// a candidate only when this infers `.pure` — the testability rule and the
+    /// idempotency rules now decide purity through the same vocabulary.
+    private let purityInferrer = PurityInferrer()
 
     required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
         super.init(pattern: pattern, viewMode: viewMode)
@@ -35,7 +32,7 @@ final class PureFunctionCandidateVisitor: BasePatternVisitor {
     }
 
     override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
-        guard let body = node.body, isCandidate(node, body: body) else { return .visitChildren }
+        guard isCandidate(node) else { return .visitChildren }
 
         addIssue(
             severity: .info,
@@ -51,29 +48,28 @@ final class PureFunctionCandidateVisitor: BasePatternVisitor {
         return .visitChildren
     }
 
-    /// A function is a candidate when it is free/`static`, takes inputs, is total
-    /// (synchronous, non-throwing, no trapping body, no impurity), and returns an
-    /// `Equatable` value. Split into grouped predicates to keep each one simple.
-    private func isCandidate(_ node: FunctionDeclSyntax, body: CodeBlockSyntax) -> Bool {
+    /// A function is a candidate when it is free/`static`, takes inputs,
+    /// returns an `Equatable` value, and is inferred `Effect.pure` (referentially
+    /// transparent — synchronous, non-throwing, no trapping body, no impurity).
+    /// Purity is delegated to the shared `PurityInferrer`; this method adds only
+    /// the *testability* requirements (assertable return, has inputs, free/static).
+    private func isCandidate(_ node: FunctionDeclSyntax) -> Bool {
         guard !fileIsTestOrFixture else { return false }
         // Free or `static` only — instance methods can read mutable `self`.
         guard isStatic(node) || isFileScope(node) else { return false }
-        return signatureQualifies(node.signature) && bodyQualifies(body)
+        // The purity verdict — `.pure` on SwiftEffectInference's lattice — is the
+        // unified signal; `_ = body` because the inferrer reads the node's body.
+        guard purityInferrer.isPure(node) else { return false }
+        return signatureIsAssertable(node.signature)
     }
 
-    /// Takes inputs, returns an `Equatable` value, and is synchronous + total at
-    /// the signature level (no `async`, no `throws`).
-    private func signatureQualifies(_ signature: FunctionSignatureSyntax) -> Bool {
+    /// The candidacy half of the signature check (purity covers async/throws):
+    /// takes inputs and returns a non-`Void`, `Equatable` value a property test
+    /// can assert on.
+    private func signatureIsAssertable(_ signature: FunctionSignatureSyntax) -> Bool {
         !signature.parameterClause.parameters.isEmpty
             && hasNonVoidReturn(signature)
-            && signature.effectSpecifiers?.asyncSpecifier == nil
-            && signature.effectSpecifiers?.throwsClause == nil
             && returnTypeIsEquatable(signature)
-    }
-
-    /// The body shows no impurity and can't trap (is total).
-    private func bodyQualifies(_ body: CodeBlockSyntax) -> Bool {
-        !bodyLooksImpure(body) && bodyIsTotal(body)
     }
 
     private func isStatic(_ node: FunctionDeclSyntax) -> Bool {
@@ -120,6 +116,10 @@ final class PureFunctionCandidateVisitor: BasePatternVisitor {
         return Self.equatableStdlibTypes.contains(base) || knownEquatableTypes.contains(base)
     }
 
+    // Purity inference (impurity markers, totality) lives in the shared
+    // `PurityInferrer` (SwiftProjectLintVisitors) so the testability rule and
+    // the idempotency rules decide purity through the same `Effect.pure` verdict.
+
     /// The underlying nominal name of a type, unwrapping optionals and arrays:
     /// `Foo?` → `Foo`, `[Foo]` → `Foo`, `Foo<Bar>` → `Foo`. `[K: V]` resolves to
     /// `Dictionary`. Returns `nil` for tuples, closures, and other non-nominal
@@ -141,65 +141,5 @@ final class PureFunctionCandidateVisitor: BasePatternVisitor {
             return identifier.name.text
         }
         return nil
-    }
-
-    private func bodyLooksImpure(_ body: CodeBlockSyntax) -> Bool {
-        body.tokens(viewMode: .sourceAccurate).contains { Self.impureMarkers.contains($0.text) }
-    }
-
-    /// True when nothing in the body can trap (crash) at runtime — the property
-    /// that lets us treat the function as total. Force-unwrap (`!`), `try!`,
-    /// `as!`, and the `fatalError` / `precondition` / `assert` family all
-    /// introduce inputs for which there is no return value, so a property test
-    /// over generated inputs would hit a crash rather than a falsified law.
-    private func bodyIsTotal(_ body: CodeBlockSyntax) -> Bool {
-        let checker = TotalityChecker(viewMode: .sourceAccurate)
-        checker.walk(body)
-        return checker.isTotal
-    }
-}
-
-/// Walks a function body looking for any runtime trap that breaks totality.
-private final class TotalityChecker: SyntaxVisitor {
-
-    private(set) var isTotal = true
-
-    /// Standard-library trap functions: reaching them means the function has no
-    /// return value for some inputs.
-    private static let trapFunctions: Set<String> = [
-        "fatalError", "preconditionFailure", "precondition",
-        "assert", "assertionFailure"
-    ]
-
-    override func visit(_ node: ForceUnwrapExprSyntax) -> SyntaxVisitorContinueKind {
-        _ = node
-        isTotal = false
-        return .skipChildren
-    }
-
-    override func visit(_ node: TryExprSyntax) -> SyntaxVisitorContinueKind {
-        if node.questionOrExclamationMark?.text == "!" { isTotal = false }
-        return .visitChildren
-    }
-
-    override func visit(_ node: AsExprSyntax) -> SyntaxVisitorContinueKind {
-        if node.questionOrExclamationMark?.text == "!" { isTotal = false }
-        return .visitChildren
-    }
-
-    // Raw (unfolded) parse trees represent `x as! T` as an `UnresolvedAsExprSyntax`
-    // inside a `SequenceExprSyntax`; the folded `AsExprSyntax` form only appears
-    // after operator-precedence folding, which the linter doesn't run.
-    override func visit(_ node: UnresolvedAsExprSyntax) -> SyntaxVisitorContinueKind {
-        if node.questionOrExclamationMark?.text == "!" { isTotal = false }
-        return .visitChildren
-    }
-
-    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
-        if let callee = node.calledExpression.as(DeclReferenceExprSyntax.self)?.baseName.text,
-           Self.trapFunctions.contains(callee) {
-            isTotal = false
-        }
-        return .visitChildren
     }
 }

--- a/Packages/SwiftProjectLintVisitors/Package.swift
+++ b/Packages/SwiftProjectLintVisitors/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "6722e260f011c89c9f0334e5189a2c42590e41e4"
+            revision: "7dc9673ff814baec8ac368dd18f57d6f74a0a727"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/EffectAnnotationParser.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/EffectAnnotationParser.swift
@@ -283,32 +283,26 @@ public enum EffectAnnotationParser {
     /// recognised by name alone. Users who write `@Idempotent` without
     /// importing the macros package get linter coverage but not the
     /// compile-time / test-time behaviour.
+    /// Attribute names that map to a fixed tier (no associated value). The
+    /// keyed `ExternallyIdempotent` form is handled separately because it must
+    /// read a `(by:)` argument. `IdempotencyTests` and any other unrecognised
+    /// name simply miss this table and skip.
+    private static let fixedTierAttributes: [String: DeclaredEffect] = [
+        "Pure": .pure,
+        "Idempotent": .idempotent,
+        "NonIdempotent": .nonIdempotent,
+        "Observational": .observational
+    ]
+
     static func effectFromAttributes(_ attributes: AttributeListSyntax) -> DeclaredEffect? {
         for element in attributes {
             guard let attr = element.as(AttributeSyntax.self) else { continue }
             guard let typeName = attributeTypeName(attr.attributeName) else { continue }
-            switch typeName {
-            case "Pure":
-                return .pure
-
-            case "Idempotent":
-                return .idempotent
-
-            case "NonIdempotent":
-                return .nonIdempotent
-
-            case "Observational":
-                return .observational
-
-            case "ExternallyIdempotent":
+            if let fixed = fixedTierAttributes[typeName] {
+                return fixed
+            }
+            if typeName == "ExternallyIdempotent" {
                 return .externallyIdempotent(keyParameter: extractByLabel(from: attr))
-
-            default:
-                // `IdempotencyTests` (test-generation attribute on `@Suite`
-                // types, added in the macros package round-8 redesign)
-                // carries no function-effect semantics and shares this
-                // skip path with any unrecognised attribute name.
-                continue
             }
         }
         return nil

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/EffectAnnotationParser.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/EffectAnnotationParser.swift
@@ -288,6 +288,9 @@ public enum EffectAnnotationParser {
             guard let attr = element.as(AttributeSyntax.self) else { continue }
             guard let typeName = attributeTypeName(attr.attributeName) else { continue }
             switch typeName {
+            case "Pure":
+                return .pure
+
             case "Idempotent":
                 return .idempotent
 
@@ -359,6 +362,9 @@ public enum EffectAnnotationParser {
         let rest = line[range.upperBound...].trimmingLeadingWhitespace()
         let token = rest.firstWord()
         switch token {
+        case "pure":
+            return .pure
+
         case "idempotent":
             return .idempotent
 

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/PurityInferrer.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/PurityInferrer.swift
@@ -1,0 +1,129 @@
+import SwiftEffectInference
+import SwiftSyntax
+
+/// Infers whether a function is `Effect.pure` — referentially transparent:
+/// no side effects, deterministic, and total (a function of its inputs alone).
+///
+/// This is the heuristic that **refutes** purity. A function is inferred
+/// `.pure` only when *none* of the impurity / nondeterminism / partiality
+/// signals fire — conservative by design, it under-claims rather than call an
+/// effectful function pure.
+///
+/// ## Why this exists
+///
+/// SwiftProjectLint historically carried two parallel effect vocabularies: the
+/// idempotency rules speak `SwiftEffectInference.Effect` (the retry-safety
+/// lattice), while the testability rules carried an *ad-hoc* purity notion
+/// (loose `impureMarkers` / totality sets, no shared type). The effect-vocabulary
+/// survey (Idea #4) found these are the same `pure` concept wearing different
+/// clothes — `pure` is the bottom of SEI's lattice, strictly stronger than
+/// `observational` (a logging function is observational but not pure).
+///
+/// `PurityInferrer` re-expresses the testability purity check as inference onto
+/// SEI's shared `Effect`, so the linter, the idempotency rules, and the PBT
+/// pipeline all speak one vocabulary. The impurity / totality predicates that
+/// once lived inside `PureFunctionCandidateVisitor` now live here and yield an
+/// `Effect.pure` verdict.
+public struct PurityInferrer: Sendable {
+
+    public init() {
+        // Stateless — the inferrer holds no configuration.
+    }
+
+    /// Strong impurity markers — any reference in the body refutes purity.
+    /// I/O, logging, persistence, and the nondeterministic randomness family
+    /// each introduce an effect or a non-reproducible result.
+    private static let impureMarkers: Set<String> = [
+        "print", "NSLog", "FileManager", "URLSession", "UserDefaults",
+        "NotificationCenter", "DispatchQueue",
+        "arc4random", "arc4random_uniform", "drand48",
+        "random", "randomElement", "shuffled"
+    ]
+
+    /// Returns `.pure` when `function` is referentially transparent — its
+    /// signature is synchronous and non-throwing, its body references no
+    /// impurity marker, and nothing in it can trap — and `nil` (purity
+    /// refuted) otherwise.
+    ///
+    /// `async` and `throws` both refute purity: an `async` body awaits some
+    /// effect, and a `throws` function has no return value for the inputs that
+    /// throw, so it is not total over its domain.
+    public func inferredEffect(for function: FunctionDeclSyntax) -> Effect? {
+        guard let body = function.body else { return nil }
+        guard isSynchronousAndNonThrowing(function.signature) else { return nil }
+        guard !bodyLooksImpure(body), bodyIsTotal(body) else { return nil }
+        return .pure
+    }
+
+    /// Convenience boolean form of `inferredEffect(for:)`.
+    public func isPure(_ function: FunctionDeclSyntax) -> Bool {
+        inferredEffect(for: function) == .pure
+    }
+
+    // MARK: - Refutation predicates
+
+    private func isSynchronousAndNonThrowing(_ signature: FunctionSignatureSyntax) -> Bool {
+        signature.effectSpecifiers?.asyncSpecifier == nil
+            && signature.effectSpecifiers?.throwsClause == nil
+    }
+
+    private func bodyLooksImpure(_ body: CodeBlockSyntax) -> Bool {
+        body.tokens(viewMode: .sourceAccurate).contains { Self.impureMarkers.contains($0.text) }
+    }
+
+    /// True when nothing in the body can trap (crash) at runtime — the property
+    /// that lets us treat the function as total. Force-unwrap (`!`), `try!`,
+    /// `as!`, and the `fatalError` / `precondition` / `assert` family all
+    /// introduce inputs for which there is no return value, so a property test
+    /// over generated inputs would hit a crash rather than a falsified law.
+    private func bodyIsTotal(_ body: CodeBlockSyntax) -> Bool {
+        let checker = TotalityChecker(viewMode: .sourceAccurate)
+        checker.walk(body)
+        return checker.isTotal
+    }
+}
+
+/// Walks a function body looking for any runtime trap that breaks totality.
+private final class TotalityChecker: SyntaxVisitor {
+
+    private(set) var isTotal = true
+
+    /// Standard-library trap functions: reaching them means the function has no
+    /// return value for some inputs.
+    private static let trapFunctions: Set<String> = [
+        "fatalError", "preconditionFailure", "precondition",
+        "assert", "assertionFailure"
+    ]
+
+    override func visit(_ node: ForceUnwrapExprSyntax) -> SyntaxVisitorContinueKind {
+        _ = node
+        isTotal = false
+        return .skipChildren
+    }
+
+    override func visit(_ node: TryExprSyntax) -> SyntaxVisitorContinueKind {
+        if node.questionOrExclamationMark?.text == "!" { isTotal = false }
+        return .visitChildren
+    }
+
+    override func visit(_ node: AsExprSyntax) -> SyntaxVisitorContinueKind {
+        if node.questionOrExclamationMark?.text == "!" { isTotal = false }
+        return .visitChildren
+    }
+
+    // Raw (unfolded) parse trees represent `x as! T` as an `UnresolvedAsExprSyntax`
+    // inside a `SequenceExprSyntax`; the folded `AsExprSyntax` form only appears
+    // after operator-precedence folding, which the linter doesn't run.
+    override func visit(_ node: UnresolvedAsExprSyntax) -> SyntaxVisitorContinueKind {
+        if node.questionOrExclamationMark?.text == "!" { isTotal = false }
+        return .visitChildren
+    }
+
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        if let callee = node.calledExpression.as(DeclReferenceExprSyntax.self)?.baseName.text,
+           Self.trapFunctions.contains(callee) {
+            isTotal = false
+        }
+        return .visitChildren
+    }
+}

--- a/Tests/CoreTests/Idempotency/IdempotencyViolationVisitorTests.swift
+++ b/Tests/CoreTests/Idempotency/IdempotencyViolationVisitorTests.swift
@@ -167,4 +167,97 @@ struct IdempotencyViolationVisitorTests {
 
         #expect(visitor.detectedIssues.isEmpty)
     }
+
+    // MARK: - Phase 3: `pure` caller contract
+
+    @Test
+    func pureCallsNonIdempotent_flagsAsPurityViolation() throws {
+        // A function declared `@lint.effect pure` must be referentially
+        // transparent — calling a non-idempotent primitive breaks that.
+        let source = """
+        /// @lint.effect non_idempotent
+        func persist(_ value: Int) async throws {}
+
+        /// @lint.effect pure
+        func compute(_ value: Int) async throws {
+            try await persist(value)
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.count == 1)
+        let issue = try #require(visitor.detectedIssues.first)
+        #expect(issue.ruleName == .idempotencyViolation)
+        #expect(issue.message.contains("Purity violation"))
+        #expect(issue.message.contains("@lint.effect pure"))
+        #expect(issue.message.contains("compute"))
+        #expect(issue.message.contains("persist"))
+    }
+
+    @Test
+    func pureCallsObservational_flags() throws {
+        // `pure` is strictly below `observational`: a pure function may not
+        // even call a logging/observation helper. This is the case that
+        // distinguishes the purity axis from the retry-safety axis — an
+        // observational caller calling another observational helper is fine,
+        // but a `pure` caller is not.
+        let source = """
+        /// @lint.effect observational
+        func logMetric(_ value: Int) {}
+
+        /// @lint.effect pure
+        func compute(_ value: Int) -> Int {
+            logMetric(value)
+            return value
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.count == 1)
+        let issue = try #require(visitor.detectedIssues.first)
+        #expect(issue.message.contains("Purity violation"))
+        #expect(issue.message.contains("logMetric"))
+    }
+
+    @Test
+    func pureCallsPure_noDiagnostic() {
+        // Composition holds: a pure caller calling a pure callee is the one
+        // OK pairing for a `pure` declaration.
+        let source = """
+        /// @lint.effect pure
+        func double(_ value: Int) -> Int { value * 2 }
+
+        /// @lint.effect pure
+        func quadruple(_ value: Int) -> Int {
+            double(double(value))
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    @Test
+    func pureCallerViaAttributeForm_flags() throws {
+        // The `@Pure` attribute grammar resolves to the same tier as the
+        // `/// @lint.effect pure` doc-comment grammar.
+        let source = """
+        /// @lint.effect non_idempotent
+        func persist(_ value: Int) async throws {}
+
+        @Pure
+        func compute(_ value: Int) async throws {
+            try await persist(value)
+        }
+        """
+
+        let visitor = run(source: source)
+
+        #expect(visitor.detectedIssues.count == 1)
+        let issue = try #require(visitor.detectedIssues.first)
+        #expect(issue.message.contains("Purity violation"))
+    }
 }

--- a/Tests/CoreTests/Visitors/PurityInferrerTests.swift
+++ b/Tests/CoreTests/Visitors/PurityInferrerTests.swift
@@ -1,0 +1,106 @@
+import SwiftEffectInference
+import SwiftParser
+@testable import SwiftProjectLintVisitors
+import SwiftSyntax
+import Testing
+
+/// Exercises `PurityInferrer` directly — the shared component that decides
+/// whether a function is `Effect.pure` (referential transparency), now the
+/// single vocabulary behind the testability `pureFunctionCandidate` rule.
+@Suite
+struct PurityInferrerTests {
+
+    private let inferrer = PurityInferrer()
+
+    /// Parses `source` and returns the inferred effect of the first `func`.
+    private func effectOfFirstFunction(in source: String) -> Effect? {
+        let tree = Parser.parse(source: source)
+        let function = tree.statements.lazy
+            .compactMap { $0.item.as(FunctionDeclSyntax.self) }
+            .first
+        guard let function else { return nil }
+        return inferrer.inferredEffect(for: function)
+    }
+
+    @Test
+    func transparentFunction_inferredPure() {
+        let effect = effectOfFirstFunction(in: """
+        func add(_ lhs: Int, _ rhs: Int) -> Int { lhs + rhs }
+        """)
+        #expect(effect == .pure)
+    }
+
+    @Test
+    func loggingFunction_refutesPure() {
+        // `print` is observational to the retry-safety lattice but NOT pure —
+        // this is the case the whole `pure` tier exists to capture.
+        let effect = effectOfFirstFunction(in: """
+        func add(_ lhs: Int, _ rhs: Int) -> Int {
+            print("adding")
+            return lhs + rhs
+        }
+        """)
+        #expect(effect == nil)
+    }
+
+    @Test
+    func randomness_refutesPure() {
+        let effect = effectOfFirstFunction(in: """
+        func pick(_ values: [Int]) -> Int { values.randomElement() ?? 0 }
+        """)
+        #expect(effect == nil)
+    }
+
+    @Test
+    func forceUnwrap_refutesPure() {
+        let effect = effectOfFirstFunction(in: """
+        func first(_ values: [Int]) -> Int { values.first! }
+        """)
+        #expect(effect == nil)
+    }
+
+    @Test
+    func fatalError_refutesPure() {
+        let effect = effectOfFirstFunction(in: """
+        func parse(_ text: String) -> Int {
+            guard let value = Int(text) else { fatalError("bad input") }
+            return value
+        }
+        """)
+        #expect(effect == nil)
+    }
+
+    @Test
+    func asyncFunction_refutesPure() {
+        let effect = effectOfFirstFunction(in: """
+        func fetch(_ id: Int) async -> Int { id }
+        """)
+        #expect(effect == nil)
+    }
+
+    @Test
+    func throwingFunction_refutesPure() {
+        // A throwing function is partial — no return value for inputs that throw.
+        let effect = effectOfFirstFunction(in: """
+        func parse(_ text: String) throws -> Int { Int(text) ?? 0 }
+        """)
+        #expect(effect == nil)
+    }
+
+    @Test
+    func bodylessDeclaration_refutesPure() {
+        // A protocol requirement has no body to inspect.
+        let effect = effectOfFirstFunction(in: """
+        protocol P { func f(_ x: Int) -> Int }
+        """)
+        #expect(effect == nil)
+    }
+
+    @Test
+    func isPure_matchesInferredEffect() throws {
+        let tree = Parser.parse(source: "func square(_ x: Int) -> Int { x * x }")
+        let function = try #require(tree.statements.first?.item.as(FunctionDeclSyntax.self))
+        #expect(inferrer.isPure(function))
+        #expect(inferrer.inferredEffect(for: function) == .pure)
+    }
+}


### PR DESCRIPTION
**Idea #4, step 1** — re-express SwiftProjectLint's testability purity check as `Effect.pure` inference, collapsing the two parallel effect vocabularies onto one type.

Background: the effect-vocabulary survey (`~/xcode_projects/PBT_EFFECT_VOCABULARY_SURVEY.md`) found the ecosystem conflates two orthogonal axes under collided names — *retry-safety* (SwiftEffectInference's lattice) and *purity / referential transparency* (the testability rules' ad-hoc markers). The proof is `print`: **observational** (retry-safe) to the lattice, yet **impure** to a property test. SwiftEffectInference [`7dc9673`](https://github.com/Joseph-Cursio/SwiftEffectInference/commit/7dc9673ff814baec8ac368dd18f57d6f74a0a727) added `pure` as the new lattice bottom; this PR consumes it.

## Part 1 — plumbing (`0d82934`)
- Bump the SEI pin to `7dc9673` across all three dependent packages.
- `EffectAnnotationParser` reads the new tier in both grammars: `@Pure` and `/// @lint.effect pure`.
- `IdempotencyViolationVisitor` makes `@lint.effect pure` an **enforceable contract** — a pure caller may call only pure callees, so every `pure → non-pure` pairing fires, including `pure → observational` (the case that separates the purity axis from retry-safety). New "Purity violation" diagnostic; rule doc updated with the Phase 3 row + examples.

## Part 2 — the unification (`8160372`)
- New **`PurityInferrer`** (`SwiftProjectLintVisitors`): returns `Effect.pure` ⟺ a function is referentially transparent (synchronous, non-throwing, no impurity marker, total). The impurity-marker set + totality checker moved out of the testability visitor **verbatim** — same verdict, shared vocabulary.
- `PureFunctionCandidateVisitor` now delegates purity to `purityInferrer.isPure(node)`, keeping only candidacy checks (free/static, has inputs, `Equatable` return).
- `effectFromAttributes` refactored to a fixed-tier dictionary lookup (the `@Pure` arm had pushed the switch past the cyclomatic-complexity limit).

The payoff: the testability rule, the idempotency rules, and the PBT-seeds pipeline all decide purity through one `Effect.pure` — no more two vocabularies in SPL.

## Tests
- 4 new idempotency pure-contract cases + 9 new `PurityInferrerTests`; all 25 existing `PureFunctionCandidateVisitor` tests still pass (behavior preserved).
- Full suite green: **2729 tests / 329 suites**. Zero SwiftLint warnings on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)