### PR TITLE
Fix a registration race that intermittently emptied a rule category

### DIFF
--- a/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/IdempotencyRules.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/IdempotencyRules.swift
@@ -12,15 +12,15 @@ public enum IdempotencyRules {
     nonisolated(unsafe) private static var registered = false
 
     public static func registerAll() {
-        let alreadyRegistered: Bool = lock.withLock {
-            if registered { return true }
+        // Held for the whole of registration — see BuiltInRules.registerAll for
+        // why the flag alone is not enough.
+        lock.withLock {
+            guard registered == false else { return }
             registered = true
-            return false
-        }
-        if alreadyRegistered { return }
 
-        SourcePatternRegistry.registerFactory { registry, visitorRegistry in
-            Idempotency(registry: registry, visitorRegistry: visitorRegistry)
+            SourcePatternRegistry.registerFactory { registry, visitorRegistry in
+                Idempotency(registry: registry, visitorRegistry: visitorRegistry)
+            }
         }
     }
 

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/BuiltInRules.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/BuiltInRules.swift
@@ -11,20 +11,26 @@ public enum BuiltInRules {
     nonisolated(unsafe) private static var registered = false
 
     public static func registerAll() {
-        // Guard against double-registration. The `withLock` closure returns
-        // `true` when this call should become a no-op (another call already
-        // registered the factories). The previous form — `guard else { return }`
-        // inside the closure — only returned from the closure, so factories
-        // got appended on every call; the resulting per-call pattern growth
-        // bloated `SourcePatternRegistry` iteration under test workloads
-        // where `createConfiguredSystem()` is invoked repeatedly.
-        let alreadyRegistered: Bool = lock.withLock {
-            if registered { return true }
+        // The lock is held for the whole of registration, not just the flag
+        // check. Setting `registered` and *then* registering outside the lock
+        // let a second caller see the flag, conclude registration was finished,
+        // and build a registry from a partial factory list — `Security` is only
+        // the third factory appended, so it went missing intermittently. A late
+        // caller must block until the work is actually done.
+        //
+        // `guard else { return }` is correct here precisely because everything
+        // lives inside the closure: it returns from the closure having done
+        // nothing, which is the intended no-op.
+        lock.withLock {
+            guard registered == false else { return }
             registered = true
-            return false
+            registerCategoryFactories()
         }
-        if alreadyRegistered { return }
+    }
 
+    /// The category factories themselves. Split out so the locked region stays
+    /// readable; it must only ever be called with `lock` held.
+    private static func registerCategoryFactories() {
         SourcePatternRegistry.registerFactory { registry, visitorRegistry in
             StateManagement(registry: registry, visitorRegistry: visitorRegistry)
         }

--- a/Tests/CoreTests/Registry/RegistryInitializationRaceTests.swift
+++ b/Tests/CoreTests/Registry/RegistryInitializationRaceTests.swift
@@ -1,0 +1,46 @@
+@testable import Core
+@testable import SwiftProjectLintIdempotencyRules
+@testable import SwiftProjectLintRules
+import Testing
+
+/// Guards the invariant that a registry handed back by `createConfiguredSystem()`
+/// is *fully* populated, even when several callers initialise concurrently.
+///
+/// The bug this pins: `registerAll()` set its `registered` flag inside the lock but
+/// registered the category factories outside it. A second caller arriving in that
+/// window saw the flag, returned immediately believing registration was complete,
+/// and initialised a registry from a partial factory list — so
+/// `getPatterns(for: .security)` came back empty, because `Security` is only the
+/// third of a dozen factories to register.
+///
+/// Serialized because it resets process-wide registration state, which would
+/// otherwise be visible to suites running in parallel.
+@Suite(.serialized)
+struct RegistryInitializationRaceTests {
+
+    @Test("concurrent initialization never yields a partially-registered registry")
+    func concurrentInitializationSeesEveryCategory() async {
+        // Force the first-caller path, which is where the race lives.
+        BuiltInRules.reset()
+        IdempotencyRules.reset()
+        SourcePatternRegistry.resetFactories()
+
+        let categories: [PatternCategory] = [
+            .security, .accessibility, .performance, .stateManagement, .codeQuality
+        ]
+
+        let missing = await withTaskGroup(of: [PatternCategory].self) { group in
+            for _ in 0..<32 {
+                group.addTask {
+                    let system = PatternRegistryFactory.createConfiguredSystem()
+                    return categories.filter { system.patternRegistry.getPatterns(for: $0).isEmpty }
+                }
+            }
+            var all: [PatternCategory] = []
+            for await gaps in group { all.append(contentsOf: gaps) }
+            return all
+        }
+
+        #expect(missing.isEmpty, "categories missing from a concurrently-built registry: \(missing)")
+    }
+}


### PR DESCRIPTION
## The bug

`BuiltInRules.registerAll()` set its `registered` flag **inside** the lock, then registered the twelve category factories **outside** it:

```swift
let alreadyRegistered: Bool = lock.withLock {
    if registered { return true }
    registered = true          // ← claim staked here
    return false
}
if alreadyRegistered { return }

SourcePatternRegistry.registerFactory { ... }   // ← work happens here, unlocked
```

A second caller arriving in that window sees the flag, concludes registration is finished, and builds a registry from a **partial factory list**.

`Security` is only the third factory appended, so the symptom was `getPatterns(for: .security)` coming back empty every so often — `SystemComponentsIntegrationTests.testSecurityPatterns` failing occasionally and passing on re-run. Exactly the shape that gets written off as flaky infrastructure.

`IdempotencyRules.registerAll()` had the same shape with one factory.

## Verified by reproduction, not by reasoning

| | Result |
|---|---|
| New regression test, **old** code | **failed 2 of 3 runs** |
| New regression test, **fixed** code | **passed 6 of 6** |
| Full suite, fixed code | **green 4 consecutive runs**, 3114 tests in ~5.8s |

The test spawns 32 concurrent `createConfiguredSystem()` calls and asserts every resulting registry has patterns for five categories.

## The fix

Hold the lock for the whole of registration, so a late caller blocks until the work is genuinely done rather than until someone has merely *claimed* it.

**Lock ordering is safe.** `registerFactory` takes `factoryLock` briefly inside the held `lock`, and `SourcePatternRegistry.initialize()` copies the factory list under `factoryLock` and releases it *before* running any registrar — so nothing acquires the two in the opposite order.

**On the old comment.** It warned that `guard else { return }` inside the closure had previously caused factories to be appended on every call. That warning applied to the *opposite* arrangement, where the guard returned from the closure and execution continued into the registration below. In the new form everything lives inside the closure, so the guard returning from it is precisely the intended no-op. The comment is rewritten to say which arrangement it is talking about.

The factory list moved into `registerCategoryFactories()` to keep the locked region readable and inside SwiftLint's `closure_body_length` budget — fixed by restructuring rather than by loosening the rule.

## A note on the deferred reset hooks

The regression test uses `BuiltInRules.reset()` and `SourcePatternRegistry.resetFactories()` — two of the four reset hooks #59 deferred rather than deleted, on the suspicion they were load-bearing for exactly this kind of test. They were. Had they been removed as "unused", this test could not have forced the first-caller path, and the race would have stayed unreproducible.

The suite is `.serialized` because it resets process-wide registration state, which would otherwise be visible to suites running in parallel — the very hazard being fixed.

## Verification

- Full suite: **3114 tests in 374 suites, ~5.8s**, green across 4 consecutive runs
- SwiftLint clean on every changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9aFzxaoGndRftLYAZQEdf