### PR TITLE
Bump SEI pin: refute clock/UUID nondeterminism in shared PurityInferrer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -62,7 +62,7 @@ let package = Package(
         // swift-syntax exact 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "b0751356cba09ed798a01a0a8930902d9955174c"
+            revision: "2b63b759e3bdf907d545f5d7aa1badf8355a4d8d"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintIdempotencyRules/Package.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // root and SwiftProjectLintVisitors pins.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "b0751356cba09ed798a01a0a8930902d9955174c"
+            revision: "2b63b759e3bdf907d545f5d7aa1badf8355a4d8d"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintVisitors/Package.swift
+++ b/Packages/SwiftProjectLintVisitors/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "b0751356cba09ed798a01a0a8930902d9955174c"
+            revision: "2b63b759e3bdf907d545f5d7aa1badf8355a4d8d"
         )
     ],
     targets: [


### PR DESCRIPTION
Idea #4 step-2 follow-up #1. Picks up SwiftEffectInference `2b63b75`, which adds `Date` / `UUID` / `CFAbsoluteTimeGetCurrent` to the shared `PurityInferrer`'s refuters so `Effect.pure` fully implies determinism.

## Effect on SwiftProjectLint
The testability `pureFunctionCandidate` signal forwards to the shared oracle, so it now correctly **withholds** the candidate nudge from functions that read the system clock or generate identities (previously a `Date()`/`UUID()`-calling function could be suggested as a PBT candidate — a false positive that leads to a flaky generated test).

Token-matched and deliberately conservative: it also over-refutes the deterministic `Date(timeIntervalSince1970:)` form. That's the sound direction (withhold `.pure` rather than risk claiming it for a clock read); the AST-precise carve-out remains in `NonInjectedNondeterminismVisitor`.

## Validation
- Full suite green: **2727 tests / 329 suites**.
- Companion landings: SEI `2b63b75` (52 tests), SIP `0ce9781` (SoundPurity inherits the stronger check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)