### PR TITLE
Add two ViewInspector hosting rules to Testability

### DIFF
--- a/Docs/rules/RULES.md
+++ b/Docs/rules/RULES.md
@@ -261,6 +261,8 @@ Rules marked **opt-in** are disabled by default and must be explicitly listed un
 | [Extractable Pure Kernel](extractable-pure-kernel.md) | Info |
 | [Missing Equatable on State Type](missing-equatable-on-state-type.md) | Info |
 | [Impure Call in View Body](impure-call-in-view-body.md) | Warning |
+| [ViewHosting Before Inspection](view-hosting-before-inspection.md) | Error |
+| [Observable Environment View Missing Inspection Hook](observable-environment-view-missing-inspection-hook.md) | Info |
 
 ---
 

--- a/Docs/rules/observable-environment-view-missing-inspection-hook.md
+++ b/Docs/rules/observable-environment-view-missing-inspection-hook.md
@@ -1,0 +1,84 @@
+[← Back to Rules](RULES.md)
+
+## Observable Environment View Missing Inspection Hook
+
+**Identifier:** `Observable Environment View Missing Inspection Hook`
+**Category:** Testability
+**Severity:** Info
+
+### Rationale
+`@Environment(SomeType.self)` — the `@Observable` form — has **no default value**. Read outside a hosted view hierarchy it traps in SwiftUICore's `EnvironmentValues.subscript.getter`, killing the test process rather than failing a single test.
+
+The keypath form is not affected. `@Environment(\.someKey)` falls back to a default and merely logs *"Accessing Environment<X>'s value outside of being installed on a View"*. Only the `Type.self` form is fatal, and that distinction is the rule's entire discriminator.
+
+A view reading the fatal form can only be inspected by hosting it and inspecting from inside the live render, which requires the view to carry an inspection relay. Without one, the view is untestable by ViewInspector — and the way you find out is a process-killing trap whose backtrace names neither ViewInspector nor the test that triggered it.
+
+### Discussion
+`ObservableEnvironmentViewMissingInspectionHookVisitor` reports a `struct` conforming to `View` that declares at least one `@Environment(SomeType.self)` property and no stored property named `inspection`. The message names each offending environment type.
+
+This is **advisory**, not a defect: a view nobody inspects needs no hook, and adding one to every view would be noise. It is `Info` severity for that reason. The value is that it fires at the moment the view is written, rather than leaving the constraint to be discovered later from a crash log.
+
+The relay is two lines, and deliberately lives in the app target so the app never links ViewInspector — the test target supplies the protocol conformance:
+
+```swift
+// App target
+internal final class Inspection<V>: @unchecked Sendable {
+    let notice = PassthroughSubject<UInt, Never>()
+    var callbacks = [UInt: (V) -> Void]()
+    func visit(_ view: V, _ line: UInt) {
+        if let callback = callbacks.removeValue(forKey: line) { callback(view) }
+    }
+}
+
+// Test target
+extension Inspection: InspectionEmissary {}
+```
+
+```swift
+// Before — cannot be inspected without trapping
+struct ContentView: View {
+    @Environment(VaultManager.self) private var vaultManager
+
+    var body: some View {
+        Text(vaultManager.title)
+    }
+}
+
+// After — hosted inspection becomes possible
+struct ContentView: View {
+    @Environment(VaultManager.self) private var vaultManager
+    internal let inspection = Inspection<Self>()
+
+    var body: some View {
+        Text(vaultManager.title)
+            .onReceive(inspection.notice) { inspection.visit(self, $0) }
+    }
+}
+```
+
+### Non-Violating Examples
+```swift
+// The keypath form has a default; it warns rather than traps.
+struct SettingsView: View {
+    @Environment(\.dependencies) private var dependencies
+    var body: some View { Text("x") }
+}
+
+// Already carries the relay.
+struct HookedView: View {
+    @Environment(VaultManager.self) private var vault
+    internal let inspection = Inspection<Self>()
+    var body: some View {
+        Text(vault.title)
+            .onReceive(inspection.notice) { inspection.visit(self, $0) }
+    }
+}
+
+// Not a View.
+struct Holder {
+    @Environment(VaultManager.self) private var vault
+}
+```
+
+### Companion
+[ViewHosting Before Inspection](view-hosting-before-inspection.md) catches the same hazard from the *test* side.

