### PR TITLE
Add Animation Without Reduce Motion

### DIFF
--- a/Docs/accessibility-rule-proposals.md
+++ b/Docs/accessibility-rule-proposals.md
@@ -71,7 +71,20 @@ VStack {
 
 ---
 
-### 3. Animation Without Reduce Motion Check
+### 3. ~~Animation Without Reduce Motion Check~~ -- Implemented (`animationWithoutReduceMotion`)
+
+Shipped **opt-in** rather than merely Info-severity. The proposal treated Info as
+sufficient mitigation for the false-positive risk; in practice most SwiftUI views
+animate and few consult Reduce Motion, so enabling it by default would bury a
+codebase in findings on first run. It matches the posture of the other Info-severity
+heuristic rules instead.
+
+Detection also went slightly wider and slightly narrower than specified: `.transition`
+counts as animating alongside `.animation` and `withAnimation` (the proposal's own
+violating example relies on it), while `.animation(nil, …)`, `.transition(.opacity)`,
+and `.transition(.identity)` are excluded because they introduce no motion.
+`UIAccessibility.isReduceMotionEnabled` counts as consulting the preference, not just
+the SwiftUI environment value.
 
 **Source:** [User Settings](https://mobilea11y.com/guides/swiftui/swiftui-settings/)
 

--- a/Docs/rules/RULES.md
+++ b/Docs/rules/RULES.md
@@ -168,6 +168,7 @@ Rules marked **opt-in** are disabled by default and must be explicitly listed un
 | [Icon-Only Button Missing Label](icon-only-button-missing-label.md) | Warning |
 | [Control Missing Accessibility Label](control-missing-accessibility-label.md) | Warning |
 | [isButton Trait Without Action](is-button-trait-without-action.md) | Warning |
+| [Animation Without Reduce Motion](animation-without-reduce-motion.md) | Info |
 | [Long Text Accessibility](long-text-accessibility.md) | Info |
 | [Hardcoded Font Size](hardcoded-font-size.md) | Warning |
 | [onTapGesture Instead of Button](on-tap-gesture-instead-of-button.md) | Warning |

--- a/Docs/rules/animation-without-reduce-motion.md
+++ b/Docs/rules/animation-without-reduce-motion.md
@@ -1,0 +1,78 @@
+[← Back to Rules](RULES.md)
+
+## Animation Without Reduce Motion
+
+**Identifier:** `Animation Without Reduce Motion`
+**Category:** Accessibility
+**Severity:** Info
+**Opt-in:** yes — enable via `enabled_only`
+
+### Rationale
+Reduce Motion is not a preference about taste. People with vestibular disorders enable it because on-screen motion causes nausea, dizziness, and headaches; for them a spring animation is not a flourish but a symptom trigger. A view that scales, slides, or springs regardless of the setting can make an app physically unpleasant to use.
+
+Unlike most accessibility gaps, this one is invisible in every way a team normally checks. The view looks right, VoiceOver reads it correctly, contrast passes, and the layout survives Dynamic Type. Nothing surfaces the problem except testing with Reduce Motion switched on, which is rarely part of a review.
+
+### Discussion
+`AnimationWithoutReduceMotionVisitor` examines each `struct` conforming to `View` or `App` and asks one question: does this view animate, and does it ever mention Reduce Motion?
+
+This is a **struct-level** check by design. Asking per `.animation` call would be far noisier and would misrepresent how the fix works — a single `reduceMotion` property usually governs an entire view, so one mention anywhere in the view is enough to satisfy the rule. The rule reports at most once per view, at the first animation it finds.
+
+The scan runs over the view's member block rather than the view itself, so nested types are judged independently. A nested view's Reduce Motion check does not excuse its enclosing view, and vice versa.
+
+**Counts as animating:** `.animation(…)`, `withAnimation(…)`, and `.transition(…)`.
+
+**Counts as consulting the preference:** any mention of `accessibilityReduceMotion` — however it is used — or UIKit's `UIAccessibility.isReduceMotionEnabled`. The bar is deliberately low: reading the value at all means the author considered motion, and second-guessing *how* they used it would trade real signal for false positives.
+
+**Not treated as motion:** `.animation(nil, …)`, which switches animation off rather than on, and the `.opacity` and `.identity` transitions, which change no position or size.
+
+**Why opt-in:** most SwiftUI views animate and few consult Reduce Motion, so enabling this by default would bury a codebase in Info findings on first run. It is most valuable switched on deliberately, for a focused pass over animation-heavy views. This matches the posture of the other Info-severity heuristic rules (`flag-optional-pair-state`, `redundant-derived-property`).
+
+### Non-Violating Examples
+```swift
+// Reads the environment value and softens the motion
+struct MyView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isLoading = false
+
+    var body: some View {
+        Text("Loading")
+            .transition(reduceMotion ? .identity : .scale)
+            .animation(reduceMotion ? nil : .easeInOut, value: isLoading)
+    }
+}
+
+// A transition that moves nothing
+Text("Hello")
+    .transition(.opacity)
+
+// Animation explicitly disabled
+Text("Loading")
+    .animation(nil, value: isLoading)
+```
+
+### Violating Examples
+```swift
+// Scales and eases regardless of the user's setting
+struct MyView: View {
+    @State private var isLoading = false
+
+    var body: some View {
+        Text("Loading")
+            .transition(.scale)
+            .animation(.easeInOut, value: isLoading)
+    }
+}
+
+// A spring the user cannot turn off
+struct MyView: View {
+    @State private var expanded = false
+
+    var body: some View {
+        Button("Toggle") {
+            withAnimation(.spring()) { expanded.toggle() }
+        }
+    }
+}
+```
+
+---

--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/LintConfiguration.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/LintConfiguration.swift
@@ -110,7 +110,8 @@ public struct LintConfiguration: Sendable {
         .hoistableSequenceOperation,
         .mutuallyExclusivePresentationState,
         .flagOptionalPairState,
-        .redundantDerivedProperty
+        .redundantDerivedProperty,
+        .animationWithoutReduceMotion
     ]
 
     /// Default configuration — all rules enabled, no exclusions.

--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier+Category.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier+Category.swift
@@ -91,7 +91,8 @@ extension RuleIdentifier {
              .toggleButtonMissingSelectedTrait, .buttonTogglingBool,
              .stackMissingAccessibilityGrouping,
              .accessibilityHiddenConflict, .sortPriorityWithoutContainer,
-             .controlMissingAccessibilityLabel, .isButtonTraitWithoutAction:
+             .controlMissingAccessibilityLabel, .isButtonTraitWithoutAction,
+             .animationWithoutReduceMotion:
             return .accessibility
 
             // Memory Management Rules

--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
@@ -190,6 +190,7 @@ public enum RuleIdentifier: String, CaseIterable, Codable, Sendable {
     case sortPriorityWithoutContainer = "Sort Priority Without Container"
     case controlMissingAccessibilityLabel = "Control Missing Accessibility Label"
     case isButtonTraitWithoutAction = "isButton Trait Without Action"
+    case animationWithoutReduceMotion = "Animation Without Reduce Motion"
 
     // Memory Management Rules
     case potentialRetainCycle = "Potential Retain Cycle"

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/Accessibility.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/Accessibility.swift
@@ -15,7 +15,8 @@ class Accessibility: BasePatternRegistrar {
         registry.register(registrars: [
             HardcodedFontSize(),
             ControlMissingAccessibilityLabel(),
-            IsButtonTraitWithoutAction()
+            IsButtonTraitWithoutAction(),
+            AnimationWithoutReduceMotion()
         ])
     }
 

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/AnimationWithoutReduceMotion.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/AnimationWithoutReduceMotion.swift
@@ -1,0 +1,25 @@
+import Foundation
+import SwiftProjectLintModels
+import SwiftProjectLintRegistry
+import SwiftProjectLintVisitors
+
+/// A registrar for the Animation Without Reduce Motion pattern.
+///
+/// Provides the pattern for detecting SwiftUI views that animate without ever
+/// consulting the user's Reduce Motion preference. Opt-in.
+struct AnimationWithoutReduceMotion: PatternRegistrarProtocol {
+
+    var pattern: SyntaxPattern {
+        SyntaxPattern(
+            name: .animationWithoutReduceMotion,
+            visitor: AnimationWithoutReduceMotionVisitor.self,
+            severity: .info,
+            category: .accessibility,
+            messageTemplate: "View animates without checking accessibilityReduceMotion",
+            suggestion: "Read @Environment(\\.accessibilityReduceMotion) and use it to soften "
+                + "the motion, e.g. .animation(reduceMotion ? nil : .easeInOut, value:).",
+            description: "Detects SwiftUI views that animate but never consult the user's "
+                + "Reduce Motion preference. Opt-in — enable via enabled_only."
+        )
+    }
+}

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/AnimationWithoutReduceMotionVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/AnimationWithoutReduceMotionVisitor.swift
@@ -1,0 +1,141 @@
+import SwiftProjectLintModels
+import SwiftProjectLintVisitors
+import SwiftSyntax
+
+/// Detects a SwiftUI view that animates without ever consulting the user's
+/// Reduce Motion preference.
+///
+/// Reduce Motion is not a cosmetic setting. People with vestibular disorders
+/// enable it because motion on screen causes nausea and dizziness, so a view
+/// that scales, slides, or springs regardless of the setting can make an app
+/// physically unpleasant to use.
+///
+/// This is a **struct-level** check, deliberately: asking "does this view ever
+/// consider Reduce Motion?" once is far quieter than asking it of every
+/// individual `.animation` call, and a single `reduceMotion` check usually
+/// governs a whole view.
+///
+/// Flagged:
+/// ```swift
+/// struct MyView: View {
+///     @State private var isLoading = false
+///     var body: some View {
+///         Text("Loading")
+///             .transition(.scale)
+///             .animation(.easeInOut, value: isLoading)
+///     }
+/// }
+/// ```
+///
+/// Not flagged: any view mentioning `accessibilityReduceMotion` (however it uses
+/// it) or UIKit's `UIAccessibility.isReduceMotionEnabled`; `.animation(nil, …)`,
+/// which disables animation rather than adding it; and transitions that carry no
+/// motion, `.opacity` and `.identity`.
+final class AnimationWithoutReduceMotionVisitor: BasePatternVisitor {
+
+    required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
+        super.init(pattern: pattern, viewMode: viewMode)
+    }
+
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        if isTestOrFixtureFile() { return .visitChildren }
+        guard isSwiftUIView(node) else { return .visitChildren }
+
+        // Scan the member block rather than the struct, so a nested type's
+        // animations are not attributed to its enclosing view — and a nested
+        // type's Reduce Motion check does not excuse the outer one.
+        let scanner = MotionScanner(viewMode: .sourceAccurate)
+        scanner.walk(node.memberBlock)
+
+        guard let trigger = scanner.firstTrigger, scanner.checksReduceMotion == false else {
+            return .visitChildren
+        }
+
+        addIssue(
+            severity: .info,
+            message: "\(node.name.text) animates (\(trigger.description)) but never checks "
+                + "accessibilityReduceMotion — motion plays regardless of the user's preference",
+            filePath: getFilePath(for: Syntax(trigger.node)),
+            lineNumber: getLineNumber(for: Syntax(trigger.node)),
+            suggestion: "Read @Environment(\\.accessibilityReduceMotion) and use it to soften the "
+                + "motion, e.g. .animation(reduceMotion ? nil : .easeInOut, value: isLoading) "
+                + "or .transition(reduceMotion ? .identity : .scale).",
+            ruleName: .animationWithoutReduceMotion
+        )
+        return .visitChildren
+    }
+}
+
+/// Collects, from one view's members, whether it animates and whether it ever
+/// consults Reduce Motion. Nested type declarations are skipped so each view is
+/// judged on its own body.
+private final class MotionScanner: SyntaxVisitor {
+
+    struct Trigger {
+        let description: String
+        let node: FunctionCallExprSyntax
+    }
+
+    /// Identifiers that mean the view has consulted the preference. Any mention
+    /// counts — reading it at all implies the author considered motion.
+    private static let reduceMotionNames: Set<String> = [
+        "accessibilityReduceMotion",
+        "isReduceMotionEnabled"
+    ]
+
+    /// Transitions that move nothing, so they need no Reduce Motion handling.
+    private static let motionlessTransitions: Set<String> = ["opacity", "identity"]
+
+    private(set) var firstTrigger: Trigger?
+    private(set) var checksReduceMotion = false
+
+    override func visit(_ _: StructDeclSyntax) -> SyntaxVisitorContinueKind { .skipChildren }
+    override func visit(_ _: ClassDeclSyntax) -> SyntaxVisitorContinueKind { .skipChildren }
+    override func visit(_ _: EnumDeclSyntax) -> SyntaxVisitorContinueKind { .skipChildren }
+    override func visit(_ _: ActorDeclSyntax) -> SyntaxVisitorContinueKind { .skipChildren }
+
+    override func visit(_ node: TokenSyntax) -> SyntaxVisitorContinueKind {
+        if Self.reduceMotionNames.contains(node.text) {
+            checksReduceMotion = true
+        }
+        return .visitChildren
+    }
+
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        if firstTrigger == nil, let description = triggerDescription(node) {
+            firstTrigger = Trigger(description: description, node: node)
+        }
+        return .visitChildren
+    }
+
+    /// Names the animation this call introduces, or nil when it introduces none.
+    private func triggerDescription(_ node: FunctionCallExprSyntax) -> String? {
+        if node.calledExpression.as(DeclReferenceExprSyntax.self)?.baseName.text == "withAnimation" {
+            return "withAnimation"
+        }
+
+        guard let member = node.calledExpression.as(MemberAccessExprSyntax.self) else { return nil }
+
+        switch member.declName.baseName.text {
+        case "animation":
+            // `.animation(nil, value:)` switches animation off — the opposite of the problem.
+            guard let first = node.arguments.first,
+                  first.expression.is(NilLiteralExprSyntax.self) == false else { return nil }
+            return ".animation"
+
+        case "transition":
+            guard let first = node.arguments.first, carriesMotion(first.expression) else { return nil }
+            return ".transition"
+
+        default:
+            return nil
+        }
+    }
+
+    /// False for `.opacity` and `.identity`, which change no position or size.
+    private func carriesMotion(_ expression: ExprSyntax) -> Bool {
+        guard let member = expression.as(MemberAccessExprSyntax.self),
+              member.base == nil else { return true }
+        return Self.motionlessTransitions.contains(member.declName.baseName.text) == false
+    }
+}

--- a/Tests/CoreTests/Accessibility/AnimationWithoutReduceMotionVisitorTests.swift
+++ b/Tests/CoreTests/Accessibility/AnimationWithoutReduceMotionVisitorTests.swift
@@ -1,0 +1,200 @@
+@testable import Core
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+@Suite
+struct AnimationWithoutReduceMotionVisitorTests {
+
+    private func makeVisitor() -> AnimationWithoutReduceMotionVisitor {
+        let pattern = AnimationWithoutReduceMotion().pattern
+        return AnimationWithoutReduceMotionVisitor(pattern: pattern)
+    }
+
+    private func runVisitor(_ visitor: AnimationWithoutReduceMotionVisitor, source: String) {
+        let sourceFile = Parser.parse(source: source)
+        visitor.walk(sourceFile)
+    }
+
+    // MARK: - Positive Cases
+
+    @Test
+    func detectsAnimatingViewWithNoReduceMotionCheck() throws {
+        let source = """
+        import SwiftUI
+
+        struct MyView: View {
+            @State private var isLoading = false
+
+            var body: some View {
+                Text("Loading")
+                    .transition(.scale)
+                    .animation(.easeInOut, value: isLoading)
+            }
+        }
+        """
+
+        let visitor = makeVisitor()
+        runVisitor(visitor, source: source)
+
+        #expect(visitor.detectedIssues.count == 1)
+
+        let issue = try #require(visitor.detectedIssues.first)
+        #expect(issue.ruleName == .animationWithoutReduceMotion)
+        #expect(issue.severity == .info)
+        #expect(issue.message.contains("MyView"))
+        #expect(issue.message.contains("accessibilityReduceMotion"))
+    }
+
+    @Test
+    func detectsWithAnimationCall() {
+        let source = """
+        import SwiftUI
+
+        struct MyView: View {
+            @State private var expanded = false
+
+            var body: some View {
+                Button("Toggle") {
+                    withAnimation(.spring()) { expanded.toggle() }
+                }
+            }
+        }
+        """
+
+        let visitor = makeVisitor()
+        runVisitor(visitor, source: source)
+
+        #expect(visitor.detectedIssues.count == 1)
+    }
+
+    /// The scan is per-view: a nested view's Reduce Motion check does not excuse
+    /// the enclosing view, which animates on its own.
+    @Test
+    func nestedViewsCheckDoesNotExcuseTheOuterView() throws {
+        let source = """
+        import SwiftUI
+
+        struct OuterView: View {
+            @State private var isLoading = false
+
+            var body: some View {
+                Text("Loading")
+                    .animation(.easeInOut, value: isLoading)
+            }
+
+            struct InnerView: View {
+                @Environment(\\.accessibilityReduceMotion) private var reduceMotion
+
+                var body: some View {
+                    Text("Inner")
+                }
+            }
+        }
+        """
+
+        let visitor = makeVisitor()
+        runVisitor(visitor, source: source)
+
+        #expect(visitor.detectedIssues.count == 1)
+
+        let issue = try #require(visitor.detectedIssues.first)
+        #expect(issue.message.contains("OuterView"))
+    }
+
+    // MARK: - Negative Cases
+
+    @Test("No issue when motion is absent or the preference is consulted", arguments: [
+        // Reads the environment value
+        """
+        import SwiftUI
+
+        struct MyView: View {
+            @Environment(\\.accessibilityReduceMotion) private var reduceMotion
+            @State private var isLoading = false
+
+            var body: some View {
+                Text("Loading")
+                    .animation(reduceMotion ? nil : .easeInOut, value: isLoading)
+            }
+        }
+        """,
+        // UIKit-era check counts too
+        """
+        import SwiftUI
+
+        struct MyView: View {
+            @State private var isLoading = false
+
+            var body: some View {
+                Text("Loading")
+                    .animation(UIAccessibility.isReduceMotionEnabled ? nil : .easeInOut,
+                               value: isLoading)
+            }
+        }
+        """,
+        // .animation(nil, …) disables animation rather than adding it
+        """
+        import SwiftUI
+
+        struct MyView: View {
+            @State private var isLoading = false
+
+            var body: some View {
+                Text("Loading")
+                    .animation(nil, value: isLoading)
+            }
+        }
+        """,
+        // A transition that moves nothing
+        """
+        import SwiftUI
+
+        struct MyView: View {
+            var body: some View {
+                Text("Hello")
+                    .transition(.opacity)
+            }
+        }
+        """,
+        // .identity likewise
+        """
+        import SwiftUI
+
+        struct MyView: View {
+            var body: some View {
+                Text("Hello")
+                    .transition(.identity)
+            }
+        }
+        """,
+        // Not a SwiftUI view
+        """
+        import Foundation
+
+        struct AnimationSettings {
+            func apply() {
+                withAnimation(.spring()) { }
+            }
+        }
+        """,
+        // No animation at all
+        """
+        import SwiftUI
+
+        struct MyView: View {
+            var body: some View {
+                Text("Hello")
+                    .padding()
+            }
+        }
+        """
+    ])
+    func noIssue(source: String) {
+        let visitor = makeVisitor()
+        runVisitor(visitor, source: source)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+}


### PR DESCRIPTION
## What

A new opt-in, Info-severity Accessibility rule, `animationWithoutReduceMotion`, flagging SwiftUI views that animate without ever consulting the user's Reduce Motion preference.

## Why

Reduce Motion is not a preference about taste. People with vestibular disorders enable it because on-screen motion causes nausea, dizziness, and headaches — a spring animation is a symptom trigger, not a flourish.

Before this, `reduceMotion` appeared **nowhere** in `Sources` or `Packages`. The linter shipped ~8 animation rules (`excessive-spring-animations`, `conflicting-animations`, `long-animation-duration`, …) and none of them considered the one animation problem that physically hurts people.

The gap is easy to miss because it is invisible to every check a team normally runs: the view looks right, VoiceOver reads it correctly, contrast passes, and the layout survives Dynamic Type. Only switching Reduce Motion on reveals it, and that is rarely part of review.

## Struct-level by design

The rule asks one question per view — *does this view animate, and does it ever mention Reduce Motion?* — and reports at most once, at the first animation found.

Per-call detection would be far noisier and would misrepresent how the fix works: a single `reduceMotion` property usually governs an entire view, so one mention anywhere in it is enough.

The scan runs over the view's **member block** rather than the view itself, so nested types are judged independently. A nested view's Reduce Motion check does not excuse its enclosing view. There is a dedicated test for that (`nestedViewsCheckDoesNotExcuseTheOuterView`).

## Two deliberate departures from proposal 3

**1. Opt-in, not merely Info severity.** The proposal in `Docs/accessibility-rule-proposals.md` treated Info as sufficient mitigation for the false-positive risk. I don't think it is: most SwiftUI views animate and almost none consult Reduce Motion, so enabled by default this would bury a first run in Info findings and get ignored wholesale. Opt-in matches the posture of the other Info-severity heuristic rules (`flag-optional-pair-state`, `redundant-derived-property`).

**If you'd rather it run by default, it is one line out of `LintConfiguration.optInRules`.**

**2. Detection went both wider and narrower than specified.**

*Wider:* `.transition` counts as animating alongside `.animation` and `withAnimation` — the proposal's own violating example depends on it, and its suggested fix addresses it.

*Narrower:* `.animation(nil, …)` is excluded because it switches animation **off**, and `.transition(.opacity)` / `.transition(.identity)` because they move nothing. This addresses the proposal's stated worry about opacity and colour animations structurally, rather than leaving it to severity alone.

## A deliberately low bar for "consulted the preference"

Any mention of `accessibilityReduceMotion` satisfies the rule, however it is used, as does UIKit's `UIAccessibility.isReduceMotionEnabled`. Reading the value at all means the author considered motion; second-guessing *how* they used it would trade real signal for false positives.

## Verification

- Full suite on a clean build: **3426 passed, 0 failures** at time of push, with only the AppTests tail outstanding — that stretch exercises SwiftUI views via ViewInspector and cannot reach a linter rule. Will confirm the final tally on the PR.
- New rule: 3 positive cases (canonical `.transition` + `.animation`, `withAnimation`, nested-view attribution) and 7 negative (environment value read, `UIAccessibility` check, `.animation(nil)`, `.transition(.opacity)`, `.transition(.identity)`, non-`View` struct, no animation at all)
- 180 tests across 21 config and accessibility suites pass
- SwiftLint clean — it caught unused parameters in the nested-type overrides and switch-case spacing, both fixed in the code rather than by loosening config

`swift package clean` was run after touching `RuleIdentifier`, per the note added in #49, and the new case is appended at the end of the accessibility block rather than inserted mid-list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9aFzxaoGndRftLYAZQEdf