### PR TITLE
Fix the AppTests hang: three tests were linting the shared temp directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,11 +11,17 @@ swift build
 # Run all tests
 swift test
 
-# Run every test EXCEPT AppTests — the fast loop for linter work
-# ~2900 tests in ~6s, vs ~900s for the full run. AppTests (ViewInspector,
-# SwiftUI view structure) is essentially all of the runtime and cannot be
-# affected by a rule change, so skip it while iterating and run the full
-# suite once before merging.
+# The whole suite is ~3100 tests in ~6 seconds. Just run `swift test`.
+#
+# It used to take ~900s and often never finished, which made skipping
+# AppTests look necessary. The cause was three tests in ContentViewModelTests
+# pointing the linter at `FileManager.default.temporaryDirectory` *itself* —
+# shared machine state holding 26,000+ Swift files on a developer machine,
+# every one of them parsed through SwiftSyntax. Fixed by giving those tests
+# their own directories. If a run ever crawls again, suspect a test analysing
+# a directory it does not own, not the suite being inherently slow.
+
+# Run every test EXCEPT AppTests (rarely needed now — see above)
 swift test --skip AppTests
 
 # Run a specific test file

--- a/Docs/rules/RULES.md
+++ b/Docs/rules/RULES.md
@@ -169,6 +169,7 @@ Rules marked **opt-in** are disabled by default and must be explicitly listed un
 | [Control Missing Accessibility Label](control-missing-accessibility-label.md) | Warning |
 | [isButton Trait Without Action](is-button-trait-without-action.md) | Warning |
 | [Animation Without Reduce Motion](animation-without-reduce-motion.md) | Info |
+| [Unlabeled Control](unlabeled-control.md) | Warning |
 | [Long Text Accessibility](long-text-accessibility.md) | Info |
 | [Hardcoded Font Size](hardcoded-font-size.md) | Warning |
 | [onTapGesture Instead of Button](on-tap-gesture-instead-of-button.md) | Warning |

--- a/Docs/rules/unlabeled-control.md
+++ b/Docs/rules/unlabeled-control.md
@@ -1,0 +1,60 @@
+[← Back to Rules](RULES.md)
+
+## Unlabeled Control
+
+**Identifier:** `Unlabeled Control`
+**Category:** Accessibility
+**Severity:** Warning
+**Opt-in:** yes — enable via `enabled_only`
+
+### Rationale
+`Slider(value: $volume, in: 0...1)` announces to VoiceOver as "50 percent, slider" — a value and a role, with nothing saying *what* it adjusts. A VoiceOver user can operate the control perfectly well and still have no idea what it does, which is worse than it sounds: the control is reachable, focusable, and adjustable, so nothing signals that anything is missing.
+
+This is the sibling of [Control Missing Accessibility Label](control-missing-accessibility-label.md), which covers labels that are present but **empty**. The split matters because the fixes differ. There you blanked out a label you already had, and the repair is to stop blanking it. Here you never wrote one.
+
+### Discussion
+The rule's scope is genuinely narrow, and that is not an oversight.
+
+**Most SwiftUI controls cannot be written without a label.** `Toggle`, `Stepper`, and `Picker` require either a string title or a label closure in *every* initializer, so they can only ever have an *empty* label — never an absent one. Those belong to the sibling rule. Only `Slider` and `ProgressView` ship label-less initializers, so only they can reach this one.
+
+`UnlabeledControlVisitor` flags a `Slider` or `ProgressView` that supplies no label in any spelling — no string title, no trailing closure, no explicit `label:` — and has no compensating `.accessibilityLabel` on its chain.
+
+The bare `ProgressView()` spinner is excluded. It is usually decorative and explained by adjacent text, so only the determinate `value:` form — the one that announces a bare number — is flagged.
+
+As with the sibling rule, an ancestor applying `.accessibilityElement(children: .combine)` or `.ignore` suppresses the finding, because the parent then supplies the accessible name. `.contain` does not suppress: it keeps children as individual elements, so an unlabeled one stays unlabeled.
+
+**Why opt-in:** `Slider(value:in:)` is the ordinary way people write a slider, so a default-on rule would fire across most codebases at once. Severity is Warning rather than Info because, once you have chosen to look for this, an unlabeled slider is a real defect rather than a matter of taste.
+
+### Non-Violating Examples
+```swift
+// Label closure
+Slider(value: $volume, in: 0...1) { Text("Volume") }
+
+// Compensating modifier
+Slider(value: $volume, in: 0...1)
+    .accessibilityLabel("Volume")
+
+// Titled progress
+ProgressView("Uploading", value: progress, total: 1.0)
+
+// Indeterminate spinner — decorative, explained by nearby text
+ProgressView()
+
+// Parent supplies the name
+HStack {
+    Text("Volume")
+    Slider(value: $volume, in: 0...1)
+}
+.accessibilityElement(children: .combine)
+```
+
+### Violating Examples
+```swift
+// "50 percent, slider" — of what?
+Slider(value: $volume, in: 0...1)
+
+// Announces a bare number with no context
+ProgressView(value: progress, total: 1.0)
+```
+
+---

