### PR TITLE
Say WHY a symbol is unreachable, not just that it is

### DIFF
--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/TestReachability.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/TestReachability.swift
@@ -1,3 +1,21 @@
+/// **Why** a declaration is out of `@testable import`'s reach — which decides what a fix has to
+/// touch, and is the whole reason this is not a `Bool`.
+///
+/// The two cases need *different patches*, and getting that wrong produces a change that compiles,
+/// alters nothing, and then fails verification for a reason unrelated to the property being tested:
+///
+/// - `.declaration` — widen this declaration and a test can call it.
+/// - `.enclosingType` — **widening the declaration is a no-op.** A `private struct`'s `internal`
+///   members are unreachable however they are marked; the container decides. The type is what has
+///   to move.
+///
+/// `.enclosingType` wins when both apply, because it names the *binding* constraint: a `private`
+/// func inside a `private` struct is still unreachable after the func is widened.
+public enum TestRestriction: String, Sendable, Equatable, Codable, CaseIterable {
+    case declaration = "declaration"
+    case enclosingType = "enclosing-type"
+}
+
 /// Whether a test could call the symbol a finding names.
 ///
 /// Three-valued rather than `Bool?`, and not only to satisfy `discouraged_optional_boolean`:
@@ -9,9 +27,27 @@ public enum TestReachability: Sendable, Equatable {
     case reachable
 
     /// `private` / `fileprivate`, or nested inside a type that is. No test can call it.
-    case unreachable
+    ///
+    /// The restriction travels *inside* the case rather than beside it, so an unreachable finding
+    /// cannot exist without saying what would fix it. A consumer building a patch needs that, and a
+    /// separate optional field would let the two drift apart.
+    case unreachable(TestRestriction)
 
     /// The rule did not determine it. Treated as `reachable` by anything that must choose, because
     /// the alternative silently narrows what the pipeline is offered.
     case unknown
+
+    /// `true` for any `.unreachable`, whatever the restriction. For callers that only need the
+    /// yes/no — `effectiveKind`'s demotion, for one — so they do not pattern-match a detail they
+    /// do not use.
+    public var isUnreachable: Bool {
+        if case .unreachable = self { return true }
+        return false
+    }
+
+    /// The restriction, when there is one.
+    public var restriction: TestRestriction? {
+        if case .unreachable(let reason) = self { return reason }
+        return nil
+    }
 }

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/PureFunctionCandidateVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/PureFunctionCandidateVisitor.swift
@@ -73,7 +73,8 @@ final class PureFunctionCandidateVisitor: BasePatternVisitor {
                 + "for the property rather than a failure."
         }
 
-        let reachable = PropertyTestCandidacy.isTestReachable(node)
+        let restriction = PropertyTestCandidacy.restriction(of: node)
+        let reachable = restriction == nil
         if !reachable { advice = Self.wideningAdvice }
 
         addIssue(
@@ -88,7 +89,7 @@ final class PureFunctionCandidateVisitor: BasePatternVisitor {
             // A computed property is a nullary function of `self`, so there is no signature to
             // read a role from — only the `FunctionDeclSyntax` path classifies.
             role: DeclaredRoleClassifier.role(of: node, isPartial: candidate.isPartial),
-            testReachability: reachable ? .reachable : .unreachable
+            testReachability: restriction.map(TestReachability.unreachable) ?? .reachable
         )
         return .visitChildren
     }
