### PR TITLE
Read a string literal's value, not its source text; and four extractor laws

### DIFF
--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/ExecutableTargetDetector.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/ExecutableTargetDetector.swift
@@ -49,7 +49,7 @@ public struct ExecutableTargetDetector {
 
     /// Returns the substring of `content` between the already-consumed opening `(`
     /// and its matching `)`, by counting paren depth.
-    private static func balancedArgs(in content: String, from start: String.Index) -> String? {
+    static func balancedArgs(in content: String, from start: String.Index) -> String? {
         var depth = 1
         var pos = start
         while pos < content.endIndex, depth > 0 {

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/DependencyConsumption.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/DependencyConsumption.swift
@@ -55,7 +55,7 @@ enum DependencyConsumption {
     /// optionals, and a single array layer (`[any P]` — plugin-list injection) so the
     /// existential `any DataParsing` and the bare `DataParsing` both resolve to
     /// `DataParsing`. Returns `nil` for tuples, functions, and other non-nominal types.
-    private static func baseTypeName(_ type: TypeSyntax) -> String? {
+    static func baseTypeName(_ type: TypeSyntax) -> String? {
         if let someOrAny = type.as(SomeOrAnyTypeSyntax.self) {
             return baseTypeName(someOrAny.constraint)
         }

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Security/StringLiteralValue.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Security/StringLiteralValue.swift
@@ -1,0 +1,40 @@
+import SwiftParser
+import SwiftSyntax
+
+/// The **value** of a string literal, as opposed to its source text.
+///
+/// Extracted because three security visitors each had a `extractStringValue` and they did not
+/// agree. `SecurityVisitor` read `literal.segments` — the route SwiftSyntax provides, which hands
+/// back the decoded content. `InsecureTransportVisitor` and `UserDefaultsSensitiveDataVisitor`
+/// sliced `literal.description` with `dropFirst().dropLast()`, which operates on **source text**:
+///
+/// - `"a\"b"` is seven characters of source. Stripping the outer quotes yields `a\"b` — a string
+///   containing a literal backslash, not the value `a"b`. Any downstream comparison against a real
+///   string then silently fails to match.
+/// - A multiline literal `"""abc"""` starts and ends with `"` and is longer than two characters, so
+///   it passes the guard and yields `""abc""` — two stray quotes on each end.
+///
+/// Neither visitor is *reported* wrong by these; a URL scheme check simply stops recognising the
+/// value, and a sensitive-key check stops matching. Silent under-detection in a security rule.
+///
+/// The interpolation guard is kept, and it is the one thing the sliced versions got right that the
+/// segment version does not: a literal with `\(...)` in it has no compile-time value, and joining
+/// only its literal segments would invent one.
+enum StringLiteralValue {
+
+    /// The literal's value, or `nil` when it has no compile-time value.
+    ///
+    /// `nil` for an interpolated literal — `"\(scheme)://x"` is not a constant, and returning
+    /// `"://x"` would hand a caller a value the program never has.
+    /// A property test drove this to the right API. The first cut joined
+    /// `StringSegmentSyntax.content.text`, which is still **source text**: the literal `"\\"` came
+    /// back as two backslashes rather than the one character it denotes. Better than slicing
+    /// `description`, and wrong in the same direction.
+    ///
+    /// `representedLiteralValue` is SwiftSyntax's own decoder. It handles escapes, multiline
+    /// literals and raw (`#"..."#`) delimiters, and returns `nil` for an interpolated literal —
+    /// which is exactly the refusal this needs, for free.
+    static func of(_ literal: StringLiteralExprSyntax) -> String? {
+        literal.representedLiteralValue
+    }
+}

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Security/Visitors/InsecureTransportVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Security/Visitors/InsecureTransportVisitor.swift
@@ -86,12 +86,7 @@ final class InsecureTransportVisitor: BasePatternVisitor {
     // MARK: - Helpers
 
     private func extractStringValue(from literal: StringLiteralExprSyntax) -> String? {
-        guard !literal.description.contains("\\(") else { return nil }
-        let trimmed = literal.description.trimmingCharacters(in: .whitespaces)
-        guard trimmed.hasPrefix("\""), trimmed.hasSuffix("\""), trimmed.count >= 2 else {
-            return nil
-        }
-        return String(trimmed.dropFirst().dropLast())
+        StringLiteralValue.of(literal)
     }
 
     private func isInsecureScheme(_ urlString: String) -> Bool {

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Security/Visitors/UserDefaultsSensitiveDataVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Security/Visitors/UserDefaultsSensitiveDataVisitor.swift
@@ -148,10 +148,7 @@ final class UserDefaultsSensitiveDataVisitor: BasePatternVisitor {
 
     /// Extracts the string value from a simple (non-interpolated) string literal.
     private func extractStringValue(from literal: StringLiteralExprSyntax) -> String? {
-        guard !literal.description.contains("\\(") else { return nil }
-        let trimmed = literal.description.trimmingCharacters(in: .whitespaces)
-        guard trimmed.hasPrefix("\""), trimmed.hasSuffix("\""), trimmed.count >= 2 else { return nil }
-        return String(trimmed.dropFirst().dropLast())
+        StringLiteralValue.of(literal)
     }
 
     // MARK: - Sensitivity Heuristics

--- a/Tests/CoreTests/Extractors/ExtractorLawsTests.swift
+++ b/Tests/CoreTests/Extractors/ExtractorLawsTests.swift
@@ -1,0 +1,151 @@
+import Foundation
+import PropertyBased
+import SwiftParser
+@testable import SwiftProjectLintConfig
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+/// Laws for four `-> String?` extractors, written to test a claim rather than to add coverage.
+///
+/// The claim was mine: that the 254 seeds `DeclaredRoleClassifier` leaves unclassified "genuinely
+/// owe nothing entailed", so the template catalog's silence on them is correct rather than a gap.
+/// It was reached by reading shapes from a distance. A frozen sample of 20 `String?` extractors —
+/// every third of 78, sorted by file:line, chosen before any was read — refuted it: nine had a law
+/// worth writing. These are the four strongest.
+///
+/// Two of them were also unreachable (`private`) until this change, which is the advice the linter
+/// now gives applied to itself: `balancedArgs` and `baseTypeName` were widened to `internal`, and
+/// the duplicated string-literal readers were lifted into `StringLiteralValue` — the two remedies
+/// `PureFunctionCandidateVisitor` names, one each.
+@Suite("Extractor laws — from the frozen sample of twenty")
+struct ExtractorLawsTests {
+
+    // MARK: - 1. Unwrapping a type is invariant under wrapping
+
+    /// `baseTypeName` strips `some` / `any` / `?` / `!` recursively.
+    ///
+    /// The law needs no name and no docstring: wrapping a type in any combination of those markers
+    /// must not change the base name it resolves to. Refutable by any implementation that stops at
+    /// the first layer, and the generator is a random tower of wrappers.
+    @Test("wrapping a type in any combination of some/any/?/! leaves the base name unchanged")
+    func baseTypeNameIgnoresWrappers() async {
+        await propertyCheck(
+            input: Self.baseNameGen, Self.wrappersGen, Self.prefixMarkerGen
+        ) { base, wrappers, marker in
+            // `some`/`any` bind outermost and cannot stack; optionals attach to the inner type.
+            let text = marker + base + wrappers.joined()
+            guard let type = Self.parseTypeAnnotation("let x: \(text) = y") else { return }
+            #expect(DependencyConsumption.baseTypeName(type) == base,
+                    "\(marker)\(base)\(wrappers.joined()) did not resolve to \(base)")
+        }
+    }
+
+    // MARK: - 2. A balanced scan returns balanced text
+
+    /// `balancedArgs` walks forward from just inside a `(` until depth returns to zero.
+    ///
+    /// Two laws, and the second is the one worth generating for: the result must itself be
+    /// balanced, and the scan must **terminate without trapping** on any input — it advances with
+    /// `content.index(after:)` inside a loop, which is where an off-by-one meets `endIndex`.
+    @Test("what balancedArgs returns is itself balanced, and it never traps")
+    func balancedArgsReturnsBalancedText() async {
+        await propertyCheck(input: Self.parenCharsGen) { characters in
+            let content = "f(" + characters.joined()
+            guard let open = content.firstIndex(of: "(") else { return }
+            let start = content.index(after: open)
+            // Refusing is always allowed; returning something unbalanced is not.
+            guard let extracted = ExecutableTargetDetector.balancedArgs(in: content, from: start) else {
+                return
+            }
+            var depth = 0
+            var wentNegative = false
+            for character in extracted {
+                if character == "(" { depth += 1 }
+                if character == ")" { depth -= 1 }
+                if depth < 0 { wentNegative = true }
+            }
+            #expect(wentNegative == false, "unbalanced result for \(content)")
+            #expect(depth == 0, "unbalanced result for \(content)")
+        }
+    }
+
+    // MARK: - 3 & 4. A string literal's value round-trips
+
+    /// **The law that motivated the whole experiment.**
+    ///
+    /// For any string with no interpolation, building a literal from it and reading the value back
+    /// must return the original. Two of the three security visitors implemented this by slicing
+    /// `description` with `dropFirst().dropLast()`, which returns SOURCE TEXT: an escaped quote
+    /// came back as `a\"b` rather than `a"b`. A security rule then silently stops matching.
+    @Test("reading a literal's value round-trips through the source it was written as")
+    func stringLiteralValueRoundTrips() async {
+        await propertyCheck(input: Self.literalCharsGen) { characters in
+            let original = characters.joined()
+            let escaped = original
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "\"", with: "\\\"")
+            guard let literal = Self.parseStringLiteral("let x = \"\(escaped)\"") else { return }
+            #expect(StringLiteralValue.of(literal) == original,
+                    "value did not round-trip for \(original.debugDescription)")
+        }
+    }
+
+    /// Interpolation has no compile-time value, so the reader must refuse rather than invent one by
+    /// joining the literal segments around the hole.
+    @Test("an interpolated literal has no value")
+    func interpolatedLiteralHasNoValue() async {
+        await propertyCheck(input: Self.prefixGen, Self.suffixGen) { prefix, suffix in
+            let source = "let x = \"\(prefix)\\(value)\(suffix)\""
+            guard let literal = Self.parseStringLiteral(source) else { return }
+            #expect(StringLiteralValue.of(literal) == nil, "invented a value for an interpolation")
+        }
+    }
+
+    // MARK: - Generators and parsing helpers
+    //
+    // Hoisted out of the `propertyCheck` calls deliberately: inline, the parse chains and generator
+    // compositions tripped "unable to type-check this expression in reasonable time". This project
+    // has been bitten by that before, and a local build that merely takes a long time is a CI build
+    // that fails outright.
+
+    private static let baseNameGen = Gen<String?>
+        .element(of: ["Foo", "Bar", "ServiceProtocol"]).map { $0 ?? "Foo" }
+    /// Optionals only, and an opaque/existential marker chosen separately.
+    ///
+    /// The first version drew freely from `["?", "!", "some ", "any "]` and composed them in
+    /// order, which builds text Swift does not accept — `any some T`, `some T?`. The parser's
+    /// error recovery then produced a tree whose base name was literally `some`, and the property
+    /// went red for the generator's fault rather than the function's. A generator that emits
+    /// invalid inputs tests the parser, not the subject.
+    private static let optionalMarkerGen = Gen<String?>
+        .element(of: ["?", "!"]).map { $0 ?? "?" }
+    private static let wrappersGen = optionalMarkerGen.array(of: 0...3)
+    private static let prefixMarkerGen = Gen<String?>
+        .element(of: ["", "some ", "any "]).map { $0 ?? "" }
+    private static let parenCharGen = Gen<String?>
+        .element(of: ["(", ")", "a", " ", ",", "\""]).map { $0 ?? "a" }
+    private static let parenCharsGen = parenCharGen.array(of: 0...30)
+    private static let literalCharGen = Gen<String?>
+        .element(of: ["a", "Z", "1", "/", ":", "\"", "\\", " ", "-"]).map { $0 ?? "a" }
+    private static let literalCharsGen = literalCharGen.array(of: 0...12)
+    private static let prefixGen = Gen<String?>
+        .element(of: ["prefix", "", "https://"]).map { $0 ?? "" }
+    private static let suffixGen = Gen<String?>
+        .element(of: ["suffix", "", "/path"]).map { $0 ?? "" }
+
+    private static func parseTypeAnnotation(_ source: String) -> TypeSyntax? {
+        let tree = Parser.parse(source: source)
+        guard let item = tree.statements.first?.item else { return nil }
+        guard let declaration = item.as(VariableDeclSyntax.self) else { return nil }
+        return declaration.bindings.first?.typeAnnotation?.type
+    }
+
+    private static func parseStringLiteral(_ source: String) -> StringLiteralExprSyntax? {
+        let tree = Parser.parse(source: source)
+        guard let item = tree.statements.first?.item else { return nil }
+        guard let declaration = item.as(VariableDeclSyntax.self) else { return nil }
+        let value = declaration.bindings.first?.initializer?.value
+        return value?.as(StringLiteralExprSyntax.self)
+    }
+}


### PR DESCRIPTION
Two commits, each standing alone. Both come from one exercise: testing a claim about this codebase and being refuted by it.

## 1. A silent security defect (`007f7f2`)

Three security visitors each had an `extractStringValue` and **they did not agree.** `SecurityVisitor` read `literal.segments` — the route SwiftSyntax provides, which returns decoded content. The other two sliced `literal.description` with `dropFirst().dropLast()`, which operates on **source text**:

| written | sliced yields | actual value |
|---|---|---|
| `"a\"b"` | `a\"b` — a literal backslash | `a"b` |
| `"""abc"""` | `""abc""` | `abc` |

Neither visitor is *reported* wrong by this. A URL-scheme check simply stops recognising the value; a sensitive-key check stops matching. **Silent under-detection in a security rule** — the worst direction for a linter to be wrong in, because a clean run and a blind one look identical.

Lifted into `StringLiteralValue.of`, delegating to SwiftSyntax's own `representedLiteralValue`: escapes, multiline, raw `#"..."#` delimiters, and `nil` for interpolation — which is exactly the refusal needed, for free. The interpolation guard is the one thing the *sliced* versions got right and the segment version does not: `"\(scheme)://x"` has no compile-time value, and joining only its literal segments would invent one.

**A property test refuted the first fix too.** That cut joined `StringSegmentSyntax.content.text` — still source text, so `"\\"` came back as two backslashes. Better than slicing `description`, and wrong in the same direction.

## 2. Four extractor laws (`c82326d`)

The claim was that the 254 seeds `DeclaredRoleClassifier` leaves unclassified genuinely owe nothing entailed — so the catalog's silence is correct, not a gap. It was reached by reading shapes from a distance.

A frozen sample of 20 `String?` extractors — **every third of 78, sorted by `file:line`, chosen before any was read** — refuted it. Nine had a law worth writing; these are the four strongest.

The sampling discipline is the point: chosen mechanically and frozen before reading, so the result can't be steered by which ones looked promising. Same rule the road tests use, turned on a claim about this codebase's own shape.

**Two of the four subjects were `private`** — unreachable by any test — until this commit. That's the linter's own advice applied to itself: `PureFunctionCandidateVisitor` names two remedies for a pure function no test can call (widen the access, or lift the duplicated logic out), and this does one of each.

## Verification

- Rebased onto current `origin/main`: patch applied **cleanly to all four files** despite 46 commits of drift, no conflicts
- Commit 1 verified **standing alone** (rest stashed): 78 tests, 5 suites
- Full suite: **3140 tests / 378 suites**, up exactly 4 — the laws
- **No existing test had encoded the old extraction behaviour**, so none needed changing. Worth stating, since a passing test that ratifies a bug is this project's recurring failure shape

## One flake, investigated not assumed

`SourcePatternRegistryConcurrencyTests` failed once on the first full run (immediately after a cold build), then passed 3/3 on re-run; clean `origin/main` passed 2/2. I could not reproduce it on the clean arm, so this is not proof of independence — but it's a *concurrency* test on the pattern registry, this branch touches string-literal extraction and access levels, and `f435b91` upstream is *"Fix a registration race that intermittently emptied a rule category."* Same intermittency, named by whoever fixed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cUDGPb8pG6W25v3PjnAat