--- a/Tests/AppTests/ContentViewModelTests.swift
+++ b/Tests/AppTests/ContentViewModelTests.swift
@@ -8,6 +8,25 @@ import Testing
 @MainActor
 struct ContentViewModelTests {
 
+    /// A unique, empty directory for a test to analyze.
+    ///
+    /// Never point the linter at `FileManager.default.temporaryDirectory` *itself*.
+    /// That is shared machine state, and on a developer machine it accumulates Swift
+    /// sources — 26,000+ of them after a day of builds, largely from the toolchain's
+    /// own `swift-generated-sources`. Analysing it parses every one through
+    /// SwiftSyntax, which made this suite non-hermetic: fast on a clean machine,
+    /// stalled for ten minutes on a working one, and the single reason a full
+    /// `swift test` run appeared to hang.
+    ///
+    /// The caller is responsible for removing the directory; `defer` is the tidiest
+    /// way to do that.
+    private func makeIsolatedDirectory(_ name: String = #function) throws -> String {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ContentViewModelTests_\(name)_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory.path
+    }
+
     // MARK: - Initial State
 
     @Test("initial state has empty selected directory")
@@ -85,19 +104,27 @@ struct ContentViewModelTests {
     }
 
     @Test("analyzeProject with non-empty directory sets isAnalyzing to true")
-    func analyzeProjectSetsIsAnalyzing() {
+    func analyzeProjectSetsIsAnalyzing() throws {
+        let directory = try makeIsolatedDirectory()
+        defer { try? FileManager.default.removeItem(atPath: directory) }
+
         let viewModel = ContentViewModel()
-        viewModel.selectedDirectory = FileManager.default.temporaryDirectory.path
+        viewModel.selectedDirectory = directory
         viewModel.enabledRuleNames = [.relatedDuplicateStateVariable]
         viewModel.analyzeProject()
+        // Safe to read synchronously: analyzeProject sets the flag before starting its
+        // task, and resetting it requires the MainActor this test is holding.
         #expect(viewModel.isAnalyzing)
         viewModel.cancelAnalysis()
     }
 
     @Test("analyzeProject prevents double-start when already analyzing")
-    func analyzeProjectPreventsDoubleStart() {
+    func analyzeProjectPreventsDoubleStart() throws {
+        let directory = try makeIsolatedDirectory()
+        defer { try? FileManager.default.removeItem(atPath: directory) }
+
         let viewModel = ContentViewModel()
-        viewModel.selectedDirectory = FileManager.default.temporaryDirectory.path
+        viewModel.selectedDirectory = directory
         viewModel.enabledRuleNames = [.relatedDuplicateStateVariable]
         viewModel.analyzeProject()
         #expect(viewModel.isAnalyzing)
@@ -109,9 +136,12 @@ struct ContentViewModelTests {
     }
 
     @Test("analyzeProject with no enabled categories completes without issues")
-    func analyzeProjectWithNoCategoriesCompletesEmpty() async {
+    func analyzeProjectWithNoCategoriesCompletesEmpty() async throws {
+        let directory = try makeIsolatedDirectory()
+        defer { try? FileManager.default.removeItem(atPath: directory) }
+
         let viewModel = ContentViewModel()
-        viewModel.selectedDirectory = FileManager.default.temporaryDirectory.path
+        viewModel.selectedDirectory = directory
         viewModel.enabledRuleNames = [] // no rules → no categories → skips linter
         viewModel.analyzeProject()
         await viewModel.analysisTask?.value


### PR DESCRIPTION
## The headline

| | Before | After |
|---|---|---|
| Full `swift test` | ~900s, frequently never finished | **5.9s** |
| `--filter AppTests` | never completed in this session | **0.6s** |
| `ContentViewModelTests` alone | hung past 75s | **0.038s** |

3113 tests in 373 suites, zero failures.

## What was wrong

Three tests in `ContentViewModelTests` pointed the real linter at `FileManager.default.temporaryDirectory` **itself**:

```swift
viewModel.selectedDirectory = FileManager.default.temporaryDirectory.path
viewModel.analyzeProject()
```

That is shared machine state. On this machine it held **26,116 Swift files** across 30,815 entries — 100 MB of it the toolchain's own `swift-generated-sources`. Each test parsed all of it through SwiftSyntax.

The rest of the file already did this correctly: the integration tests further down create a UUID-named subdirectory and clean it up. These three just used the root.

## How it was found

The symptom was a full run reporting 163 tests in 69 seconds and then sitting for another ~530 seconds without finishing — the same 163 every time, so deterministic rather than flaky.

1. Summing reported durations showed **69.4s of test time inside a 600s wall clock**. The time was not in the tests.
2. Nine of 24 suites never closed. Bisecting each in isolation: every suite finished in ~1.3s except `ContentViewModelTests`, which hung past 75s.
3. A `sample` of the stuck process showed `RawSyntax.makeLayout` frames — it was never deadlocked, just parsing tens of thousands of files nobody asked for.

## Why it looked intermittent

The tests were non-hermetic: runtime depended entirely on what the machine had in `/var/folders`. Quick on a clean machine, unusable after a day of Swift builds. That is also why it read as an OS-beta problem rather than a test bug.

## Two corrections to earlier claims of mine

**"AppTests is unhealthy on macOS 27 beta" was wrong**, and I said it more than once. AppTests is fine — one suite scanned a directory it should not have. The only genuine macOS 27 issue remains the 2 disabled ViewInspector accessibility tests, which were verified against pristine `HEAD` separately.

**The `--skip AppTests` advice added in #54 is now obsolete**, and this PR removes it. It claimed ~900s for the full run; the full run is ~6s. The note now records what the slowness actually was, so the next person seeing a crawling run suspects a test analysing a directory it does not own rather than concluding the suite is inherently slow.

## Also fixed: a missing rule doc

`everyRuleResolvesToBundledMarkdown` was failing because #53 shipped `unlabeledControl` without `Docs/rules/unlabeled-control.md` or its `RULES.md` row. My omission — the two rules before it in the same session both got theirs. The exhaustive doc test caught exactly what it exists to catch.

## Commits

- `964e509a` the temp-directory fix, with the explanation on the new helper so the shared root does not creep back
- `42bb5234` the missing rule doc
- `08a96f95` the `CLAUDE.md` correction

SwiftLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9aFzxaoGndRftLYAZQEdf