### PR TITLE
Archive the accessibility rule proposals — all six shipped

### DIFF
--- a/Docs/archive/accessibility-rule-proposals.md
+++ b/Docs/archive/accessibility-rule-proposals.md
@@ -2,6 +2,22 @@
 
 Potential lint rules derived from [mobilea11y.com SwiftUI accessibility guides](https://mobilea11y.com/guides/swiftui/swiftui-accessibility/).
 
+> **Status (2026-07-31): closed.** Every candidate is resolved — all six shipped,
+> and the seven Deferred items below are decisions not to build rather than
+> pending work. Kept as the record of what was proposed, what shipped, and where
+> each rule departed from its proposal. The shipped rules are documented in
+> [`rules/RULES.md`](../rules/RULES.md); read those for current behaviour, and
+> this only for intent.
+>
+> | # | Proposal | Shipped as |
+> |---|---|---|
+> | 1 | Accessibility Hidden With Other Modifiers | `accessibilityHiddenConflict` |
+> | 2 | Sort Priority Without Container | `sortPriorityWithoutContainer` |
+> | 3 | Animation Without Reduce Motion | `animationWithoutReduceMotion` (opt-in) |
+> | 4 | Custom Font With Fixed Size | folded into `hardcodedFontSize` |
+> | 5 | isButton Trait Without Action | `isButtonTraitWithoutAction` |
+> | 6 | Unlabeled Toggle, Slider, or Picker | folded into `controlMissingAccessibilityLabel`, with the absent-label half split out as `unlabeledControl` |
+
 ---
 
 ## Strong Candidates


### PR DESCRIPTION
## What

Moves `Docs/accessibility-rule-proposals.md` to `Docs/archive/`. Every candidate in it is resolved.

| # | Proposal | Shipped as | PR |
|---|---|---|---|
| 1 | Accessibility Hidden With Other Modifiers | `accessibilityHiddenConflict` | pre-existing |
| 2 | Sort Priority Without Container | `sortPriorityWithoutContainer` | pre-existing |
| 3 | Animation Without Reduce Motion | `animationWithoutReduceMotion` (opt-in) | #50 |
| 4 | Custom Font With Fixed Size | folded into `hardcodedFontSize` | — |
| 5 | isButton Trait Without Action | `isButtonTraitWithoutAction` | #49 |
| 6 | Unlabeled Toggle, Slider, or Picker | folded into `controlMissingAccessibilityLabel`, absent-label half split out as `unlabeledControl` | #52, #53 |

The remaining **Deferred** section is seven decisions *not* to build — "cannot determine meaningfulness of asset names statically", "length thresholds are arbitrary and context-dependent" — not a backlog. That is a record, not pending work, which is what makes the document finished rather than merely mostly-done.

## The status header

Added at the top, following the convention of the other archived documents. It carries the proposal-to-rule mapping above, and points readers at `rules/RULES.md` for current behaviour.

That pointer matters: **every one of these rules departed from its proposal in at least one way**, and the departures are recorded in the sections below. Proposal 4 became an extension rather than a rule. Proposal 6 split in two, because the empty-label and absent-label cases have different fixes and different noise profiles. Proposal 3 shipped opt-in rather than merely Info-severity. Read this document for intent; read the rule docs for what the linter actually does.

## Not archived, and why

- `rule-ideas.md` — the TCA backlog still has four "Maybe" items open (#2, #6, #7, #9)
- `history-aware-drift-and-sync-contracts-design.md` — its own header says "**not implemented** as a rule", Parts 2–3 unbuilt
- `architecture.md`, `lintstudioui-shared-components.md`, `no_empty_block.md` — living reference documents

`Docs/` now holds only living documents.

## Verification

No links to repair — nothing referenced this file, and it referenced nothing relative. Confirmed zero dangling references repo-wide, and the one new relative link (`../rules/RULES.md`) resolves from `Docs/archive/`.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9aFzxaoGndRftLYAZQEdf