### PR TITLE
Add Unlabeled Control

### DIFF
--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/LintConfiguration.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/LintConfiguration.swift
@@ -119,7 +119,10 @@ public struct LintConfiguration: Sendable {
         // and Docs/rules/decorative-image-missing-trait.md for why each is
         // heuristic enough to warrant opting in.
         .missingDynamicTypeSupport,
-        .decorativeImageMissingTrait
+        .decorativeImageMissingTrait,
+        // Opt-in: `Slider(value:in:)` is the ordinary spelling, so this would fire
+        // across most codebases on a default run.
+        .unlabeledControl
     ]
 
     /// Default configuration — all rules enabled, no exclusions.

--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier+Category.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier+Category.swift
@@ -92,7 +92,7 @@ extension RuleIdentifier {
              .stackMissingAccessibilityGrouping,
              .accessibilityHiddenConflict, .sortPriorityWithoutContainer,
              .controlMissingAccessibilityLabel, .isButtonTraitWithoutAction,
-             .animationWithoutReduceMotion:
+             .animationWithoutReduceMotion, .unlabeledControl:
             return .accessibility
 
             // Memory Management Rules

--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
@@ -191,6 +191,7 @@ public enum RuleIdentifier: String, CaseIterable, Codable, Sendable {
     case controlMissingAccessibilityLabel = "Control Missing Accessibility Label"
     case isButtonTraitWithoutAction = "isButton Trait Without Action"
     case animationWithoutReduceMotion = "Animation Without Reduce Motion"
+    case unlabeledControl = "Unlabeled Control"
 
     // Memory Management Rules
     case potentialRetainCycle = "Potential Retain Cycle"

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/Accessibility.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/Accessibility.swift
@@ -16,7 +16,8 @@ class Accessibility: BasePatternRegistrar {
             HardcodedFontSize(),
             ControlMissingAccessibilityLabel(),
             IsButtonTraitWithoutAction(),
-            AnimationWithoutReduceMotion()
+            AnimationWithoutReduceMotion(),
+            UnlabeledControl()
         ])
     }
 

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/UnlabeledControl.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/UnlabeledControl.swift
@@ -1,0 +1,26 @@
+import Foundation
+import SwiftProjectLintModels
+import SwiftProjectLintRegistry
+import SwiftProjectLintVisitors
+
+/// A registrar for the Unlabeled Control pattern.
+///
+/// Provides the pattern for detecting controls written with no label at all —
+/// only `Slider` and `ProgressView` have label-less initializers. Opt-in.
+struct UnlabeledControl: PatternRegistrarProtocol {
+
+    var pattern: SyntaxPattern {
+        SyntaxPattern(
+            name: .unlabeledControl,
+            visitor: UnlabeledControlVisitor.self,
+            severity: .warning,
+            category: .accessibility,
+            messageTemplate: "Control has no label — VoiceOver announces its value "
+                + "and role but not what it controls",
+            suggestion: "Add a label closure, e.g. Slider(value:in:) { Text(\"Volume\") }, "
+                + "or add .accessibilityLabel(\"Volume\").",
+            description: "Detects Slider and ProgressView written without a label. "
+                + "Opt-in — enable via enabled_only."
+        )
+    }
+}

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/AccessibilityTreeTraverser.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/AccessibilityTreeTraverser.swift
@@ -73,6 +73,51 @@ class AccessibilityTreeTraverser {
         return false
     }
 