--- a/Docs/rules/view-hosting-before-inspection.md
+++ b/Docs/rules/view-hosting-before-inspection.md
@@ -1,0 +1,75 @@
+[← Back to Rules](RULES.md)
+
+## ViewHosting Before Inspection
+
+**Identifier:** `ViewHosting Before Inspection`
+**Category:** Testability
+**Severity:** Error
+
+### Rationale
+ViewInspector evaluates a view's `body` *outside* SwiftUI unless the view is hosted and the inspection runs from inside that live render. For a view reading `@Environment(SomeType.self)` — the `@Observable` form, which has **no default value** — out-of-tree evaluation does not fail. It **traps**, inside SwiftUICore's `EnvironmentValues.subscript.getter`.
+
+A trap is not a test failure. It kills the test process, so every test scheduled alongside it is reported failed at **0.000 seconds with no assertion message**, and the set differs run to run because scheduling is nondeterministic. The reported crash site names neither ViewInspector nor the offending test, so the visible symptom is a large, shifting set of unrelated suites failing for no stated reason.
+
+Hosting *before* inspecting does not help: the inspection still evaluates the body out-of-tree. The ordering has to be inverted — register the inspection, then let hosting drive it.
+
+### Discussion
+Measured on macOS 27 against a minimal reproduction of [nalexn/ViewInspector#329](https://github.com/nalexn/ViewInspector/issues/329):
+
+| shape | result |
+|---|---|
+| `.environment(obj)` then `.inspect()` | traps |
+| `.environment(obj)`, `ViewHosting.host(…)`, then `.inspect()` | traps |
+| inspection registered, then hosted | **passes** |
+
+Only the last works, and it is what ViewInspector's maintainer prescribed when closing that issue: *"hosting the view should be the last step, after you setup the inspection."*
+
+`ViewHostingBeforeInspectionVisitor` walks each `FunctionDeclSyntax` body and compares **sibling** statements only. If a single statement contains both the hosting call and an inspection call, the inspection is nested inside the hosting closure — the correct async shape — and nothing is reported. A violation requires the two calls to be in *different* top-level statements with the hosting first.
+
+That sibling restriction is the whole difficulty of the rule. The correct async form places `ViewHosting.host` textually first, so a naive position comparison flags working code.
+
+```swift
+// Before — hosted, then inspected: traps and takes the process with it
+func testContent() throws {
+    let view = ContentView().environment(VaultManager())
+    ViewHosting.host(view: view)
+    _ = try view.inspect().find(NoteListView.self)
+}
+
+// After — the inspection is nested inside the hosting scope
+func testContent() async throws {
+    let sut = ContentView()
+    try await ViewHosting.host(sut.environment(VaultManager())) {
+        try await sut.inspection.inspect { view in
+            _ = try view.find(NoteListView.self)
+        }
+    }
+}
+```
+
+### Non-Violating Examples
+```swift
+// XCTest shape: the inspection is registered first, hosting drives it.
+func testContent() throws {
+    let sut = ContentView()
+    let exp = sut.inspection.inspect { view in
+        _ = try view.find(NoteListView.self)
+    }
+    ViewHosting.host(view: sut.environmentObject(model))
+    wait(for: [exp], timeout: 0.1)
+}
+
+// Inspection with no hosting — a different question, not this rule's.
+func testPlain() throws {
+    _ = try PlainView().inspect().find(ViewType.Text.self)
+}
+
+// An unrelated `.host` member call is not ViewHosting.
+func testServer() throws {
+    server.host(view: thing)
+    _ = try view.inspect()
+}
+```
+
+### Companion
+[Observable Environment View Missing Inspection Hook](observable-environment-view-missing-inspection-hook.md) catches the same hazard from the *view* side, before any test is written.

--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier+Category.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier+Category.swift
@@ -130,7 +130,8 @@ extension RuleIdentifier {
             // Testability / PBT-readiness Rules
         case .globalMutableState, .nonInjectedNondeterminism, .pureFunctionCandidate,
              .pureClosureCandidate, .extractablePureKernel, .missingEquatableOnStateType,
-             .impureCallInViewBody:
+             .impureCallInViewBody, .viewHostingBeforeInspection,
+             .observableEnvironmentViewMissingInspectionHook:
             return .testability
 
             // Other/System Rules

--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
@@ -230,6 +230,14 @@ public enum RuleIdentifier: String, CaseIterable, Codable, Sendable {
     case missingEquatableOnStateType = "Missing Equatable on State Type"
     case impureCallInViewBody = "Impure Call in View Body"
 
+    /// A ViewInspector test that hosts a view and only *then* inspects it. The
+    /// inspection must be registered first; hosting drives it.
+    case viewHostingBeforeInspection = "ViewHosting Before Inspection"
+
+    /// A view reading `@Environment(SomeType.self)` with no inspection relay —
+    /// so it cannot be inspected without trapping.
+    case observableEnvironmentViewMissingInspectionHook = "Observable Environment View Missing Inspection Hook"
+
     /// A value rebuilt field-by-field from one you already have, where the initialiser has
     /// defaulted parameters — so a forgotten field takes its default SILENTLY.
     case lossyStructRebuild = "Lossy Struct Rebuild"

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/Testability.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/Testability.swift
@@ -67,6 +67,36 @@ class Testability: BasePatternRegistrar {
                 description: "Surfaces arithmetic that governs a loop bound, an index, a slice or a "
                     + "progress fraction while inlined in a method that also performs I/O — a pure "
                     + "function with no boundary drawn around it, which no test can reach."
+            ),
+            SyntaxPattern(
+                name: .viewHostingBeforeInspection,
+                visitor: ViewHostingBeforeInspectionVisitor.self,
+                severity: .error,
+                category: .testability,
+                messageTemplate: "ViewHosting.host(…) runs before the view is inspected — the "
+                    + "inspection must be registered first, and hosting drives it",
+                suggestion: "Either register the callback before hosting "
+                    + "(`let exp = sut.inspection.inspect { … }` then `ViewHosting.host(…)`), or "
+                    + "nest it inside `try await ViewHosting.host(sut) { … }`.",
+                description: "Inspecting after hosting still evaluates the body out-of-tree. For a "
+                    + "view reading @Environment(SomeType.self) that traps rather than fails, "
+                    + "killing the test process and reporting every co-scheduled test as failed at "
+                    + "0.000s — a different set each run, with a backtrace naming neither "
+                    + "ViewInspector nor the offending test. Measured on macOS 27."
+            ),
+            SyntaxPattern(
+                name: .observableEnvironmentViewMissingInspectionHook,
+                visitor: ObservableEnvironmentViewMissingInspectionHookVisitor.self,
+                severity: .info,
+                category: .testability,
+                messageTemplate: "View reads @Environment(SomeType.self) but has no inspection "
+                    + "relay — ViewInspector cannot evaluate its body without trapping",
+                suggestion: "If the view is inspected in tests, add `internal let inspection = "
+                    + "Inspection<Self>()` plus `.onReceive(inspection.notice) { … }` to its body.",
+                description: "The @Observable form of @Environment has no default value, so reading "
+                    + "it outside a hosted hierarchy traps. Only the keypath form degrades safely. "
+                    + "Advisory: a view nobody inspects needs no hook, but adding it up front beats "
+                    + "discovering the constraint via a process-killing trap."
             )
         ]
         registry.register(patterns: patterns)

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ObservableEnvironmentViewMissingInspectionHookVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ObservableEnvironmentViewMissingInspectionHookVisitor.swift
@@ -1,0 +1,100 @@
+import SwiftProjectLintModels
+import SwiftProjectLintVisitors
+import SwiftSyntax
+
+/// Detects a `View` that reads `@Environment(SomeType.self)` but carries no
+/// inspection relay, so ViewInspector cannot evaluate its `body` without
+/// trapping.
+///
+/// The `@Observable` form `@Environment(SomeType.self)` has **no default
+/// value**. Read outside a hosted view hierarchy it traps in SwiftUICore's
+/// `EnvironmentValues.subscript.getter` — killing the test process rather than
+/// failing one test. The keypath form `@Environment(\.someKey)` is fine: it
+/// falls back to a default and merely logs a warning.
+///
+/// The only way to test such a view is to host it and inspect from inside the
+/// live render, which requires the view to carry a relay:
+///
+/// ```swift
+/// internal let inspection = Inspection<Self>()
+///
+/// var body: some View {
+///     …
+///     .onReceive(inspection.notice) { inspection.visit(self, $0) }
+/// }
+/// ```
+///
+/// This is advisory rather than a defect: a view nobody inspects needs no hook.
+/// It fires early, at the point the view is written, instead of leaving the
+/// discovery to a process-killing trap whose backtrace names neither
+/// ViewInspector nor the offending test.
+///
+/// Companion to ``RuleIdentifier/viewHostingBeforeInspection``, which catches
+/// the same hazard from the test side.
+final class ObservableEnvironmentViewMissingInspectionHookVisitor: BasePatternVisitor {
+
+    required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
+        super.init(pattern: pattern, viewMode: viewMode)
+    }
+
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard Self.conformsToView(node) else { return .visitChildren }
+
+        let observableReads = Self.observableEnvironmentProperties(in: node)
+        guard !observableReads.isEmpty else { return .visitChildren }
+        guard !Self.hasInspectionHook(node) else { return .visitChildren }
+
+        let names = observableReads.joined(separator: ", ")
+        addIssue(
+            severity: .info,
+            message: "\(node.name.text) reads @Environment(\(names)) but has no inspection relay "
+                + "— ViewInspector cannot evaluate this body without trapping",
+            filePath: getFilePath(for: Syntax(node)),
+            lineNumber: getLineNumber(for: Syntax(node)),
+            suggestion: "If this view is inspected in tests, add `internal let inspection = "
+                + "Inspection<Self>()` and `.onReceive(inspection.notice) { inspection.visit(self, $0) }` "
+                + "to its body, then host it in the test rather than inspecting directly.",
+            ruleName: .observableEnvironmentViewMissingInspectionHook
+        )
+        return .visitChildren
+    }
+
+    // MARK: - Detection
+
+    private static func conformsToView(_ node: StructDeclSyntax) -> Bool {
+        node.inheritanceClause?.inheritedTypes.contains { inherited in
+            inherited.type.as(IdentifierTypeSyntax.self)?.name.text == "View"
+        } ?? false
+    }
+
+    /// Type names read via the `@Environment(SomeType.self)` form. The keypath
+    /// form is deliberately excluded — it has a default and does not trap.
+    private static func observableEnvironmentProperties(in node: StructDeclSyntax) -> [String] {
+        var found: [String] = []
+        for member in node.memberBlock.members {
+            guard let variable = member.decl.as(VariableDeclSyntax.self) else { continue }
+            for attribute in variable.attributes {
+                guard let attr = attribute.as(AttributeSyntax.self),
+                      attr.attributeName.as(IdentifierTypeSyntax.self)?.name.text == "Environment",
+                      let args = attr.arguments?.as(LabeledExprListSyntax.self),
+                      let first = args.first?.expression.as(MemberAccessExprSyntax.self),
+                      first.declName.baseName.text == "self",
+                      let type = first.base?.as(DeclReferenceExprSyntax.self) else {
+                    continue
+                }
+                found.append("\(type.baseName.text).self")
+            }
+        }
+        return found
+    }
+
+    /// Whether the struct declares a stored property named `inspection`.
+    private static func hasInspectionHook(_ node: StructDeclSyntax) -> Bool {
+        node.memberBlock.members.contains { member in
+            guard let variable = member.decl.as(VariableDeclSyntax.self) else { return false }
+            return variable.bindings.contains { binding in
+                binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text == "inspection"
+            }
+        }
+    }
+}

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ViewHostingBeforeInspectionVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ViewHostingBeforeInspectionVisitor.swift
@@ -1,0 +1,139 @@
+import SwiftProjectLintModels
+import SwiftProjectLintVisitors
+import SwiftSyntax
+
+/// Detects a ViewInspector test that hosts a view and only *then* inspects it.
+///
+/// ViewInspector evaluates a view's `body` outside SwiftUI unless the view is
+/// hosted. For a view reading `@Environment(SomeType.self)` — the `@Observable`
+/// form, which has no default value — that out-of-tree evaluation **traps**
+/// inside `EnvironmentValues.subscript.getter` rather than failing. A trap kills
+/// the test process, so every test scheduled alongside it is reported failed at
+/// 0.000s with no assertion message, and the set differs run to run. The
+/// reported crash site names neither ViewInspector nor the offending test.
+///
+/// Measured on macOS 27 against a minimal reproduction:
+///
+/// | shape | result |
+/// |---|---|
+/// | `.environment(obj)` then `.inspect()` | traps |
+/// | `ViewHosting.host(…)` then `.inspect()` | traps |
+/// | inspection registered, then hosted | passes |
+///
+/// Only the last works, and it is what ViewInspector's maintainer prescribes:
+/// hosting is the last step, after the inspection is set up.
+///
+/// Two shapes are correct and must not be flagged:
+///
+/// ```swift
+/// // XCTest: inspection registered first, host after.
+/// let exp = sut.inspection.inspect { view in … }
+/// ViewHosting.host(view: sut.environmentObject(model))
+/// wait(for: [exp], timeout: 0.1)
+///
+/// // async: the inspection is nested *inside* the hosting scope.
+/// try await ViewHosting.host(sut.environment(model)) {
+///     try await sut.inspection.inspect { view in … }
+/// }
+/// ```
+///
+/// The nested form places `ViewHosting.host` textually first, so a naive
+/// position comparison would flag it. This visitor only compares *sibling*
+/// statements: if one statement contains both calls, the inspection is nested
+/// inside the hosting scope and the ordering is correct by construction.
+final class ViewHostingBeforeInspectionVisitor: BasePatternVisitor {
+
+    required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
+        super.init(pattern: pattern, viewMode: viewMode)
+    }
+
+    override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard let body = node.body else { return .visitChildren }
+
+        var hostStatementIndex: Int?
+        var inspectStatementIndex: Int?
+        var offendingInspect: Syntax?
+
+        for (index, statement) in body.statements.enumerated() {
+            let hosts = Self.containsViewHosting(statement)
+            let inspects = Self.firstInspection(in: statement)
+
+            // Both in one statement means the inspection is nested inside the
+            // hosting closure — the correct async shape.
+            if hosts, inspects != nil { continue }
+
+            if hosts, hostStatementIndex == nil {
+                hostStatementIndex = index
+            }
+            if let found = inspects, inspectStatementIndex == nil {
+                inspectStatementIndex = index
+                offendingInspect = found
+            }
+        }
+
+        guard let hostIndex = hostStatementIndex,
+              let inspectIndex = inspectStatementIndex,
+              hostIndex < inspectIndex,
+              let anchor = offendingInspect else {
+            return .visitChildren
+        }
+
+        addIssue(
+            severity: .error,
+            message: "ViewHosting.host(…) runs before the view is inspected — inspect after "
+                + "hosting evaluates the body out-of-tree, which traps rather than fails",
+            filePath: getFilePath(for: anchor),
+            lineNumber: getLineNumber(for: anchor),
+            suggestion: "Register the inspection first and let hosting drive it: either "
+                + "`let exp = sut.inspection.inspect { … }` before `ViewHosting.host(…)`, or "
+                + "nest the inspection inside `try await ViewHosting.host(sut) { … }`.",
+            ruleName: .viewHostingBeforeInspection
+        )
+        return .visitChildren
+    }
+
+    // MARK: - Detection
+
+    /// Whether the statement calls `ViewHosting.host(…)` anywhere within it.
+    private static func containsViewHosting(_ statement: CodeBlockItemSyntax) -> Bool {
+        SyntaxSearch.firstCall(in: Syntax(statement)) { call in
+            guard let member = call.calledExpression.as(MemberAccessExprSyntax.self),
+                  member.declName.baseName.text == "host",
+                  let base = member.base?.as(DeclReferenceExprSyntax.self) else {
+                return false
+            }
+            return base.baseName.text == "ViewHosting"
+        } != nil
+    }
+
+    /// The first inspection call in the statement — either ViewInspector's
+    /// `.inspect()` entry point or the `inspection.inspect { }` relay.
+    private static func firstInspection(in statement: CodeBlockItemSyntax) -> Syntax? {
+        SyntaxSearch.firstCall(in: Syntax(statement)) { call in
+            guard let member = call.calledExpression.as(MemberAccessExprSyntax.self) else {
+                return false
+            }
+            return member.declName.baseName.text == "inspect"
+        }
+    }
+}
+
+/// Small search helper: the first `FunctionCallExprSyntax` under `root`
+/// satisfying `predicate`, in source order.
+enum SyntaxSearch {
+
+    static func firstCall(
+        in root: Syntax,
+        where predicate: (FunctionCallExprSyntax) -> Bool
+    ) -> Syntax? {
+        if let call = root.as(FunctionCallExprSyntax.self), predicate(call) {
+            return root
+        }
+        for child in root.children(viewMode: .sourceAccurate) {
+            if let found = firstCall(in: child, where: predicate) {
+                return found
+            }
+        }
+        return nil
+    }
+}

