### PR TITLE
Trim redundant public from the local packages

### DIFF
--- a/.periphery.yml
+++ b/.periphery.yml
@@ -44,10 +44,20 @@ report_exclude:
 #
 # Also left on:
 #
-#   redundant public analysis — the Packages/* are local path dependencies with
-#     no external consumers, so a `public` that nothing outside its module uses
-#     is genuinely redundant. Tests reach in via `@testable import`, which
-#     Periphery accounts for.
+#   redundant public analysis — the Packages/* are local path dependencies used
+#     only by this repo (Sources/Core re-exports them with `@_exported`), so a
+#     `public` that nothing outside its module uses is genuinely redundant.
+#     Tests reach in via `@testable import`, which Periphery accounts for.
+#
+#     The 26 remaining findings are all in FrameworkAllowlist.swift and are
+#     expected to stay. Its constants are adopter-facing API: the doc comment on
+#     `LintConfiguration.enabledFrameworkAllowlists` tells adopters to configure
+#     it "using `FrameworkAllowlist` constants like `Foundation`, `NIOCore`".
+#     Nothing in this repo uses them from outside the Visitors module, which is
+#     exactly why Periphery flags them — and exactly why the flag is wrong here.
+#     Marking them with `// periphery:ignore` was tried and rejected: it
+#     suppressed 21 findings but produced 13 `superfluousIgnoreCommand` ones,
+#     trading one kind of noise for another.
 #
 #   unused import analysis — this found 272 real unused imports across 251
 #     files in the first run (all removed 2026-07-31, verified by a clean

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Models/ViewRelationship.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Models/ViewRelationship.swift
@@ -30,15 +30,15 @@ import Foundation
 ///     filePath: "/path/to/RootView.swift"
 /// )
 /// ```