+    /// Parent groupings that take over naming, making an unlabeled child harmless:
+    /// `.combine` merges the children's labels into one, `.ignore` removes them from
+    /// the accessibility tree. `.contain` is absent on purpose — it keeps children as
+    /// individual elements, so an unlabeled one stays unlabeled.
+    private static let groupingChildBehaviours: Set<String> = ["combine", "ignore"]
+
+    /// Whether any ancestor applies `.accessibilityElement(children: .combine/.ignore)`,
+    /// which hands naming to the parent.
+    ///
+    /// Unlike `hasAccessibilityModifier`, this walks the *whole* ancestor chain rather
+    /// than the node's own modifier chain — and that is the point. A container's
+    /// modifier call is an ancestor of the controls inside it:
+    /// ```
+    /// FunctionCallExpr(.accessibilityElement)      ← ancestor
+    ///   └─ MemberAccessExpr(.accessibilityElement)
+    ///        └─ FunctionCallExpr(HStack)
+    ///             └─ … └─ FunctionCallExpr(Toggle) ← the control
+    /// ```
+    /// so one upward walk covers both the control's own chain and any enclosing
+    /// container's, with no separate parent tracking.
+    static func isInsideNamingGroup(_ node: FunctionCallExprSyntax) -> Bool {
+        var current: Syntax? = Syntax(node)
+
+        while let syntax = current {
+            if let call = syntax.as(FunctionCallExprSyntax.self),
+               let member = call.calledExpression.as(MemberAccessExprSyntax.self),
+               member.declName.baseName.text == "accessibilityElement",
+               groupsChildren(call.arguments) {
+                return true
+            }
+            current = syntax.parent
+        }
+        return false
+    }
+
+    private static func groupsChildren(_ arguments: LabeledExprListSyntax) -> Bool {
+        arguments.contains { argument in
+            guard argument.label?.text == "children",
+                  let member = argument.expression.as(MemberAccessExprSyntax.self) else {
+                return false
+            }
+            return groupingChildBehaviours.contains(member.declName.baseName.text)
+        }
+    }
+
     /// Checks if a Button call has a string literal as its first unlabeled argument,
     /// which acts as the button's title (e.g., `Button("Send", systemImage: "paperplane", action: ...)`).
     static func buttonHasStringTitle(_ node: FunctionCallExprSyntax) -> Bool {

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/ControlMissingAccessibilityLabelVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/ControlMissingAccessibilityLabelVisitor.swift
@@ -40,10 +40,6 @@ final class ControlMissingAccessibilityLabelVisitor: BasePatternVisitor {
         "Toggle", "Slider", "Stepper"
     ]
 
-    /// Parent groupings that take over naming, making an unlabeled child harmless:
-    /// `.combine` merges the children's labels, `.ignore` removes them from the tree.
-    private static let groupingChildBehaviours: Set<String> = ["combine", "ignore"]
-
     required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
         super.init(pattern: pattern, viewMode: viewMode)
     }
@@ -63,7 +59,9 @@ final class ControlMissingAccessibilityLabelVisitor: BasePatternVisitor {
         }
 
         // A parent that merges or ignores its children names the group itself.