--- a/Tests/CoreTests/Testability/ObservableEnvironmentViewMissingInspectionHookVisitorTests.swift
+++ b/Tests/CoreTests/Testability/ObservableEnvironmentViewMissingInspectionHookVisitorTests.swift
@@ -1,0 +1,115 @@
+@testable import Core
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+@Suite
+struct ObservableEnvironmentViewMissingInspectionHookVisitorTests {
+
+    private func run(_ source: String) -> ObservableEnvironmentViewMissingInspectionHookVisitor {
+        let pattern = SyntaxPattern(
+            name: .observableEnvironmentViewMissingInspectionHook,
+            visitor: ObservableEnvironmentViewMissingInspectionHookVisitor.self,
+            severity: .info,
+            category: .testability,
+            messageTemplate: "",
+            suggestion: "",
+            description: ""
+        )
+        let visitor = ObservableEnvironmentViewMissingInspectionHookVisitor(pattern: pattern)
+        visitor.walk(Parser.parse(source: source))
+        return visitor
+    }
+
+    // MARK: - Flagged
+
+    @Test("View reading @Environment(Type.self) with no hook is flagged")
+    func observableEnvironmentWithoutHookFlags() {
+        let visitor = run("""
+        struct ContentView: View {
+            @Environment(VaultManager.self) private var vaultManager
+
+            var body: some View {
+                Text(vaultManager.title)
+            }
+        }
+        """)
+
+        #expect(visitor.detectedIssues.count == 1)
+        #expect(visitor.detectedIssues.first?.ruleName == .observableEnvironmentViewMissingInspectionHook)
+    }
+
+    @Test("message names every offending environment type")
+    func messageNamesTypes() {
+        let visitor = run("""
+        struct ContentView: View {
+            @Environment(VaultManager.self) private var vault
+            @Environment(PluginManager.self) private var plugins
+
+            var body: some View { Text("x") }
+        }
+        """)
+
+        let message = visitor.detectedIssues.first?.message ?? ""
+        #expect(message.contains("VaultManager.self"))
+        #expect(message.contains("PluginManager.self"))
+    }
+
+    // MARK: - Not flagged
+
+    @Test("the keypath form degrades to a default and is not flagged")
+    func keyPathEnvironmentIsClean() {
+        // @Environment(\.someKey) has a default value, so it warns rather than
+        // traps. Only the Type.self form is fatal.
+        let visitor = run("""
+        struct ContentView: View {
+            @Environment(\\.dependencies) private var dependencies
+
+            var body: some View { Text("x") }
+        }
+        """)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    @Test("a view that already carries the inspection relay is clean")
+    func withHookIsClean() {
+        let visitor = run("""
+        struct ContentView: View {
+            @Environment(VaultManager.self) private var vaultManager
+            internal let inspection = Inspection<Self>()
+
+            var body: some View {
+                Text(vaultManager.title)
+                    .onReceive(inspection.notice) { inspection.visit(self, $0) }
+            }
+        }
+        """)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    @Test("a non-View struct is not flagged")
+    func nonViewStructIsClean() {
+        let visitor = run("""
+        struct Holder {
+            @Environment(VaultManager.self) private var vaultManager
+        }
+        """)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    @Test("a View with no environment reads is clean")
+    func plainViewIsClean() {
+        let visitor = run("""
+        struct PlainView: View {
+            let title: String
+            var body: some View { Text(title) }
+        }
+        """)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+}

--- a/Tests/CoreTests/Testability/ViewHostingBeforeInspectionVisitorTests.swift
+++ b/Tests/CoreTests/Testability/ViewHostingBeforeInspectionVisitorTests.swift
@@ -1,0 +1,127 @@
+@testable import Core
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+@Suite
+struct ViewHostingBeforeInspectionVisitorTests {
+
+    private func run(_ source: String) -> ViewHostingBeforeInspectionVisitor {
+        let pattern = SyntaxPattern(
+            name: .viewHostingBeforeInspection,
+            visitor: ViewHostingBeforeInspectionVisitor.self,
+            severity: .error,
+            category: .testability,
+            messageTemplate: "",
+            suggestion: "",
+            description: ""
+        )
+        let visitor = ViewHostingBeforeInspectionVisitor(pattern: pattern)
+        visitor.walk(Parser.parse(source: source))
+        return visitor
+    }
+
+    // MARK: - Flagged
+
+    @Test("host then a sibling inspect is flagged")
+    func hostThenInspectFlags() {
+        let visitor = run("""
+        func testThing() throws {
+            let view = ContentView().environment(VaultManager())
+            ViewHosting.host(view: view)
+            _ = try view.inspect().find(ViewType.Text.self)
+        }
+        """)
+
+        #expect(visitor.detectedIssues.count == 1)
+        #expect(visitor.detectedIssues.first?.ruleName == .viewHostingBeforeInspection)
+    }
+
+    @Test("host then a sibling inspection relay call is flagged")
+    func hostThenRelayFlags() {
+        let visitor = run("""
+        func testThing() throws {
+            let sut = ContentView()
+            ViewHosting.host(view: sut)
+            let exp = sut.inspection.inspect { view in
+                _ = try view.find(ViewType.Text.self)
+            }
+            wait(for: [exp], timeout: 0.1)
+        }
+        """)
+
+        #expect(visitor.detectedIssues.count == 1)
+    }
+
+    // MARK: - Not flagged — the two correct shapes
+
+    @Test("XCTest shape: inspection registered before hosting is clean")
+    func inspectionThenHostIsClean() {
+        let visitor = run("""
+        func testThing() throws {
+            let sut = ContentView()
+            let exp = sut.inspection.inspect { view in
+                _ = try view.find(ViewType.Text.self)
+            }
+            ViewHosting.host(view: sut.environmentObject(model))
+            wait(for: [exp], timeout: 0.1)
+        }
+        """)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    @Test("async shape: inspection nested inside the hosting scope is clean")
+    func nestedInsideHostingIsClean() {
+        // Regression guard: `ViewHosting.host` appears textually FIRST here, so a
+        // naive position comparison would flag this correct code.
+        let visitor = run("""
+        func testThing() async throws {
+            let sut = ContentView()
+            try await ViewHosting.host(sut.environment(model)) {
+                try await sut.inspection.inspect { view in
+                    _ = try view.find(ViewType.Text.self)
+                }
+            }
+        }
+        """)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    @Test("inspection with no hosting at all is clean for this rule")
+    func inspectOnlyIsClean() {
+        let visitor = run("""
+        func testThing() throws {
+            let view = PlainView()
+            _ = try view.inspect().find(ViewType.Text.self)
+        }
+        """)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    @Test("hosting with no inspection is clean")
+    func hostOnlyIsClean() {
+        let visitor = run("""
+        func testThing() throws {
+            ViewHosting.host(view: ContentView())
+        }
+        """)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    @Test("an unrelated .host call is not mistaken for ViewHosting")
+    func unrelatedHostIsClean() {
+        let visitor = run("""
+        func testThing() throws {
+            server.host(view: thing)
+            _ = try view.inspect()
+        }
+        """)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+}


### PR DESCRIPTION
Two rules encoding a hazard **measured on macOS 27**, not folklore. Both came out of a real debugging session where the symptom was 234 failures across 68 suites and the true count was 1.

## The hazard

`@Environment(SomeType.self)` — the `@Observable` form — has **no default value**. Read outside a hosted view hierarchy it *traps* inside SwiftUICore's `EnvironmentValues.subscript.getter` rather than failing.

A trap kills the test process. Every co-scheduled test is then reported failed at **0.000s with no assertion message**, and the set differs run to run. The backtrace names neither ViewInspector nor the offending test, so the visible symptom is a large shifting set of unrelated suites failing for no stated reason.

The keypath form `@Environment(\.someKey)` is fine — it has a default and only logs a warning. That distinction is the discriminator both rules use.

## Rule 1 — `ViewHosting Before Inspection` (error)

Flags a test that hosts a view and only *then* inspects it. Measured against a minimal reproduction of [nalexn/ViewInspector#329](https://github.com/nalexn/ViewInspector/issues/329):

| shape | result |
|---|---|
| `.environment(obj)` then `.inspect()` | traps |
| `.environment(obj)`, `ViewHosting.host(…)`, then `.inspect()` | traps |
| inspection registered, then hosted | **passes** |

Only the last works — exactly what ViewInspector's maintainer prescribed when closing that issue.

**The subtlety, and the reason this isn't a one-liner:** the correct async shape nests the inspection *inside* the hosting closure, so `ViewHosting.host` appears textually **first**. A naive position comparison flags working code. The rule compares **sibling statements only** — if a single statement contains both calls, the ordering is correct by construction.

Tests pin both correct shapes, not just the violation:

```swift
// clean — XCTest: inspection registered first
let exp = sut.inspection.inspect { … }
ViewHosting.host(view: sut.environmentObject(model))

// clean — async: nested inside the hosting scope
try await ViewHosting.host(sut.environment(model)) {
    try await sut.inspection.inspect { … }
}

// flagged — hosted, then inspected as a sibling
ViewHosting.host(view: view)
_ = try view.inspect().find(NoteListView.self)
```

## Rule 2 — `Observable Environment View Missing Inspection Hook` (info)

Flags a `View` reading `@Environment(SomeType.self)` with no `inspection` relay, so the constraint surfaces where the view is written rather than via a crash log later.

Advisory severity on purpose: a view nobody inspects needs no hook, and requiring one everywhere would be noise.

## Validation

Beyond the 13 unit tests, both rules were run against a real project (SwiftMarkdownWiki):

- **Correctly silent** on `ContentView` and `EditorView`, which now carry hooks — true negatives.
- **Flags `SettingsView`**, which reads two Observable environment objects without one — true positive, naming both types.

Notably `SettingsView` is *not* currently inspected in tests, which is precisely why rule 2 is advisory rather than an error.

## Housekeeping

- Full suite: **3127 tests pass**.
- SwiftLint clean (including this repo's own `prefer_condition_list`).
- Both rules documented in `Docs/rules/` and indexed in `RULES.md`, per the `everyRuleResolvesToBundledMarkdown` invariant — which caught me for omitting them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)