### PR TITLE
Mark four Periphery false positives at the source

### DIFF
--- a/.periphery.yml
+++ b/.periphery.yml
@@ -53,10 +53,20 @@ report_exclude:
 #     files in the first run (all removed 2026-07-31, verified by a clean
 #     build). Worth keeping honest.
 #
-# Two known false positives are deliberately NOT configured away, because they
-# are better marked at the source with a `// periphery:ignore` comment:
+# Known false positives are marked at the source with `// periphery:ignore`
+# rather than listed here, so the reason sits next to the code it explains:
 #
-#   SyntaxHelpers   — an intentionally empty enum that exists to satisfy
-#                     SwiftLint's file_name rule (see the doc comment on it)
-#   previewPatterns — RuleSelectionDialog.swift, consumed by a #Preview block,
-#                     which Periphery does not index
+#   SyntaxHelpers                 empty enums that exist only to satisfy
+#   FrameworkAllowlistTestSupport   SwiftLint's file_name rule. Note the latter
+#                                   file's `firstCall`/`memberCall` helpers have
+#                                   250+ call sites — only the marker is unused.
+#   previewPatterns               RuleSelectionDialog.swift, consumed by a
+#                                   #Preview block, which Periphery does not index
+#   PatternCategoryColors         kept for the CategoryBadge integration listed
+#                                   under "Adoption Path for Unused Components"
+#                                   in Docs/lintstudioui-shared-components.md
+#
+# Before deleting anything Periphery reports as unused, check *why* it exists.
+# Two of the four above were briefly slated for deletion on the strength of a
+# zero-reference grep; one is a namespace marker whose file backs 250+ call
+# sites, the other is documented scaffolding.

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/SyntaxHelpers.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/SyntaxHelpers.swift
@@ -1,10 +1,15 @@
 import SwiftProjectLintModels
 import SwiftSyntax
 
+// periphery:ignore
 /// Namespace marker. Required by SwiftLint's `file_name` rule, which
 /// expects this file to declare a type matching its name. The helpers
 /// below remain at module scope by design (call sites bypass the verbose
 /// `Type.` prefix that would push them past `line_length`).
+///
+/// Unreferenced on purpose — the marker's whole job is to exist. Periphery
+/// reports it as unused, which is correct and useless, so it is silenced here
+/// rather than in `.periphery.yml`: the reason belongs next to the code.
 public enum SyntaxHelpers {}
 
 /// Returns whether a `ForEach` collection expression is safe to use with `id: \.self`.

--- a/Sources/App/Models/PatternCategoryColors.swift
+++ b/Sources/App/Models/PatternCategoryColors.swift
@@ -1,6 +1,16 @@
 import Core
 import SwiftUI
 
+// periphery:ignore
+/// Maps a `PatternCategory` to the colour used to display it.
+///
+/// Unreferenced today, and deliberately kept: it is the colour half of the
+/// `CategoryBadge<PatternCategory>` integration listed under "Adoption Path for
+/// Unused Components" in `Docs/lintstudioui-shared-components.md`, and it backs
+/// the `PatternCategory` → `LintCategory` row in that document's conformance
+/// table. Periphery reports it as unused, which is true and not a reason to
+/// delete it. If the adoption path is ever abandoned, remove this type *and*
+/// both doc references together.
 enum PatternCategoryColors {
     // Table lookup keeps `color(for:)` under SwiftLint's cyclomatic-complexity
     // budget. `.other` is both an explicit entry and the fallback colour, so

--- a/Sources/App/Views/RuleSelectionDialog.swift
+++ b/Sources/App/Views/RuleSelectionDialog.swift
@@ -235,6 +235,9 @@ struct RuleSelectionDialog: View {
     }
 }
 
