### PR TITLE
Say how many rules classify a seed role, and name them

### DIFF
--- a/Sources/Core/Export/PBTSeedsFormatter.swift
+++ b/Sources/Core/Export/PBTSeedsFormatter.swift
@@ -93,8 +93,20 @@ public struct PBTSeed: Codable, Sendable {
     /// What the logic **is** — comparator, predicate, partition — when the rule classified it.
     ///
     /// `symbol` says where to look; `kind` says whether a tool can call it yet; this says what law
-    /// it owes. Absent when the rule that produced the seed classifies nothing, which is every rule
-    /// but the two candidate rules.
+    /// it owes. Absent when the rule that produced the seed classifies nothing.
+    ///
+    /// **Three rules classify**, and naming them is the point — the count has already drifted once:
+    ///
+    /// - `.pureFunctionCandidate` — `PureFunctionCandidateVisitor`, via `DeclaredRoleClassifier`
+    /// - `.pureClosureCandidate` — `PureClosureCandidateVisitor`, via `seedRole`
+    /// - `.extractablePureKernel` — `ExtractablePureKernelVisitor`, via `kernel.role`
+    ///
+    /// This said *"every rule but the two candidate rules"* until 2026-08-04, which was wrong twice
+    /// over: the count was stale, and the description ruled the third one out **by name** —
+    /// `extractablePureKernel` is a kernel rule, not a candidate rule, so a reader checking the
+    /// sentence against the code would have concluded the classification it saw there was a bug.
+    /// A doc that characterises a set by a property its newest member lacks does not merely go out
+    /// of date; it argues against the code.
     ///
     /// Encoded only when present, so a seed with no role is byte-identical to one written before
     /// this field existed.

--- a/Tests/CoreTests/Testability/SeedRoleEmissionTests.swift
+++ b/Tests/CoreTests/Testability/SeedRoleEmissionTests.swift
@@ -140,6 +140,34 @@ struct SeedRoleEmissionTests {
         """) == nil)
     }
 
+    // MARK: - How many rules classify, and which
+
+    /// The third classifier, and the one this suite had no coverage for.
+    ///
+    /// `PBTSeed.role`'s doc said *"every rule but the two candidate rules"* until 2026-08-04, when
+    /// there were three — and the wording ruled the third out **by name**, since
+    /// `extractablePureKernel` is a kernel rule rather than a candidate one. A reader checking that
+    /// sentence against the code would have read the classification they found there as a bug.
+    private func functionRole(_ source: String) -> PBTSeedRole? {
+        let visitor = PureFunctionCandidateVisitor(patternCategory: .testability)
+        let syntax = Parser.parse(source: source)
+        visitor.setSourceLocationConverter(SourceLocationConverter(fileName: "F.swift", tree: syntax))
+        visitor.setFilePath("F.swift")
+        visitor.walk(syntax)
+        return visitor.detectedIssues.first { $0.ruleName == .pureFunctionCandidate }?.role
+    }
+
+    @Test("a pure comparator FUNCTION is classified, not just a closure")
+    func functionCandidateClassifies() {
+        // The closure and kernel rules already have arms above. This is the third, and without it
+        // the count in the doc rests on nothing executable.
+        #expect(functionRole("""
+        func isBefore(_ lhs: Int, _ rhs: Int) -> Bool {
+            lhs < rhs
+        }
+        """) == .comparator)
+    }
+
     // MARK: - The entailment claim this repository makes
 
     @Test("exactly the three entailed roles claim an entailed law")


### PR DESCRIPTION
Closes SwiftInferProperties open item 5. `PBTSeed.role`'s doc said the role is absent for *"every rule but the **two** candidate rules"*. Three rules classify:

| rule | site |
|---|---|
| `.pureFunctionCandidate` | `PureFunctionCandidateVisitor:91`, via `DeclaredRoleClassifier` |
| `.pureClosureCandidate` | `PureClosureCandidateVisitor:78`, via `seedRole` |
| `.extractablePureKernel` | `ExtractablePureKernelVisitor:105`, via `kernel.role` |

## The sentence was wrong twice over

The count was stale — but the description also ruled the third one out **by name**. `extractablePureKernel` is a *kernel* rule, not a *candidate* rule, so a reader checking the sentence against the code would have concluded the classification they found there was a bug rather than the doc being behind.

**A doc that characterises a set by a property its newest member lacks does not merely go out of date; it argues against the code.**

The rules are now named individually rather than counted, so the next addition has an obvious place to go and the drift shows up in a diff.

## The count was resting on nothing executable

`SeedRoleEmissionTests` had arms for the closure and kernel rules and **none** for `pureFunctionCandidate` — the third classifier had no executable claim anywhere, which is precisely how a doc about it could be wrong without a test noticing.

`functionCandidateClassifies` asserts a pure comparator function is seeded `.comparator`, **not merely non-nil**, so it cannot pass by the visitor firing with an empty role.

## What a reviewer should scrutinise

- **That three is now right and complete.** I found the producers by searching for `PBTSeedRole`; if a fourth classifies somewhere I missed, the new doc is wrong in the same way the old one was, just with a bigger number.
- **Whether naming them is better than counting them.** It is more to keep current, but it fails visibly.

3,155 tests pass. Both touched files lint clean under `--strict`; the 5 remaining violations are pre-existing in files this does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDKCpvBPhx9UtsrkVqVzKw