### PR TITLE
Register the two accessibility rules that were only documented as opt-in

### DIFF
--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/LintConfiguration.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/LintConfiguration.swift
@@ -111,7 +111,15 @@ public struct LintConfiguration: Sendable {
         .mutuallyExclusivePresentationState,
         .flagOptionalPairState,
         .redundantDerivedProperty,
-        .animationWithoutReduceMotion
+        .animationWithoutReduceMotion,
+        // Both of these were authored as opt-in — their rule docs say so, their
+        // registrar descriptions say "Disabled by default", and the commits that
+        // added them are titled "(opt-in)" — but neither was ever registered here,
+        // so both ran by default. See Docs/rules/missing-dynamic-type-support.md
+        // and Docs/rules/decorative-image-missing-trait.md for why each is
+        // heuristic enough to warrant opting in.
+        .missingDynamicTypeSupport,
+        .decorativeImageMissingTrait
     ]
 
     /// Default configuration — all rules enabled, no exclusions.


### PR DESCRIPTION
## The bug

`missingDynamicTypeSupport` and `decorativeImageMissingTrait` were authored as opt-in and documented that way in **three** places — but neither was ever registered in `LintConfiguration.optInRules`, so both have been running by default.

| Source | Says |
|---|---|
| `Docs/rules/missing-dynamic-type-support.md:7` | "Severity: Info *(opt-in)*", with line 17 explaining why |
| `Docs/rules/decorative-image-missing-trait.md:7` | "Severity: Info *(opt-in)*", with line 20 explaining why |
| Both registrar descriptions in `Accessibility.swift` | "Disabled by default." |
| `LintConfiguration.optInRules` | **neither rule listed** |

`resolveRules` has exactly one default-disable mechanism — `rules.subtract(Self.optInRules)` — and neither rule was in the set. No shipped config disabled them either; `Docs/configs/duplication-family.yml` is unrelated.

## Why this is safe: the pickaxe is empty

This is an omission, not a deliberate reversal someone will want back:

```
git log -S'missingDynamicTypeSupport'   -- LintConfiguration.swift  → empty
git log -S'decorativeImageMissingTrait' -- LintConfiguration.swift  → empty
```

Neither identifier has *ever* appeared in that file, in any revision. That rules out the one hypothesis that would make this change risky — that someone registered them, hit a problem, and backed it out. What remains is an authoring-time omission.

Corroborating: the commits that introduced the rules are titled `Add missing-dynamic-type-support accessibility rule (opt-in)` and `Add decorative-image-missing-trait accessibility rule (opt-in)`.

*(Technique borrowed from `Docs/archive/history-aware-drift-and-sync-contracts-design.md` — an empty pickaxe is not a null result, it is the answer.)*

## What changes for users

**This disables two rules that currently run.** Anyone relying on them will need `enabled_only`. That is the documented intent being restored, not a regression, but it is a real user-visible change and worth saying plainly.

Nothing in this repo relied on them:

- **CI is unaffected.** `.github/workflows/ci.yml:33` runs `swift run CLI . --include-nested-packages --threshold error`. Both rules are Info severity, so `--threshold error` already filtered them out — CI has never seen their output.
- **The repo's own `.swiftprojectlint.yml` doesn't mention them.** It sets `include_nested_packages`, two `excluded_paths`, and one per-rule exclusion for `Discarded Try Result`. No `enabled_only`.

## Why the registration carries a comment

The two entries are annotated at the site with the evidence for their existence — rule docs, registrar text, commit titles. Without it, a future reader diffing `optInRules` against the rules that *look* heuristic could reasonably conclude these were added by mistake and remove them, recreating the bug. The PR description would be long forgotten by then.

## Verification

- `RuleResolutionLawsTests` passes, including `optInRulesRequireExplicitEnabling` (line 129), which asserts the default rule set is disjoint from `optInRules` — precisely the law being violated before this change. It derives its expectations from the constant rather than hardcoding a list, so it adapts.
- Both visitor test suites still pass; they invoke their visitors directly and bypass config resolution, so they were never affected either way.
- 78 tests across 6 config and accessibility suites pass.
- Full suite running at time of opening; will report.

Rebased onto `main` after #50 merged, resolving the expected one-line `optInRules` conflict by keeping both entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9aFzxaoGndRftLYAZQEdf