+// periphery:ignore
+/// Sample data for the `#Preview` below. Periphery does not index preview
+/// macros, so it reports this as unused; the consumer is 25 lines down.
 private let previewPatterns: [PatternCategoryInfo] = [
     PatternCategoryInfo(
         category: .stateManagement,

--- a/Tests/CoreTests/Idempotency/FrameworkAllowlistTestSupport.swift
+++ b/Tests/CoreTests/Idempotency/FrameworkAllowlistTestSupport.swift
@@ -9,9 +9,16 @@ import Testing
 // helpers — member lookup shadows these at usage sites inside those types,
 // so there is no ambiguity.
 
+// periphery:ignore
 /// Namespace marker. Required by SwiftLint's `file_name` rule, which
 /// expects this file to declare a type matching its name. The helpers
 /// below remain at module scope by design.
+///
+/// Unreferenced on purpose — the marker's whole job is to exist. Periphery
+/// reports it as unused, which is correct and useless, so it is silenced here
+/// rather than in `.periphery.yml`: the reason belongs next to the code. Note
+/// that only this enum is unused; `firstCall` and `memberCall` below have 250+
+/// call sites across the idempotency suites.
 enum FrameworkAllowlistTestSupport {}
 
 func firstCall(in source: String) throws -> FunctionCallExprSyntax {


### PR DESCRIPTION
## What happened

This started as "delete `PatternCategoryColors` and `FrameworkAllowlistTestSupport`" — both reported by Periphery as unused, both confirmed zero-reference by grep. Reading them before deleting showed **neither should go**.

## `FrameworkAllowlistTestSupport` — deleting it would have broken the idempotency suite

Periphery flagged only the empty `enum FrameworkAllowlistTestSupport {}`. The same file also declares two module-scope helpers:

| Helper | Call sites |
|---|---|
| `firstCall(in:)` | 210 |
| `memberCall(method:in:)` | 45 |

Across `HeuristicInference*`, `FrameworkAllowlist*`, `ReceiverTypeResolver*` and more. The empty enum is a **namespace marker** required by SwiftLint's `file_name` rule (enabled at `.swiftlint.yml:140`) — its whole job is to be unreferenced. Identical to `SyntaxHelpers`.

## `PatternCategoryColors` — documented scaffolding

`Docs/lintstudioui-shared-components.md` names it twice, the second under a heading called **"Adoption Path for Unused Components"**:

> **Category display in issue rows** — Use `CategoryBadge<PatternCategory>` with `PatternCategoryColors`

That section exists precisely to list things unused today and prescribed for later. Line 84 also documents it as the `PatternCategory` → `LintCategory` colour mapping. Deleting it discards prepared integration work and falsifies two doc lines.

## The fix

`// periphery:ignore` on all four known false positives, with the reasoning in the doc comment beside each:

- `SyntaxHelpers`, `FrameworkAllowlistTestSupport` — `file_name` namespace markers
- `previewPatterns` — consumed by a `#Preview` block, which Periphery does not index
- `PatternCategoryColors` — the documented `CategoryBadge` adoption path

The reason belongs next to the code, not in a config file nobody reads while holding a delete key. `.periphery.yml`'s comment on these is updated (it claimed they were deliberately *not* marked) and now carries the lesson: check *why* something exists before deleting it.

**Implementation note:** the markers sit *above* the doc comments, not between them and the declaration. A `//` line in that position orphans the doc comment and trips SwiftLint's `orphaned_doc_comment` rule — which is exactly what happened on the first attempt.

## Verification

- Periphery: **132 → 128**, all four confirmed suppressed
- SwiftLint: clean across `Sources`, `Tests`, and `Packages/SwiftProjectLintVisitors/Sources`
- Full suite: **3113 tests in 373 suites, 5.9s, zero failures**

## If you do want them gone

`PatternCategoryColors` is a real choice, not a bug: if the `CategoryBadge` adoption path is dead, the type should go **and** both doc references with it. Say the word and I will do both together. `FrameworkAllowlistTestSupport` is not a choice — the marker is load-bearing for `file_name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9aFzxaoGndRftLYAZQEdf