-public struct ViewRelationship: Sendable {
-    public let parentView: String
-    public let childView: String
-    public let relationshipType: RelationshipType
-    public let lineNumber: Int
-    public let filePath: String
+struct ViewRelationship: Sendable {
+    let parentView: String
+    let childView: String
+    let relationshipType: RelationshipType
+    let lineNumber: Int
+    let filePath: String
 }
 
-public enum RelationshipType: Sendable {
+enum RelationshipType: Sendable {
     case directChild
     case navigationDestination
     case sheet

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/StateManagement/StateVariable.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/StateManagement/StateVariable.swift
@@ -14,11 +14,11 @@ import Foundation
 ///   - viewName: The name of the containing SwiftUI view (typically the struct name, inferred from the file name).
 ///   - propertyWrapper: The property wrapper used (e.g., `@State`, `@StateObject`, `@ObservedObject`, or `@EnvironmentObject`).
 ///
-public struct StateVariable: Sendable {
-    public let name: String
-    public let type: String
-    public let filePath: String
-    public let lineNumber: Int
-    public let viewName: String
-    public let propertyWrapper: PropertyWrapper
+struct StateVariable: Sendable {
+    let name: String
+    let type: String
+    let filePath: String
+    let lineNumber: Int
+    let viewName: String
+    let propertyWrapper: PropertyWrapper
 }

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/ReceiverTypeResolver.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/ReceiverTypeResolver.swift
@@ -6,7 +6,7 @@ import SwiftSyntax
 /// annotations, pattern-binding annotations, literal shapes) and does not
 /// perform semantic resolution. Cases the resolver cannot classify
 /// lexically return `.unresolved`.
-public enum ResolvedReceiverType: Equatable, Sendable {
+enum ResolvedReceiverType: Equatable, Sendable {
     /// A well-known stdlib collection or wrapper type. The `String` payload
     /// is the bare type name (`"Array"`, `"Set"`, `"Dictionary"`, `"String"`,
     /// `"Optional"`). Used by `StdlibExclusions` to suppress bare-name
@@ -54,12 +54,12 @@ public enum ResolvedReceiverType: Equatable, Sendable {
 /// resolves to one of the stdlib names *and* `localTypes` contains that
 /// name, the result is downgraded to `.named` — the stdlib exclusion table
 /// won't fire on a user-defined shadow.
-public enum ReceiverTypeResolver {
+enum ReceiverTypeResolver {
 
     /// Convenience wrapper that extracts the receiver expression from a
     /// method call. For `x.foo(y)` returns the resolution of `x`. For
     /// `foo(y)` (no receiver) returns `.unresolved`.
-    public static func resolve(
+    static func resolve(
         receiverOf call: FunctionCallExprSyntax,
         localTypes: Set<String> = []
     ) -> ResolvedReceiverType {
@@ -73,7 +73,7 @@ public enum ReceiverTypeResolver {
     /// Resolves a single receiver expression. Public so that the inferrer
     /// (and future callers) can operate on arbitrary expressions without
     /// routing through a `FunctionCallExprSyntax`.
-    public static func resolve(
+    static func resolve(
         _ expr: ExprSyntax,
         localTypes: Set<String> = []
     ) -> ResolvedReceiverType {

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/SelfAccessAnalyzer.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/SelfAccessAnalyzer.swift
@@ -8,7 +8,7 @@ import SwiftSyntax
 /// only *immutable* stored state is a function of `(self, arguments)` — still property-testable,
 /// you just have to build a `self`. Only a method that reads *mutable* instance state is genuinely
 /// out of reach, because its result is not a function of anything a test can pin down.
-public enum SelfAccess: Sendable, Equatable {
+enum SelfAccess: Sendable, Equatable {
     /// The body reads nothing from `self`. A function of its arguments alone.
     ///
     /// Deliberately not spelled `none` — at a use site `.none` reads as `Optional.none`,
@@ -47,7 +47,7 @@ public enum SelfAccess: Sendable, Equatable {
 /// This establishes that the method does not *read mutable instance state*. It does not establish
 /// that everything the method transitively calls is pure — the same boundary the rule has always
 /// had for free functions, and the reason its findings are candidates rather than proofs.
-public enum SelfAccessAnalyzer {
+enum SelfAccessAnalyzer {
 
     /// What `method` reads from `self`, given the stored properties its enclosing type declares.
     ///
@@ -59,7 +59,7 @@ public enum SelfAccessAnalyzer {
     ///   - cleanMethods: names the project pre-scan cleared as sibling methods that are themselves
     ///     functions of their inputs. Empty by default, which refuses every call — the behaviour
     ///     before `CleanInstanceMethodCatalog` existed.
-    public static func access(
+    static func access(
         of method: FunctionDeclSyntax,
         storedProperties: [String: StoredProperty],
         enclosingIsValueType: Bool = false,
@@ -416,14 +416,10 @@ public enum SelfAccessAnalyzer {
 }
 
 /// A stored property of a type, as the file that declares it shows.
-public struct StoredProperty: Sendable, Equatable {
+struct StoredProperty: Sendable, Equatable {
     /// `true` for `var`, `false` for `let`. A `var` may differ between two reads, so a method
     /// that reads one is not a function of its inputs.
-    public let isMutable: Bool
-
-    public init(isMutable: Bool) {
-        self.isMutable = isMutable
-    }
+    let isMutable: Bool
 
     /// The properties of a type that a method may read while remaining a function of `self`.
     ///
@@ -449,7 +445,7 @@ public struct StoredProperty: Sendable, Equatable {
     ///   would wave it straight through;
     /// - every **name** the getter reads must already be immutable stored state or derived, which is
     ///   what refutes `var scaled: Int { count * multiplier }` when `multiplier` is a `var`.
-    public static func declared(in members: MemberBlockItemListSyntax) -> [String: Self] {
+    static func declared(in members: MemberBlockItemListSyntax) -> [String: Self] {
         var properties: [String: Self] = [:]
         var computed: [(name: String, accessor: AccessorBlockSyntax)] = []
 

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/StdlibExclusions.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/StdlibExclusions.swift
@@ -33,7 +33,7 @@ import Foundation
 /// - Any user-defined type methods that happen to share names with stdlib
 ///   methods: that's the problem receiver-type inference exists to fix —
 ///   user-defined receivers stay on the bare-name path.
-public enum StdlibExclusions {
+enum StdlibExclusions {
 
     /// Returns `true` when the `(receiver, method)` pair is a stdlib
     /// exclusion — i.e., a bare-name inference match that should be
@@ -41,7 +41,7 @@ public enum StdlibExclusions {
     ///
     /// Pair matches require the receiver to be `.stdlibCollection(name)`.
     /// Named or unresolved receivers are never excluded.
-    public static func isExcluded(
+    static func isExcluded(
         receiver: ResolvedReceiverType,
         method: String
     ) -> Bool {

--- a/Tests/CoreTests/TestRegistryManager.swift
+++ b/Tests/CoreTests/TestRegistryManager.swift
@@ -4,28 +4,28 @@ import Foundation
 @testable import SwiftProjectLintRules
 
 /// A struct containing isolated test instances for pattern detection.
-public struct IsolatedTestInstances {
-    public let visitorRegistry: PatternVisitorRegistry
-    public let patternRegistry: SourcePatternRegistry
-    public let detector: SourcePatternDetector
+struct IsolatedTestInstances {
+    let visitorRegistry: PatternVisitorRegistry
+    let patternRegistry: SourcePatternRegistry
+    let detector: SourcePatternDetector
 }
 
 /// Shared test registry manager for performance optimization across all tests.
 /// This provides a centralized way to manage shared registries while maintaining
 /// test isolation where needed.
 @preconcurrency @MainActor
-public class TestRegistryManager {
+class TestRegistryManager {
 
     // MARK: - Shared Instances
 
     /// Shared visitor registry instance for all tests
-    public static let sharedVisitorRegistry = PatternVisitorRegistry()
+    static let sharedVisitorRegistry = PatternVisitorRegistry()
 
     /// Shared pattern registry instance for all tests
-    public static let sharedPatternRegistry = SourcePatternRegistry(visitorRegistry: sharedVisitorRegistry)
+    static let sharedPatternRegistry = SourcePatternRegistry(visitorRegistry: sharedVisitorRegistry)
 
     /// Shared detector instance for all tests
-    public static let sharedDetector = SourcePatternDetector(registry: sharedVisitorRegistry)
+    static let sharedDetector = SourcePatternDetector(registry: sharedVisitorRegistry)
 
     // MARK: - Initialization State
 
@@ -34,21 +34,21 @@ public class TestRegistryManager {
     // MARK: - Timeout Configuration
 
     /// Default timeout for tests (30 seconds)
-    public static let defaultTestTimeout: Duration = .seconds(30)
+    static let defaultTestTimeout: Duration = .seconds(30)
 
     /// Short timeout for quick tests (10 seconds)
-    public static let shortTestTimeout: Duration = .seconds(10)
+    static let shortTestTimeout: Duration = .seconds(10)
 
     /// Long timeout for complex tests (60 seconds)
-    public static let longTestTimeout: Duration = .seconds(60)
+    static let longTestTimeout: Duration = .seconds(60)
 
     /// Very long timeout for integration tests (120 seconds)
-    public static let veryLongTestTimeout: Duration = .seconds(120)
+    static let veryLongTestTimeout: Duration = .seconds(120)
 
     // MARK: - Public Methods
 
     /// Initialize the shared registry once for all tests
-    public static func initializeSharedRegistry() {
+    static func initializeSharedRegistry() {
         guard !isInitialized else { return }
         BuiltInRules.registerAll()
         IdempotencyRules.registerAll()
@@ -57,14 +57,14 @@ public class TestRegistryManager {
     }
 
     /// Reset the shared registry to a clean state
-    public static func resetSharedRegistry() {
+    static func resetSharedRegistry() {
         sharedVisitorRegistry.clear()
 
         isInitialized = false
     }
 
     /// Create isolated instances for tests that need complete isolation
-    public static func createIsolatedInstances() -> IsolatedTestInstances {
+    static func createIsolatedInstances() -> IsolatedTestInstances {
         let visitorRegistry = PatternVisitorRegistry()
         let patternRegistry = SourcePatternRegistry(visitorRegistry: visitorRegistry)
         let detector = SourcePatternDetector(registry: visitorRegistry)
@@ -76,7 +76,7 @@ public class TestRegistryManager {
     }
 
     /// Get a detector with specific patterns for focused testing
-    public static func getDetectorWithPatterns(_ patterns: [SyntaxPattern]) -> SourcePatternDetector {
+    static func getDetectorWithPatterns(_ patterns: [SyntaxPattern]) -> SourcePatternDetector {
         initializeSharedRegistry()
         for pattern in patterns {
             sharedVisitorRegistry.register(pattern: pattern)
@@ -85,25 +85,25 @@ public class TestRegistryManager {
     }
 
     /// Get a detector for specific categories
-    public static func getDetectorForCategories(_ _: [PatternCategory]) -> SourcePatternDetector {
+    static func getDetectorForCategories(_ _: [PatternCategory]) -> SourcePatternDetector {
         initializeSharedRegistry()
         return SourcePatternDetector(registry: sharedVisitorRegistry)
     }
 
     /// Get the shared detector (most common use case)
-    public static func getSharedDetector() -> SourcePatternDetector {
+    static func getSharedDetector() -> SourcePatternDetector {
         initializeSharedRegistry()
         return sharedDetector
     }
 
     /// Get the shared visitor registry
-    public static func getSharedVisitorRegistry() -> PatternVisitorRegistry {
+    static func getSharedVisitorRegistry() -> PatternVisitorRegistry {
         initializeSharedRegistry()
         return sharedVisitorRegistry
     }
 
     /// Get the shared pattern registry
-    public static func getSharedPatternRegistry() -> SourcePatternRegistry {
+    static func getSharedPatternRegistry() -> SourcePatternRegistry {
         initializeSharedRegistry()
         return sharedPatternRegistry
     }
@@ -112,7 +112,7 @@ public class TestRegistryManager {
 
     /// Measure execution time of a synchronous test operation
     @preconcurrency
-    public static func measureExecutionTime<T: Sendable>(_ operation: @Sendable () throws -> T) rethrows -> (T, Duration) {
+    static func measureExecutionTime<T: Sendable>(_ operation: @Sendable () throws -> T) rethrows -> (T, Duration) {
         let start = ContinuousClock.now
         let result = try operation()
         let end = ContinuousClock.now
@@ -121,7 +121,7 @@ public class TestRegistryManager {
 
     /// Measure execution time of an async test operation
     @preconcurrency
-    public static func measureExecutionTime<T: Sendable>(_ operation: @Sendable () async throws -> T) async rethrows -> (T, Duration) {
+    static func measureExecutionTime<T: Sendable>(_ operation: @Sendable () async throws -> T) async rethrows -> (T, Duration) {
         let start = ContinuousClock.now
         let result = try await operation()
         let end = ContinuousClock.now
@@ -129,7 +129,7 @@ public class TestRegistryManager {
     }
 
     /// Log slow test execution for debugging
-    public static func logSlowTest(_ testName: String, duration: Duration, threshold: Duration = .seconds(5)) {
+    static func logSlowTest(_ testName: String, duration: Duration, threshold: Duration = .seconds(5)) {
         if duration > threshold {
             print("⚠️  SLOW TEST: \(testName) took \(duration.formatted()) (threshold: \(threshold.formatted()))")
         }


### PR DESCRIPTION
## What

Periphery reported 57 `redundantPublicAccessibility` findings — declarations marked `public` that nothing outside their own module uses. This removes 31 of them (plus 19 more surfaced by cascade), and deliberately keeps 26.

| | Before | After |
|---|---|---|
| Redundant public | 57 | **26** |
| Total Periphery findings | 128 | **97** |

## Why `public` buys nothing here

The `Packages/*` are local path dependencies consumed only by this repo, through `Sources/Core/Exports.swift`'s `@_exported` facade. `Docs/architecture.md` describes them as internal decomposition — "six local packages" — not reusable libraries, and no external `Package.swift` references them.

## The cascade

Trimming was not one pass. Making a parent type internal exposed members that were still `public` inside it — invisible to Periphery beforehand, and a SwiftLint `lower_acl_than_parent` violation afterwards. Three passes in total:

1. 31 declarations Periphery flagged, across `TestRegistryManager`, `StateVariable`, `ViewRelationship`, `ReceiverTypeResolver`, `SelfAccessAnalyzer`, `StdlibExclusions`
2. 11 more that the re-scan surfaced once their parents were internal
3. 8 that only SwiftLint caught, plus one initializer that became identical to the synthesized memberwise one and was deleted

The compiler was the safety net throughout — reducing visibility fails loudly if something outside the module needed it. Nothing did.

## The 26 that stay, and why

**All of them are in `FrameworkAllowlist.swift`, and they are adopter-facing API.** The doc comment on `LintConfiguration.enabledFrameworkAllowlists` says:

> Setting this to a non-nil set restricts allowlist activity to the listed frameworks (using `FrameworkAllowlist` constants like `Foundation`, `NIOCore`, `Logging`, `Metrics`, etc.). **Adopters** who want to disable a specific framework's classifications … can omit the framework name from the set.

Nothing in this repo uses those constants from outside the Visitors module — which is precisely why Periphery flags them, and precisely why the flag is wrong. They exist for consumers configuring the linter programmatically.

I tried marking them `// periphery:ignore` and **reverted it**: it suppressed 21 findings but produced 13 `superfluousIgnoreCommand` findings, trading one kind of noise for another. `.periphery.yml` now documents the position instead, so the remaining 26 read as a known decision rather than an untriaged backlog.

## Verification

- Full suite: **3113 tests in 373 suites, 6.0s, zero failures**
- SwiftLint clean on every changed file
- Three pre-existing `DuplicateEnumMappingVisitor` warnings are untouched and identical to `main` — not from this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9aFzxaoGndRftLYAZQEdf