-        guard isInsideNamingGroup(node) == false else { return .visitChildren }
+        guard AccessibilityTreeTraverser.isInsideNamingGroup(node) == false else {
+            return .visitChildren
+        }
 
         addIssue(
             severity: .warning,
@@ -112,36 +110,6 @@ final class ControlMissingAccessibilityLabelVisitor: BasePatternVisitor {
             return false
         }
         return callee.baseName.text == "EmptyView" && call.arguments.isEmpty
-    }
-
-    /// True when any ancestor applies `.accessibilityElement(children: .combine/.ignore)`.
-    ///
-    /// A parent's modifier call is an ancestor of the control in the syntax tree, so one
-    /// upward walk covers both the control's own chain and any enclosing container's —
-    /// no separate parent tracking needed.
-    private func isInsideNamingGroup(_ node: FunctionCallExprSyntax) -> Bool {
-        var current: Syntax? = Syntax(node)
-
-        while let syntax = current {
-            if let call = syntax.as(FunctionCallExprSyntax.self),
-               let member = call.calledExpression.as(MemberAccessExprSyntax.self),
-               member.declName.baseName.text == "accessibilityElement",
-               groupsChildren(call.arguments) {
-                return true
-            }
-            current = syntax.parent
-        }
-        return false
-    }
-
-    private func groupsChildren(_ arguments: LabeledExprListSyntax) -> Bool {
-        arguments.contains { argument in
-            guard argument.label?.text == "children",
-                  let member = argument.expression.as(MemberAccessExprSyntax.self) else {
-                return false
-            }
-            return Self.groupingChildBehaviours.contains(member.declName.baseName.text)
-        }
     }
 
     /// True for `""` and a literal made only of empty string segments (no interpolation).

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/UnlabeledControlVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/UnlabeledControlVisitor.swift
@@ -1,0 +1,89 @@
+import SwiftProjectLintModels
+import SwiftProjectLintVisitors
+import SwiftSyntax
+
+/// Detects a control written with **no label at all**, and no compensating
+/// `.accessibilityLabel`.
+///
+/// `Slider(value: $volume, in: 0...1)` announces to VoiceOver as "50 percent,
+/// slider" — a value and a role, with nothing saying *what* it adjusts. The user
+/// can operate it perfectly well and still have no idea what it does.
+///
+/// This is the sibling of Control Missing Accessibility Label, which covers labels
+/// that are present but *empty*. The split matters because the fixes differ: there
+/// you blank out a label you already have, here you never wrote one.
+///
+/// **Scope is narrower than it first appears.** Most SwiftUI controls cannot be
+/// written without a label — `Toggle`, `Stepper`, and `Picker` all require either a
+/// string title or a label closure in every initializer, so they can only ever have
+/// an *empty* label, never an absent one. Only `Slider` and `ProgressView` ship
+/// label-less initializers, so only they can reach this rule.
+///
+/// Opt-in, because `Slider(value:in:)` is the ordinary way to write a slider and a
+/// default-on rule would fire across most codebases at once.
+///
+/// Not flagged:
+/// - a label closure, however spelled: `Slider(value:) { Text("Volume") }`
+/// - a compensating `.accessibilityLabel` on the chain
+/// - a control inside a group that merges or ignores its children
+/// - the indeterminate `ProgressView()` spinner, which is usually decorative and
+///   explained by adjacent text
+final class UnlabeledControlVisitor: BasePatternVisitor {
+
+    /// Controls with label-less initializers. Deliberately short: every other
+    /// SwiftUI control requires a label, so it cannot reach this rule.
+    private static let labelOptionalControls: Set<String> = ["Slider", "ProgressView"]
+
+    required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
+        super.init(pattern: pattern, viewMode: viewMode)
+    }
+
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        if isTestOrFixtureFile() { return .visitChildren }
+
+        guard let callee = node.calledExpression.as(DeclReferenceExprSyntax.self),
+              Self.labelOptionalControls.contains(callee.baseName.text),
+              carriesAValue(node),
+              hasNoLabel(node) else {
+            return .visitChildren
+        }
+
+        guard AccessibilityTreeTraverser.hasAccessibilityModifier(
+            in: node, modifierName: "accessibilityLabel"
+        ) == false else {
+            return .visitChildren
+        }
+
+        guard AccessibilityTreeTraverser.isInsideNamingGroup(node) == false else {
+            return .visitChildren
+        }
+
+        addIssue(
+            severity: .warning,
+            message: "\(callee.baseName.text) has no label — VoiceOver announces its value "
+                + "and role but not what it controls",
+            filePath: getFilePath(for: Syntax(node)),
+            lineNumber: getLineNumber(for: Syntax(node)),
+            suggestion: "Add a label closure, e.g. Slider(value: $volume, in: 0...1) "
+                + "{ Text(\"Volume\") }, or add .accessibilityLabel(\"Volume\").",
+            ruleName: .unlabeledControl
+        )
+        return .visitChildren
+    }
+
+    /// True when the control reports a value worth naming. A bare `ProgressView()`
+    /// spinner is excluded: it is usually decorative and explained by nearby text.
+    private func carriesAValue(_ node: FunctionCallExprSyntax) -> Bool {
+        node.arguments.contains { $0.label?.text == "value" }
+    }
+
+    /// True when no label is supplied in any spelling — no string title, no trailing
+    /// closure, no explicit `label:`.
+    private func hasNoLabel(_ node: FunctionCallExprSyntax) -> Bool {
+        if node.trailingClosure != nil { return false }
+        if node.arguments.contains(where: { $0.label?.text == "label" }) { return false }
+        // A leading positional argument is the control's title.
+        if let first = node.arguments.first, first.label == nil { return false }
+        return true
+    }
+}