@@ -123,7 +124,8 @@ final class PureFunctionCandidateVisitor: BasePatternVisitor {
         if candidate.isPartial {
             advice += " Narrow the law's domain to the values that do not throw."
         }
-        let reachable = PropertyTestCandidacy.isTestReachable(node)
+        let restriction = PropertyTestCandidacy.restriction(of: node)
+        let reachable = restriction == nil
         if !reachable { advice = Self.wideningAdvice }
 
         addIssue(
@@ -135,7 +137,7 @@ final class PureFunctionCandidateVisitor: BasePatternVisitor {
             suggestion: advice,
             ruleName: .pureFunctionCandidate,
             symbol: name,
-            testReachability: reachable ? .reachable : .unreachable
+            testReachability: restriction.map(TestReachability.unreachable) ?? .reachable
         )
         return .visitChildren
     }

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/PropertyTestCandidacy+Reachability.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/PropertyTestCandidacy+Reachability.swift
@@ -1,3 +1,4 @@
+import SwiftProjectLintModels
 import SwiftSyntax
 /// Whether a test could actually call this declaration.
 ///
@@ -18,17 +19,28 @@ extension PropertyTestCandidacy {
 
     /// `false` when this declaration, or any type enclosing it, is `private` or `fileprivate`.
     public static func isTestReachable(_ node: some SyntaxProtocol) -> Bool {
+        restriction(of: node) == nil
+    }
+
+    /// **What** would have to move for a test to reach this declaration, or `nil` when nothing does.
+    ///
+    /// The enclosing-type check runs **last but wins**, and the order is the point. A `private` func
+    /// inside a `private` struct is restricted both ways, and only the outer one is binding: widen
+    /// the func and it is still unreachable. Reporting `.declaration` there would send a patch
+    /// generator to change a keyword that alters nothing — see `TestRestriction`.
+    public static func restriction(of node: some SyntaxProtocol) -> TestRestriction? {
+        if !enclosingTypesAreReachable(node) { return .enclosingType }
         if let declaration = node.as(DeclSyntax.self) ?? node.parent?.as(DeclSyntax.self),
            hasUnreachableModifier(declaration) {
-            return false
+            return .declaration
         }
         if let function = node.as(FunctionDeclSyntax.self), isUnreachable(function.modifiers) {
-            return false
+            return .declaration
         }
         if let property = node.as(VariableDeclSyntax.self), isUnreachable(property.modifiers) {
-            return false
+            return .declaration
         }
-        return enclosingTypesAreReachable(node)
+        return nil
     }
 
     /// A `private struct`'s `internal` members are unreachable too — the container decides.

--- a/Sources/Core/Export/PBTSeedsFormatter.swift
+++ b/Sources/Core/Export/PBTSeedsFormatter.swift
@@ -100,13 +100,26 @@ public struct PBTSeed: Codable, Sendable {
     /// this field existed.
     public let role: PBTSeedRole?
 
+    /// For a `restricted-function`, **what a consumer would have to widen** — see `TestRestriction`.
+    ///
+    /// `kind` says a test cannot reach this symbol; this says whether the remedy is one keyword on
+    /// the declaration or a change to an enclosing type. The two are not interchangeable: widening a
+    /// member nested inside a `private` type compiles and changes nothing, so a consumer acting on
+    /// the kind alone can emit a patch that unblocks nothing and then blame the property when
+    /// verification fails.
+    ///
+    /// `nil` for every other kind, and encoded only when present — a seed without it is
+    /// byte-identical to one written before this field existed.
+    public let restriction: TestRestriction?
+
     public init(
         file: String,
         line: Int,
         symbol: String,
         rule: String,
         kind: PBTSeedKind,
-        role: PBTSeedRole? = nil
+        role: PBTSeedRole? = nil,
+        restriction: TestRestriction? = nil
     ) {
         self.file = file
         self.line = line
@@ -114,6 +127,7 @@ public struct PBTSeed: Codable, Sendable {
         self.rule = rule
         self.kind = kind
         self.role = role
+        self.restriction = restriction
     }
 
     /// `kind` is **required**, mirroring the consumer.
@@ -135,6 +149,9 @@ public struct PBTSeed: Codable, Sendable {
         // legitimate answer. `kind` above is required for the opposite reason: absence there would
         // have to be guessed, and the guess decides whether a consumer may analyse the seed.
         self.role = try container.decodeIfPresent(PBTSeedRole.self, forKey: .role)
+        // Same reasoning as `role`: absent is honestly unknown, and only a `restricted-function`
+        // ever carries one. A consumer that ignores it loses the remedy, not the finding.
+        self.restriction = try container.decodeIfPresent(TestRestriction.self, forKey: .restriction)
     }
 }
 
@@ -209,7 +226,7 @@ public struct PBTSeedsFormatter: IssueFormatterProtocol {
     static func effectiveKind(
         _ declared: PBTSeedKind, reachability: TestReachability
     ) -> PBTSeedKind {
-        guard declared.isAnalysable, reachability == .unreachable else { return declared }
+        guard declared.isAnalysable, reachability.isUnreachable else { return declared }
         return .restrictedFunction
     }
 
@@ -284,7 +301,8 @@ public struct PBTSeedsFormatter: IssueFormatterProtocol {
                 symbol: symbol,
                 rule: issue.ruleName.rawValue,
                 kind: kind,
-                role: issue.role
+                role: issue.role,
+                restriction: issue.testReachability.restriction
             )
         }
 

--- a/Tests/CoreTests/Testability/RestrictedSeedTests.swift
+++ b/Tests/CoreTests/Testability/RestrictedSeedTests.swift
@@ -95,14 +95,14 @@ struct RestrictedSeedTests {
 
     @Test("an unreachable analysable seed is demoted to restricted-function")
     func unreachableSeedIsDemoted() {
-        #expect(PBTSeedsFormatter.effectiveKind(.pureFunction, reachability: .unreachable)
+        #expect(PBTSeedsFormatter.effectiveKind(.pureFunction, reachability: .unreachable(.declaration))
             == .restrictedFunction)
         // ...and it stays ANALYSABLE. The first cut returned false here, grouping it with
         // `extractableKernel`, which conflated two obstacles: a kernel has no symbol to analyse,
         // while a private function has a name and a signature and only lacks *verifiability* from
         // another module. `swift-infer` keys its seeded-private rescue on the analysable set, so
         // the false silently switched that feature off for every seed this linter produces.
-        #expect(PBTSeedsFormatter.effectiveKind(.pureFunction, reachability: .unreachable)
+        #expect(PBTSeedsFormatter.effectiveKind(.pureFunction, reachability: .unreachable(.declaration))
             .isAnalysable)
     }
 
@@ -120,7 +120,7 @@ struct RestrictedSeedTests {
     func kernelIsUnaffected() {
         // A kernel is already refactor-pending because it has no name. Re-labelling it would
         // replace the right instruction (draw a boundary) with the wrong one (widen access).
-        #expect(PBTSeedsFormatter.effectiveKind(.extractableKernel, reachability: .unreachable)
+        #expect(PBTSeedsFormatter.effectiveKind(.extractableKernel, reachability: .unreachable(.declaration))
             == .extractableKernel)
     }
 
@@ -178,7 +178,7 @@ struct RestrictedSeedTests {
         }
         """).first)
 
-        #expect(issue.testReachability == .unreachable)
+        #expect(issue.testReachability.isUnreachable)
         #expect(issue.message.contains("no test can reach it as written"))
     }
 

--- a/Tests/CoreTests/Testability/TestRestrictionTests.swift
+++ b/Tests/CoreTests/Testability/TestRestrictionTests.swift
@@ -1,0 +1,153 @@
+import Core
+import Foundation
+import SwiftParser
+@testable import SwiftProjectLintModels
+@testable import SwiftProjectLintVisitors
+import SwiftSyntax
+import Testing
+
+/// Why a declaration is unreachable, not just that it is — because the two answers need **different
+/// patches**, and the wrong one compiles while changing nothing.
+///
+/// `@testable import` reaches `internal` and stops. A `private` func is fixed by widening the func.
+/// A member nested inside a `private` struct is **not**: the container decides, so widening the
+/// member is a no-op. A consumer that acts on `kind: restricted-function` alone cannot tell those
+/// apart, and would emit a patch that unblocks nothing — then read the resulting verification
+/// failure as evidence against the property.
+///
+/// `enclosingTypeWinsWhenBothApply` is the load-bearing case: when a declaration is restricted both
+/// ways, only the outer restriction binds.
+@Suite("Test restriction — what would have to widen")
+struct TestRestrictionTests {
+
+    private func firstFunction(_ source: String) -> FunctionDeclSyntax? {
+        final class Finder: SyntaxVisitor {
+            var found: FunctionDeclSyntax?
+            override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+                if found == nil { found = node }
+                return .skipChildren
+            }
+        }
+        let finder = Finder(viewMode: .sourceAccurate)
+        finder.walk(Parser.parse(source: source))
+        return finder.found
+    }
+
+    private func restriction(_ source: String) -> TestRestriction? {
+        guard let function = firstFunction(source) else {
+            Issue.record("no function parsed from fixture")
+            return nil
+        }
+        return PropertyTestCandidacy.restriction(of: function)
+    }
+
+    // MARK: - Nothing to widen
+
+    @Test func internalFunctionIsUnrestricted() {
+        #expect(restriction("func add(_ a: Int, _ b: Int) -> Int { a + b }") == nil)
+    }
+
+    @Test func internalMemberOfInternalTypeIsUnrestricted() {
+        #expect(restriction("struct Math { func add(_ a: Int) -> Int { a } }") == nil)
+    }
+
+    // MARK: - The declaration is what moves
+
+    @Test func privateFunctionIsRestrictedByItsOwnModifier() {
+        #expect(restriction("private func add(_ a: Int) -> Int { a }") == .declaration)
+    }
+
+    @Test func fileprivateFunctionIsRestrictedByItsOwnModifier() {
+        #expect(restriction("fileprivate func add(_ a: Int) -> Int { a }") == .declaration)
+    }
+
+    @Test func privateMemberOfInternalTypeIsRestrictedByItsOwnModifier() {
+        #expect(restriction("struct Math { private func add(_ a: Int) -> Int { a } }") == .declaration)
+    }
+
+    // MARK: - The enclosing type is what moves
+
+    @Test func internalMemberOfPrivateTypeIsRestrictedByTheContainer() {
+        #expect(restriction("private struct Math { func add(_ a: Int) -> Int { a } }") == .enclosingType)
+    }
+
+    /// The case the whole distinction exists for. `public` on the member is as loud as an author can
+    /// be, and it still cannot be reached — so a patch generator must not read the member's own
+    /// modifier and conclude there is nothing to do.
+    @Test func publicMemberOfPrivateTypeIsStillRestrictedByTheContainer() {
+        #expect(restriction("private struct Math { public func add(_ a: Int) -> Int { a } }")
+            == .enclosingType)
+    }
+
+    @Test func nestingDepthDoesNotMatter() {
+        #expect(restriction("private struct Outer { struct Inner { func add(_ a: Int) -> Int { a } } }")
+            == .enclosingType)
+    }
+
+    @Test func aPrivateExtensionRestrictsItsMembers() {
+        #expect(restriction("private extension Math { func add(_ a: Int) -> Int { a } }")
+            == .enclosingType)
+    }
+
+    // MARK: - Precedence
+
+    /// **Restricted both ways: only the outer one binds.** Widening the func leaves it unreachable,
+    /// so reporting `.declaration` here would send a patch generator to change a keyword that alters
+    /// nothing.
+    @Test func enclosingTypeWinsWhenBothApply() {
+        #expect(restriction("private struct Math { private func add(_ a: Int) -> Int { a } }")
+            == .enclosingType)
+    }
+
+    // MARK: - The boolean façade still agrees
+
+    /// `isTestReachable` is now derived from `restriction(of:)`, so the two cannot disagree — but
+    /// that is worth pinning, since every existing caller still reads the boolean.
+    @Test func theBooleanFacadeAgreesWithTheReason() {
+        let cases = [
+            "func f() -> Int { 1 }",
+            "private func f() -> Int { 1 }",
+            "private struct S { func f() -> Int { 1 } }",
+            "struct S { private func f() -> Int { 1 } }"
+        ]
+        for source in cases {
+            guard let function = firstFunction(source) else { continue }
+            let reachable = PropertyTestCandidacy.isTestReachable(function)
+            let reason = PropertyTestCandidacy.restriction(of: function)
+            #expect(reachable == (reason == nil), "disagreed on: \(source)")
+        }
+    }
+
+    // MARK: - It reaches the manifest
+
+    @Test func reachabilityCarriesItsRestriction() {
+        #expect(TestReachability.unreachable(.enclosingType).restriction == .enclosingType)
+        #expect(TestReachability.unreachable(.declaration).restriction == .declaration)
+        #expect(TestReachability.reachable.restriction == nil)
+        #expect(TestReachability.unknown.restriction == nil)
+        #expect(TestReachability.unreachable(.declaration).isUnreachable)
+        #expect(!TestReachability.reachable.isUnreachable)
+    }
+
+    /// Absent for every kind but `restricted-function`, and omitted from the JSON entirely when
+    /// absent — a seed without it stays byte-identical to one written before the field existed.
+    @Test func theFieldIsOmittedWhenAbsent() throws {
+        let seed = PBTSeed(
+            file: "F.swift", line: 1, symbol: "f", rule: "R", kind: .pureFunction
+        )
+        let encoded = try JSONEncoder().encode(seed)
+        let text = try #require(String(data: encoded, encoding: .utf8))
+        #expect(!text.contains("restriction"))
+    }
+
+    @Test func theFieldRoundTripsWhenPresent() throws {
+        let seed = PBTSeed(
+            file: "F.swift", line: 1, symbol: "f", rule: "R",
+            kind: .restrictedFunction, restriction: .enclosingType
+        )
+        let decoded = try JSONDecoder().decode(
+            PBTSeed.self, from: try JSONEncoder().encode(seed)
+        )
+        #expect(decoded.restriction == .enclosingType)
+    }
+}


### PR DESCRIPTION
Prerequisite for the speculative-refactor work sketched in SwiftInferProperties' `open-threads.md` — but it stands alone as a correctness fix to the seed manifest.

## The problem

`restricted-function` says a test cannot call the symbol. It does not say **what would fix that**, and the two answers need different patches:

| restriction | remedy |
|---|---|
| `.declaration` | widen this declaration |
| `.enclosingType` | **widening the declaration is a no-op** — the container decides |

A consumer acting on `kind` alone can't tell them apart. It emits a patch that compiles, changes nothing, and then fails verification for a reason unrelated to the property — which reads as *evidence against the law* rather than against the patch. **A confident zero wearing a green diff.**

## Measured

| corpus | `.declaration` | `.enclosingType` |
|---|---:|---:|
| SwiftProjectLint | 311 | **27** (8%) |
| SwiftInferProperties | 641 | **18** (2.7%) |

Small, not zero, and silent in exactly the direction that would have been misread.

## Design

**The restriction travels *inside* `.unreachable`** rather than beside it, so an unreachable finding cannot exist without saying what would fix it — a separate optional field would let the two drift apart. `isUnreachable` and `restriction` are the accessors, so the eight existing callers that only want the yes/no don't pattern-match a detail they don't use.

**`.enclosingType` wins when both apply**, because it names the *binding* constraint: a `private` func inside a `private` struct is still unreachable after the func is widened. `restriction(of:)` checks enclosing types first for that reason, and `isTestReachable` is now derived from it so the two cannot disagree.

The manifest field is optional and omitted when absent, so a seed without it stays byte-identical to one written before — no schema bump.

## Tests

14 new. The two that carry the weight:

- `enclosingTypeWinsWhenBothApply`
- `publicMemberOfPrivateTypeIsStillRestrictedByTheContainer` — `public` on the member is as loud as an author can be, and it still can't be reached

Full suite green: **3154 tests, 379 suites**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cUDGPb8pG6W25v3PjnAat