### PR TITLE
Extend Control Missing Accessibility Label to more controls and empty closures

### DIFF
--- a/Docs/accessibility-rule-proposals.md
+++ b/Docs/accessibility-rule-proposals.md
@@ -215,7 +215,26 @@ HStack {
 
 ---
 
-### 6. Unlabeled Toggle, Slider, or Picker
+### 6. ~~Unlabeled Toggle, Slider, or Picker~~ -- Implemented (folded into `controlMissingAccessibilityLabel`)
+
+Shipped as an extension of the existing rule, which already handled the empty-*string*
+form for `Toggle`/`Button`. The extension adds `Slider`, `Stepper`, and `Picker`, plus
+the empty-*closure* form the original rule explicitly left alone.
+
+Split deliberately from the **absent**-label case. The proposal's wording ("the label
+closure is empty or the string title is empty") is about labels that are present but
+blank; a control written with no label at all — `Slider(value:in:)` — is a different and
+far more common shape. Folding both into one default-on Warning rule would have turned a
+quiet rule noisy overnight, so the absent case is tracked as its own rule instead.
+
+`Picker` is excluded from the closure check on purpose: its trailing closure is the
+option *content*, not the label, so an empty one there means something else entirely.
+
+The proposal's own false-positive note — controls intentionally unlabeled inside a
+`.accessibilityElement(children: .combine)` group — is handled, and `.ignore` too. Since
+a parent's modifier call is an ancestor of the control in the syntax tree, one upward
+walk covers both the control's own chain and any enclosing container's. `.contain` does
+not suppress, because it leaves children as individual elements.
 
 **Source:** [Named Controls](https://mobilea11y.com/guides/swiftui/swiftui-controls/)
 

--- a/Docs/rules/control-missing-accessibility-label.md
+++ b/Docs/rules/control-missing-accessibility-label.md
@@ -11,8 +11,19 @@ An interactive control built with an **empty string label** — `Toggle("", isOn
 
 This is distinct from [Icon-Only Button Missing Label](icon-only-button-missing-label.md): there the label argument is *absent* (a `Button { Image(...) }`); here it is *present but empty*.
 
+The same distinction bounds this rule generally: it is about labels that are **present but empty**. A control written with no label at all — `Slider(value:in:)` — is a different and far more common shape, and is not flagged here.
+
 ### Discussion
-`ControlMissingAccessibilityLabelVisitor` flags a `Toggle` or `Button` whose first positional argument is an empty string literal, unless a `.accessibilityLabel(…)` modifier is applied to the control's modifier chain (checked by walking up from the control). Non-empty labels and the closure-label form are left alone.
+`ControlMissingAccessibilityLabelVisitor` covers `Toggle`, `Button`, `Slider`, `Stepper`, and `Picker`, and recognises two shapes of empty label:
+
+- **An empty string title** — `Toggle("", isOn:)`, `Picker("", selection:)`
+- **An empty label closure** — `Toggle(isOn:) { }`, or one whose only content is `EmptyView()`
+
+`Picker` is deliberately excluded from the closure check. Its trailing closure is the *content* — the list of options — not the label, so an empty one there means something else entirely and is not this rule's business. Its label is the string title or an explicit `label:` argument.
+
+The rule stays quiet when a `.accessibilityLabel(…)` modifier is applied to the control's chain, and when an ancestor applies `.accessibilityElement(children: .combine)` or `.ignore`: those hand naming to the parent, so an unlabeled child is harmless. `.contain` does **not** suppress, because it keeps children as individual elements, leaving an unlabeled one still unlabeled.
+
+Because a parent's modifier call is an ancestor of the control in the syntax tree, one upward walk covers both the control's own chain and any enclosing container's.
 
 The fix is to pass the real label and hide it visually rather than blanking it: `Toggle(name, isOn:).labelsHidden()` keeps the exact same layout while giving VoiceOver a name. Or add `.accessibilityLabel("…")`.
 
@@ -24,6 +35,19 @@ Toggle(rule.name, isOn: $isEnabled).labelsHidden()  // label set, hidden visuall
 
 Toggle("", isOn: $isEnabled)
     .accessibilityLabel("Enable rule")              // compensating modifier
+
+Picker("Theme", selection: $theme) {                // trailing closure is content,
+    Text("Light").tag(0)                            // not a label
+    Text("Dark").tag(1)
+}
+
+Slider(value: $volume, in: 0...1)                   // label absent, not empty
+
+HStack {
+    Text("Bold")
+    Toggle("", isOn: $isBold).labelsHidden()        // parent names the group
+}
+.accessibilityElement(children: .combine)
 ```
 
 ### Violating Examples
@@ -32,6 +56,12 @@ Toggle("", isOn: $isEnabled)
     .labelsHidden()                                 // unlabeled checkbox for VoiceOver
 
 Button("", action: save)                            // unlabeled button
+
+Toggle(isOn: $isEnabled) { }                        // empty label closure
+
+Slider(value: $volume, in: 0...1) { EmptyView() }   // renders nothing
+
+Stepper("", value: $count)                          // unlabeled stepper
 ```
 
 ---

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/ControlMissingAccessibilityLabelVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/ControlMissingAccessibilityLabelVisitor.swift
@@ -2,7 +2,7 @@ import SwiftProjectLintModels
 import SwiftProjectLintVisitors
 import SwiftSyntax
 
-/// Detects an interactive control created with an **empty string label** and no
+/// Detects an interactive control whose label is **present but empty**, with no
 /// compensating `.accessibilityLabel`.
 ///
 /// `Toggle("", isOn:).labelsHidden()` and `Button("", action:)` are visible and
@@ -10,15 +10,39 @@ import SwiftSyntax
 /// unlabeled checkbox/button. (This is exactly the gap the icon-only-button rule
 /// doesn't cover, since here the label argument is present but empty.)
 ///
+/// Two shapes count as an empty label:
+/// - an empty string title — `Toggle("", isOn:)`, `Picker("", selection:)`
+/// - an empty label closure — `Toggle(isOn:) { }`, `Stepper(value:) { EmptyView() }`
+///
+/// `Picker` is deliberately excluded from the closure check: its trailing closure
+/// is the *content* (the options), not the label, so an empty one there means
+/// something else entirely.
+///
 /// Not flagged:
 /// - a non-empty label: `Toggle("Bold", isOn:)`
 /// - an empty label with a compensating modifier: `Toggle("", isOn:).accessibilityLabel("Bold")`
+/// - a control whose label is *absent* rather than empty — `Slider(value:in:)` — which
+///   is a different (and much more common) shape
+/// - a control inside a group that merges or ignores its children, since the parent
+///   then supplies the accessible name
 /// - the closure-label form `Button(action:) { Image(...) }` (handled by the
 ///   Icon-Only Button Missing Label rule)
 final class ControlMissingAccessibilityLabelVisitor: BasePatternVisitor {
 
     /// Controls whose first positional argument is their (accessible) title.
-    private static let labeledControls: Set<String> = ["Toggle", "Button"]
+    private static let labeledControls: Set<String> = [
+        "Toggle", "Button", "Slider", "Stepper", "Picker"
+    ]
+
+    /// Controls whose trailing closure is the label. `Picker`'s is the option
+    /// content, so it is absent here on purpose.
+    private static let closureLabelledControls: Set<String> = [
+        "Toggle", "Slider", "Stepper"
+    ]
+
+    /// Parent groupings that take over naming, making an unlabeled child harmless:
+    /// `.combine` merges the children's labels, `.ignore` removes them from the tree.
+    private static let groupingChildBehaviours: Set<String> = ["combine", "ignore"]
 
     required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
         super.init(pattern: pattern, viewMode: viewMode)
@@ -27,9 +51,7 @@ final class ControlMissingAccessibilityLabelVisitor: BasePatternVisitor {
     override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
         guard let callee = node.calledExpression.as(DeclReferenceExprSyntax.self),
               Self.labeledControls.contains(callee.baseName.text),
-              let firstArgument = node.arguments.first,
-              firstArgument.label == nil,
-              isEmptyStringLiteral(firstArgument.expression) else {
+              let emptiness = emptyLabelShape(of: node, control: callee.baseName.text) else {
             return .visitChildren
         }
 
@@ -40,9 +62,12 @@ final class ControlMissingAccessibilityLabelVisitor: BasePatternVisitor {
             return .visitChildren
         }
 
+        // A parent that merges or ignores its children names the group itself.
+        guard isInsideNamingGroup(node) == false else { return .visitChildren }
+
         addIssue(
             severity: .warning,
-            message: "\(callee.baseName.text) has an empty label and no .accessibilityLabel "
+            message: "\(callee.baseName.text) has \(emptiness) and no .accessibilityLabel "
                 + "— it is unlabeled for VoiceOver",
             filePath: getFilePath(for: Syntax(node)),
             lineNumber: getLineNumber(for: Syntax(node)),
@@ -52,6 +77,71 @@ final class ControlMissingAccessibilityLabelVisitor: BasePatternVisitor {
             ruleName: .controlMissingAccessibilityLabel
         )
         return .visitChildren
+    }
+
+    /// Describes how the control's label is empty, or nil when it is not.
+    private func emptyLabelShape(of node: FunctionCallExprSyntax, control: String) -> String? {
+        if let firstArgument = node.arguments.first,
+           firstArgument.label == nil,
+           isEmptyStringLiteral(firstArgument.expression) {
+            return "an empty label"
+        }
+
+        guard Self.closureLabelledControls.contains(control) else { return nil }
+
+        // `Toggle(isOn:) { }` — the trailing closure is the label, and it renders nothing.
+        if let trailing = node.trailingClosure, isEmptyClosure(trailing) {
+            return "an empty label closure"
+        }
+        // The explicit `label:` spelling.
+        if let labelArgument = node.arguments.first(where: { $0.label?.text == "label" }),
+           let closure = labelArgument.expression.as(ClosureExprSyntax.self),
+           isEmptyClosure(closure) {
+            return "an empty label closure"
+        }
+        return nil
+    }
+
+    /// True for `{ }` and for a closure whose only content is `EmptyView()`.
+    private func isEmptyClosure(_ closure: ClosureExprSyntax) -> Bool {
+        let statements = closure.statements
+        if statements.isEmpty { return true }
+        guard statements.count == 1,
+              let call = statements.first?.item.as(FunctionCallExprSyntax.self),
+              let callee = call.calledExpression.as(DeclReferenceExprSyntax.self) else {
+            return false
+        }
+        return callee.baseName.text == "EmptyView" && call.arguments.isEmpty
+    }
+
+    /// True when any ancestor applies `.accessibilityElement(children: .combine/.ignore)`.
+    ///
+    /// A parent's modifier call is an ancestor of the control in the syntax tree, so one
+    /// upward walk covers both the control's own chain and any enclosing container's —
+    /// no separate parent tracking needed.
+    private func isInsideNamingGroup(_ node: FunctionCallExprSyntax) -> Bool {
+        var current: Syntax? = Syntax(node)
+
+        while let syntax = current {
+            if let call = syntax.as(FunctionCallExprSyntax.self),
+               let member = call.calledExpression.as(MemberAccessExprSyntax.self),
+               member.declName.baseName.text == "accessibilityElement",
+               groupsChildren(call.arguments) {
+                return true
+            }
+            current = syntax.parent
+        }
+        return false
+    }
+
+    private func groupsChildren(_ arguments: LabeledExprListSyntax) -> Bool {
+        arguments.contains { argument in
+            guard argument.label?.text == "children",
+                  let member = argument.expression.as(MemberAccessExprSyntax.self) else {
+                return false
+            }
+            return Self.groupingChildBehaviours.contains(member.declName.baseName.text)
+        }
     }
 
     /// True for `""` and a literal made only of empty string segments (no interpolation).

--- a/Tests/CoreTests/Accessibility/ControlMissingAccessibilityLabelVisitorTests.swift
+++ b/Tests/CoreTests/Accessibility/ControlMissingAccessibilityLabelVisitorTests.swift
@@ -45,7 +45,126 @@ struct ControlMissingAccessibilityLabelVisitorTests {
         #expect(analyze(source).count == 1)
     }
 
+    @Test func testFlagsEmptyStringTitleOnNewControls() {
+        // Slider, Stepper and Picker all take a title as their first positional argument.
+        let sources = [
+            #"struct V: View { var body: some View { Picker("", selection: $c) { Text("A") } } }"#,
+            #"struct V: View { var body: some View { Stepper("", value: $n) } }"#
+        ]
+        for source in sources {
+            #expect(analyze(source).count == 1, "expected one issue for: \(source)")
+        }
+    }
+
+    @Test func testFlagsEmptyLabelClosure() throws {
+        let source = """
+        struct V: View {
+            @State private var on = false
+            var body: some View {
+                Toggle(isOn: $on) { }
+            }
+        }
+        """
+        let issues = analyze(source)
+        let issue = try #require(issues.first)
+        #expect(issues.count == 1)
+        #expect(issue.message.contains("empty label closure"))
+    }
+
+    @Test func testFlagsEmptyViewLabelClosure() {
+        // `EmptyView()` renders nothing, so it is an empty label in every sense that matters.
+        let source = """
+        struct V: View {
+            @State private var volume = 0.5
+            var body: some View {
+                Slider(value: $volume, in: 0...1) { EmptyView() }
+            }
+        }
+        """
+        #expect(analyze(source).count == 1)
+    }
+
     // MARK: - Negative (no false positives)
+
+    @Test func testPickerContentClosureNotTreatedAsLabel() {
+        // A Picker's trailing closure is its option content, not its label. A titled
+        // Picker with options is correct and must not be flagged.
+        let source = """
+        struct V: View {
+            @State private var choice = 0
+            var body: some View {
+                Picker("Theme", selection: $choice) {
+                    Text("Light").tag(0)
+                    Text("Dark").tag(1)
+                }
+            }
+        }
+        """
+        #expect(analyze(source).isEmpty)
+    }
+
+    @Test func testAbsentLabelNotFlaggedHere() {
+        // A missing label is a different shape from an empty one, and is not this
+        // rule's concern.
+        let source = """
+        struct V: View {
+            @State private var volume = 0.5
+            var body: some View { Slider(value: $volume, in: 0...1) }
+        }
+        """
+        #expect(analyze(source).isEmpty)
+    }
+
+    @Test func testEmptyLabelInsideCombiningGroupNotFlagged() {
+        // The parent merges its children's labels, so the control is named by the group.
+        let source = """
+        struct V: View {
+            @State private var on = false
+            var body: some View {
+                HStack {
+                    Text("Bold")
+                    Toggle("", isOn: $on).labelsHidden()
+                }
+                .accessibilityElement(children: .combine)
+            }
+        }
+        """
+        #expect(analyze(source).isEmpty)
+    }
+
+    @Test func testEmptyLabelInsideIgnoringGroupNotFlagged() {
+        let source = """
+        struct V: View {
+            @State private var on = false
+            var body: some View {
+                HStack {
+                    Text("Bold")
+                    Toggle("", isOn: $on).labelsHidden()
+                }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("Bold")
+            }
+        }
+        """
+        #expect(analyze(source).isEmpty)
+    }
+
+    @Test func testContainedGroupStillFlags() {
+        // `.contain` keeps children as individual elements, so an unlabeled child
+        // stays unlabeled — this must still be flagged.
+        let source = """
+        struct V: View {
+            @State private var on = false
+            var body: some View {
+                HStack {
+                    Toggle("", isOn: $on).labelsHidden()
+                }
+                .accessibilityElement(children: .contain)
+            }
+        }
+        """
+        #expect(analyze(source).count == 1)
+    }
 
     @Test func testNonEmptyLabelNotFlagged() {
         let source = """


### PR DESCRIPTION
## What

Extends the existing `controlMissingAccessibilityLabel` rule rather than adding a new one. It covered an empty string title on `Toggle` and `Button`; it now also covers `Slider`, `Stepper`, and `Picker`, plus the empty **closure** label the original explicitly left alone — `Toggle(isOn:) { }`, or a closure whose only content is `EmptyView()`.

This is proposal 6 from `Docs/accessibility-rule-proposals.md`.

## Scope: empty, not absent

The rule remains about labels that are **present but empty**. A control written with no label at all — `Slider(value: $v, in: 0...1)` — is a different and far more common shape.

That split is deliberate. `Slider(value:in:)` is the ordinary way people write a slider, so folding the absent case in would turn a quiet, default-on **Warning** rule noisy overnight. The absent-label case is tracked as its own rule, where it can be opt-in.

There is a test (`testAbsentLabelNotFlaggedHere`) pinning that boundary so it doesn't erode.

## `Picker` is excluded from the closure check

Worth reviewing carefully, because the four controls are not alike:

| Control | Trailing closure is… |
|---|---|
| `Toggle(isOn:label:)` | the **label** |
| `Stepper(value:in:step:label:)` | the **label** |
| `Slider(value:in:step:label:)` | the **label** |
| `Picker(selection:label:content:)` | the **content** — the options, *not* the label |

Treating all four alike would mean flagging `Picker("Theme", selection:) { … }` — a perfectly correct titled picker — because its option list "isn't a label". `Picker` is checked on its string title only. `testPickerContentClosureNotTreatedAsLabel` covers it.

## Closes the false positive the proposal left open

Proposal 6 noted that controls are sometimes intentionally unlabeled when a parent groups them, and said this "would need to check for that". It does now:

- `.accessibilityElement(children: .combine)` on any ancestor suppresses — the parent merges the children's labels
- `.ignore` likewise — it removes children from the accessibility tree entirely
- `.contain` does **not** suppress, because it keeps children as individual elements, so an unlabeled child stays unlabeled

The implementation is a single upward walk, not separate parent tracking. A parent's modifier call is already an ancestor of the control in the syntax tree, so one loop covers the control's own chain and any enclosing container's together.

## Verification

- **14 tests pass** in the rule's suite — the 5 original plus 9 new, covering the new controls, both empty-closure spellings, the `Picker` distinction, all three `children:` behaviours, and the empty-vs-absent boundary
- **2925 tests in 348 suites pass** (full linter suite, `--skip AppTests`)
- SwiftLint clean on the changed paths
- AppTests running separately; it drives SwiftUI views through ViewInspector and cannot reach a linter rule

No new `RuleIdentifier`, no registrar change — the concern, category, and severity are unchanged, so anyone who has disabled `Control Missing Accessibility Label` keeps all of it disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9aFzxaoGndRftLYAZQEdf