--- a/Tests/CoreTests/Accessibility/UnlabeledControlVisitorTests.swift
+++ b/Tests/CoreTests/Accessibility/UnlabeledControlVisitorTests.swift
@@ -1,0 +1,157 @@
+@testable import Core
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+@Suite
+struct UnlabeledControlVisitorTests {
+
+    private func makeVisitor() -> UnlabeledControlVisitor {
+        UnlabeledControlVisitor(pattern: UnlabeledControl().pattern)
+    }
+
+    private func analyze(_ source: String) -> [LintIssue] {
+        let visitor = makeVisitor()
+        visitor.walk(Parser.parse(source: source))
+        return visitor.detectedIssues
+    }
+
+    // MARK: - Positive
+
+    @Test
+    func detectsSliderWithNoLabel() throws {
+        let source = """
+        import SwiftUI
+
+        struct V: View {
+            @State private var volume = 0.5
+            var body: some View {
+                Slider(value: $volume, in: 0...1)
+            }
+        }
+        """
+
+        let issues = analyze(source)
+        #expect(issues.count == 1)
+
+        let issue = try #require(issues.first)
+        #expect(issue.ruleName == .unlabeledControl)
+        #expect(issue.severity == .warning)
+        #expect(issue.message.contains("Slider"))
+    }
+
+    @Test
+    func detectsDeterminateProgressViewWithNoLabel() {
+        let source = """
+        import SwiftUI
+
+        struct V: View {
+            let progress: Double
+            var body: some View {
+                ProgressView(value: progress, total: 1.0)
+            }
+        }
+        """
+
+        #expect(analyze(source).count == 1)
+    }
+
+    // MARK: - Negative
+
+    @Test("No issue when a label exists or the control is named elsewhere", arguments: [
+        // Trailing-closure label
+        """
+        import SwiftUI
+
+        struct V: View {
+            @State private var volume = 0.5
+            var body: some View {
+                Slider(value: $volume, in: 0...1) { Text("Volume") }
+            }
+        }
+        """,
+        // Compensating modifier
+        """
+        import SwiftUI
+
+        struct V: View {
+            @State private var volume = 0.5
+            var body: some View {
+                Slider(value: $volume, in: 0...1)
+                    .accessibilityLabel("Volume")
+            }
+        }
+        """,
+        // Parent merges the children's labels
+        """
+        import SwiftUI
+
+        struct V: View {
+            @State private var volume = 0.5
+            var body: some View {
+                HStack {
+                    Text("Volume")
+                    Slider(value: $volume, in: 0...1)
+                }
+                .accessibilityElement(children: .combine)
+            }
+        }
+        """,
+        // Indeterminate spinner — usually decorative, explained by nearby text
+        """
+        import SwiftUI
+
+        struct V: View {
+            var body: some View {
+                ProgressView()
+            }
+        }
+        """,
+        // A titled ProgressView
+        """
+        import SwiftUI
+
+        struct V: View {
+            let progress: Double
+            var body: some View {
+                ProgressView("Uploading", value: progress, total: 1.0)
+            }
+        }
+        """,
+        // Controls that cannot be written without a label are not this rule's business
+        """
+        import SwiftUI
+
+        struct V: View {
+            @State private var on = false
+            var body: some View {
+                Toggle("Bold", isOn: $on)
+            }
+        }
+        """
+    ])
+    func noIssue(source: String) {
+        #expect(analyze(source).isEmpty)
+    }
+
+    /// `.contain` keeps children as individual elements, so the slider stays unnamed.
+    @Test
+    func containedGroupStillFlags() {
+        let source = """
+        import SwiftUI
+
+        struct V: View {
+            @State private var volume = 0.5
+            var body: some View {
+                HStack {
+                    Slider(value: $volume, in: 0...1)
+                }
+                .accessibilityElement(children: .contain)
+            }
+        }
+        """
+
+        #expect(analyze(source).count == 1)
+    }
+}


