### PR TITLE
--categories: parse unambiguously so the path can go anywhere

### DIFF
--- a/Docs/user/reference.md
+++ b/Docs/user/reference.md
@@ -22,7 +22,7 @@ swiftprojectlint <project-path> [options]
 |--------|--------|---------|-------------|
 | `--format` | `text`, `json` | `text` | Output format. |
 | `--threshold` | `error`, `warning`, `info` | `warning` | Minimum severity that causes a non-zero exit code. |
-| `--categories` | See below | all | One or more category names (space-separated). Restricts analysis to those categories. |
+| `--categories` | See below | all | One category name. **Repeat the flag or comma-separate** for several: `--categories a,b` or `--categories a --categories b`. Restricts analysis to those categories. |
 | `--config` | file path | `.swiftprojectlint.yml` in project root | Path to a configuration file. |
 | `--include-nested-packages` | — | off | Analyze nested first-party Swift packages instead of skipping them (see [Nested Packages](#nested-packages)). Overrides `include_nested_packages` in the config when present. |
 | `--version` | — | — | Print the version number and exit. |
@@ -65,7 +65,12 @@ swiftprojectlint /path/to/MyApp
 swiftprojectlint /path/to/MyApp --format json --threshold error
 
 # Analyze only state management and security rules
-swiftprojectlint /path/to/MyApp --categories stateManagement security
+swiftprojectlint /path/to/MyApp --categories stateManagement,security
+
+# The flag may also be repeated, and the path may go anywhere. The old
+# space-separated form (`--categories stateManagement security`) no longer
+# parses: it consumed the path as a category name when the path came last.
+swiftprojectlint --categories stateManagement --categories security /path/to/MyApp
 
 # Use a custom config file
 swiftprojectlint /path/to/MyApp --config ~/configs/strict.yml

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ swift run CLI /path/to/project
 swift run CLI /path/to/project --format json
 
 # Filter by category and severity threshold
-swift run CLI /path/to/project --categories stateManagement performance --threshold error
+swift run CLI /path/to/project --categories stateManagement,performance --threshold error
 ```
 
 ## Rules

--- a/Sources/CLI/SwiftProjectLintCLI.swift
+++ b/Sources/CLI/SwiftProjectLintCLI.swift
@@ -25,7 +25,33 @@ struct SwiftProjectLintCLI: AsyncParsableCommand {
     @Option(name: .long, help: "Minimum severity to trigger a non-zero exit: error, warning, or info.")
     var threshold: SeverityThreshold = .warning
 
-    @Option(name: .long, parsing: .upToNextOption, help: "Pattern categories to analyze (default: all).")
+    /// Repeat the flag, or comma-separate: `--categories a,b` / `--categories a --categories b`.
+    ///
+    /// **`.singleValue` rather than `.upToNextOption`, and the difference is a real defect.**
+    /// `.upToNextOption` consumes every following value until the next `-`-prefixed token, which
+    /// includes the required `<project-path>` positional when it is written last:
+    ///
+    /// ```
+    /// swiftprojectlint --categories testability /path/to/project   # exit 64
+    /// Error: Missing expected argument '<project-path>'
+    /// ```
+    ///
+    /// The path was read as a category name and the positional went missing. The failure is at
+    /// least loud — a parse error, not a silent scan of the wrong tree — but it cannot be caught
+    /// and explained, because parsing fails before `validate()` ever runs. An unambiguous parsing
+    /// strategy is the only structural fix.
+    ///
+    /// Comma splitting is handled in `parseCategories()` and matches `swift-infer --packs`, so the
+    /// two halves of the lint → infer hop accept list arguments the same way.
+    ///
+    /// This drops the space-separated form (`--categories a b`), which `Docs/reference.md`
+    /// documented. Both of that file's examples put the path first and so were never at risk;
+    /// they are updated regardless, since the syntax they show no longer parses.
+    @Option(
+        name: .long,
+        parsing: .singleValue,
+        help: "Pattern category to analyze; repeat or comma-separate for several (default: all)."
+    )
     var categories: [String] = []
 
     @Option(name: .long, help: "Path to configuration file (default: .swiftprojectlint.yml in project root).")
@@ -145,8 +171,19 @@ struct SwiftProjectLintCLI: AsyncParsableCommand {
         FileHandle.standardError.write(Data((message + "\n").utf8))
     }
 
+    /// Flatten the repeated flag's values, splitting each on commas.
+    ///
+    /// Empties are dropped so `a,,b` and a trailing `a,` behave, rather than failing with
+    /// `Unknown category ''` — a message that names nothing and helps nobody.
+    static func expandCategoryNames(_ raw: [String]) -> [String] {
+        raw.flatMap { $0.split(separator: ",") }
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+
     private func parseCategories() throws -> [PatternCategory]? {
-        guard !categories.isEmpty else { return nil }
+        let names = Self.expandCategoryNames(categories)
+        guard !names.isEmpty else { return nil }
 
         let categoryMap: [String: PatternCategory] = Dictionary(
             uniqueKeysWithValues: PatternCategory.allCases.map {
@@ -155,7 +192,7 @@ struct SwiftProjectLintCLI: AsyncParsableCommand {
         )
 
         var result: [PatternCategory] = []
-        for name in categories {
+        for name in names {
             guard let category = categoryMap[name] else {
                 let valid = categoryMap.keys.sorted().joined(separator: ", ")
                 throw ValidationError("Unknown category '\(name)'. Valid categories: \(valid)")

--- a/Tests/CLITests/CategoryArgumentTests.swift
+++ b/Tests/CLITests/CategoryArgumentTests.swift
@@ -1,0 +1,91 @@
+@testable import CLI
+import ArgumentParser
+import Core
+import Testing
+
+/// `--categories` accepts a repeated flag and/or comma-separated values, and — the point of the
+/// change — **the `<project-path>` positional may appear anywhere.**
+///
+/// The parsing strategy used to be `.upToNextOption`, which consumes every following value until
+/// the next `-`-prefixed token. That swallowed the required positional whenever the path was
+/// written last:
+///
+/// ```
+/// swiftprojectlint --categories testability /path/to/project
+/// Error: Missing expected argument '<project-path>'   (exit 64)
+/// ```
+///
+/// Loud rather than silent, which is the right way for it to break — but unfixable in place,
+/// because parsing fails before `validate()` runs, so no friendlier message can be attached. The
+/// only structural fix is an unambiguous strategy, and `pathAfterCategoriesStillParses` is the
+/// test that pins it.
+@Suite
+struct CategoryArgumentTests {
+
+    // MARK: - Positional recovery (the defect this change exists for)
+
+    @Test func pathAfterCategoriesStillParses() throws {
+        let command = try SwiftProjectLintCLI.parse(["--categories", "testability", "/tmp/project"])
+        #expect(command.projectPath == "/tmp/project")
+        #expect(command.categories == ["testability"])
+    }
+
+    @Test func pathBeforeCategoriesStillParses() throws {
+        let command = try SwiftProjectLintCLI.parse(["/tmp/project", "--categories", "testability"])
+        #expect(command.projectPath == "/tmp/project")
+        #expect(command.categories == ["testability"])
+    }
+
+    /// The form `Docs/reference.md` documented before this change. It now parses as ONE category
+    /// with the second name taken as the positional — which is why the docs were updated in the
+    /// same commit rather than left to rot.
+    @Test func spaceSeparatedFormNoLongerCollectsBothNames() throws {
+        let command = try SwiftProjectLintCLI.parse(["--categories", "security", "stateManagement"])
+        #expect(command.categories == ["security"])
+        #expect(command.projectPath == "stateManagement")
+    }
+
+    // MARK: - The two supported spellings
+
+    @Test func flagMayBeRepeated() throws {
+        let command = try SwiftProjectLintCLI.parse(
+            ["/tmp/p", "--categories", "security", "--categories", "performance"]
+        )
+        #expect(command.categories == ["security", "performance"])
+    }
+
+    @Test func commaSeparatedValuesExpand() {
+        #expect(
+            SwiftProjectLintCLI.expandCategoryNames(["security,performance"])
+                == ["security", "performance"]
+        )
+    }
+
+    /// Both spellings at once, because a user who learns one will eventually mix them.
+    @Test func repeatedAndCommaSeparatedCompose() {
+        #expect(
+            SwiftProjectLintCLI.expandCategoryNames(["a,b", "c"]) == ["a", "b", "c"]
+        )
+    }
+
+    // MARK: - Degenerate input
+
+    /// `a,,b` and a trailing `a,` must not reach the category map, where they would fail with
+    /// `Unknown category ''` — a message that names nothing and helps nobody.
+    @Test func emptyComponentsAreDropped() {
+        #expect(SwiftProjectLintCLI.expandCategoryNames(["a,,b"]) == ["a", "b"])
+        #expect(SwiftProjectLintCLI.expandCategoryNames(["a,"]) == ["a"])
+        #expect(SwiftProjectLintCLI.expandCategoryNames([","]).isEmpty)
+    }
+
+    @Test func surroundingWhitespaceIsTrimmed() {
+        #expect(SwiftProjectLintCLI.expandCategoryNames(["a, b"]) == ["a", "b"])
+    }
+
+    /// No `--categories` at all still means "every category", not "none". The guard for that lives
+    /// on the expanded list now, so an input expanding to empty must behave like an absent flag.
+    @Test func absentAndEmptyBothMeanAllCategories() {
+        #expect(SwiftProjectLintCLI.expandCategoryNames([]).isEmpty)
+        #expect(SwiftProjectLintCLI.expandCategoryNames([""]).isEmpty)
+    }
+}


### PR DESCRIPTION
Found while building a driver for the lint → infer loop in SwiftInferProperties.

## The defect

`--categories` used `.upToNextOption`, which consumes every following value until the next `-`-prefixed token — including the required `<project-path>` positional when the path comes last:

```
$ swiftprojectlint --categories testability /path/to/project
Error: Missing expected argument '<project-path>'      # exit 64
```

The path was read as a category name.

Two things worth noting about how it survived. The failure is **loud** — a parse error, not a silent scan of the wrong tree — which is the right way for it to break. And **both documented examples put the path first**, so neither the reference nor the README ever exercised the broken order.

It also can't be fixed in place with a friendlier message: parsing fails before `validate()` runs, so nothing can attach an explanation. An unambiguous strategy is the only structural fix.

## The change

`.singleValue` plus comma splitting in `parseCategories()`. Both spellings work and compose, and the positional may now go anywhere:

```
swiftprojectlint <path> --categories a,b
swiftprojectlint --categories a --categories b <path>
```

Comma separation also matches `swift-infer --packs`, so both halves of the lint→infer hop accept list arguments the same way.

## What it costs

**The space-separated form no longer parses.** `Docs/reference.md:25` documented it and `README.md:47` showed it; both are updated here rather than left to rot. `spaceSeparatedFormNoLongerCollectsBothNames` pins the new behaviour explicitly rather than leaving the cost implied.

## Tests

9 new, all passing. `pathAfterCategoriesStillParses` is the one that pins the defect. Degenerate input covered too — `a,,b` and a trailing `a,` are dropped rather than reaching the category map and failing with `Unknown category ''`, a message that names nothing.

Wider CLI suite green: **76 tests, 10 suites**. Verified against the real binary — the previously-failing invocation now returns 9 seeds, and `--categories bogus` still rejects with the valid-category list.

## Note

This branch contains **only** these four files. Unrelated work in progress on `main` (Security visitors, `ExecutableTargetDetector`, `Tests/CoreTests/Extractors/`) was left unstaged and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cUDGPb8pG6W25v3PjnAat