### PR DESCRIPTION
> **Stacked on #52** — base is `slice-accessibility-empty-control-label`, not `main`. It needs the grouping-suppression helper that PR introduces. Merge #52 first; this retargets to `main` automatically once it lands.

## What

A new opt-in, Warning-severity Accessibility rule, `unlabeledControl`, flagging controls written with **no label at all** and no compensating `.accessibilityLabel`.

`Slider(value: $volume, in: 0...1)` announces to VoiceOver as "50 percent, slider" — a value and a role, with nothing saying *what* it adjusts. The user can operate it perfectly well and still have no idea what it does.

This is the sibling of `controlMissingAccessibilityLabel`, which covers labels that are present but **empty**. The split is not cosmetic: the fixes differ. There you blanked out a label you already had; here you never wrote one.

## Scope is narrower than "add the absent case", and deliberately so

Worth stating plainly, because the short control list looks like an oversight otherwise:

**Most SwiftUI controls cannot be written without a label.** `Toggle`, `Stepper`, and `Picker` require either a string title or a label closure in *every* initializer — so they can only ever have an *empty* label, never an absent one. Those are #52's business, not this rule's.

Only `Slider` and `ProgressView` ship label-less initializers, so only they can reach this rule. The visitor's doc comment records that reasoning, to stop a future reader "fixing" the list by adding controls that can never match.

## Design choices

**Opt-in.** `Slider(value:in:)` is the ordinary way people write a slider, so a default-on rule would fire across most codebases at once. Same posture as `animationWithoutReduceMotion`.

**Warning, not Info.** Once you have opted in to looking for this, an unlabeled slider is a real defect rather than a style preference. Opt-in handles the volume; severity should reflect the seriousness.

**Bare `ProgressView()` is excluded.** The indeterminate spinner is usually decorative and explained by adjacent text. Only the determinate `value:` form — the one that announces a bare number — is flagged.

## Shared helper extracted

The `.combine`/`.ignore` grouping suppression moves out of `ControlMissingAccessibilityLabelVisitor` into `AccessibilityTreeTraverser`, where both rules now share one implementation rather than a copy.

Its doc comment explains why a single upward walk suffices, since that is the non-obvious part: a container's modifier call is an *ancestor* of the controls inside it in the syntax tree, so one loop covers a control's own modifier chain and any enclosing container's together — no separate parent tracking.

`.contain` still does not suppress, in either rule: it keeps children as individual elements, so an unlabeled one stays unlabeled. Both suites test that.

## Verification

- **18 tests pass** across this rule and its sibling — 3 positive (unlabeled `Slider`, determinate `ProgressView`, `.contain` group) and 7 negative (label closure, compensating modifier, `.combine` parent, bare spinner, titled `ProgressView`, and a `Toggle` that cannot reach the rule)
- **2929 tests in 349 suites pass** (full linter suite, `--skip AppTests`)
- SwiftLint clean on all changed paths
- Clean rebuild after the `RuleIdentifier` change; the new case is appended, not inserted

**AppTests is not included.** It has not completed a clean run in this session — it stalled once and was killed twice — and it drives SwiftUI views through ViewInspector, so it cannot reach a linter rule. That suite's health on macOS 27 beta looks like a separate problem worth its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9aFzxaoGndRftLYAZQEdf