### PR TITLE
Bump the SEI pin past the purity regression, and guard the three-way pin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -62,7 +62,7 @@ let package = Package(
         // swift-syntax exact 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "097181aa3ebcca3918c98cf071ca083d69d97650"
+            revision: "bfcf0e3899d014752d4d73389b901f29cf3db6c9"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintIdempotencyRules/Package.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // root and SwiftProjectLintVisitors pins.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "097181aa3ebcca3918c98cf071ca083d69d97650"
+            revision: "bfcf0e3899d014752d4d73389b901f29cf3db6c9"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintVisitors/Package.swift
+++ b/Packages/SwiftProjectLintVisitors/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "097181aa3ebcca3918c98cf071ca083d69d97650"
+            revision: "bfcf0e3899d014752d4d73389b901f29cf3db6c9"
         )
     ],
     targets: [

--- a/Tests/CoreTests/Packaging/SEIPinAgreementTests.swift
+++ b/Tests/CoreTests/Packaging/SEIPinAgreementTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Testing
+
+/// The three SEI pins in this repository must name one revision.
+///
+/// `Package.swift` says so in prose — *"keep this SHA aligned with the nested
+/// packages' pins"* — and until now nothing checked it. Three manifests declare
+/// `SwiftEffectInference` by revision (SEI carries no version tags): the root,
+/// `SwiftProjectLintVisitors`, and `SwiftProjectLintIdempotencyRules`.
+///
+/// **Why divergence is worth a test rather than a convention.** SEI owns
+/// `PurityInferrer`, the shared purity oracle, and `DeclaredEffect` is a
+/// typealias onto `SwiftEffectInference.Effect`. If the nested packages resolved
+/// a different revision from the root, SwiftPM would either fail loudly (best
+/// case) or the repository would carry two notions of one lattice. The failure
+/// this is really guarding is the quiet one: bumping the pin where you happened
+/// to be looking and leaving the other two behind — which is exactly what a
+/// three-way duplication invites, and a `grep` only catches if you remember to
+/// run it.
+///
+/// **Written on 2026-08-04, when the pins had already drifted across repos.**
+/// SwiftInferProperties moved its SEI pin past a measured ~2× regression on the
+/// whole-domain purity path ([SEI#1](https://github.com/Joseph-Cursio/SwiftEffectInference/issues/1))
+/// while this repository stayed on the regressed revision — and calls
+/// `PurityInferrer` from `ExtractablePureKernelVisitor` and
+/// `PureClosureCandidateVisitor` over every function *and closure* in a project.
+/// This test cannot see that cross-repo gap; nothing in a single repository can.
+/// What it can do is make sure that when this repository's pin moves, it moves
+/// in all three places at once.
+@Suite("Packaging — the three SEI pins agree")
+struct SEIPinAgreementTests {
+
+    private static let manifests = [
+        "Package.swift",
+        "Packages/SwiftProjectLintVisitors/Package.swift",
+        "Packages/SwiftProjectLintIdempotencyRules/Package.swift"
+    ]
+
+    private static var repositoryRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // Packaging
+            .deletingLastPathComponent()   // CoreTests
+            .deletingLastPathComponent()   // Tests
+            .deletingLastPathComponent()   // repository root
+    }
+
+    /// The revision each manifest pins `SwiftEffectInference` to.
+    ///
+    /// Deliberately parsed from the manifest TEXT rather than from
+    /// `Package.resolved`: resolved state is a build artefact that a stale
+    /// checkout can carry, while the manifests are the declaration under test.
+    /// A test that read the resolved file would agree with itself even when the
+    /// three sources disagreed.
+    private static func pinnedRevision(in manifest: String) throws -> String {
+        let url = repositoryRoot.appendingPathComponent(manifest)
+        let text = try String(contentsOf: url, encoding: .utf8)
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+        guard let seiLine = lines.firstIndex(where: { $0.contains("SwiftEffectInference.git") }) else {
+            throw PinError.noDependency(manifest)
+        }
+        // The `revision:` argument follows the `url:` within a few lines.
+        for line in lines[seiLine ..< min(seiLine + 5, lines.count)] {
+            guard let range = line.range(of: "revision:") else { continue }
+            let tail = line[range.upperBound...]
+            let sha = tail.filter(\.isHexDigit)
+            guard sha.count == 40 else { continue }
+            return String(sha)
+        }
+        throw PinError.noRevision(manifest)
+    }
+
+    enum PinError: Error, CustomStringConvertible {
+        case noDependency(String)
+        case noRevision(String)
+
+        var description: String {
+            switch self {
+            case let .noDependency(manifest):
+                return "\(manifest) declares no SwiftEffectInference dependency"
+
+            case let .noRevision(manifest):
+                return "\(manifest) pins SwiftEffectInference without a 40-char revision"
+            }
+        }
+    }
+
+    @Test("All three manifests pin the same SEI revision")
+    func pinsAgree() throws {
+        let pins = try Self.manifests.map { (manifest: $0, revision: try Self.pinnedRevision(in: $0)) }
+        let distinct = Set(pins.map(\.revision))
+        #expect(
+            distinct.count == 1,
+            """
+            SEI pins disagree across manifests — bump them together:
+            \(pins.map { "  \($0.manifest): \($0.revision)" }.joined(separator: "\n"))
+            """
+        )
+    }
+
+    /// The non-vacuity check. Without it, a parser that silently returned the
+    /// same wrong thing for every manifest — an empty string, say — would make
+    /// the agreement test pass while reading nothing.
+    @Test("Each manifest yields a real 40-character revision")
+    func everyManifestYieldsARevision() throws {
+        for manifest in Self.manifests {
+            let revision = try Self.pinnedRevision(in: manifest)
+            let isAllHex = revision.allSatisfy(\.isHexDigit)
+            #expect(revision.count == 40, "\(manifest) → \(revision)")
+            #expect(isAllHex, "\(manifest) → \(revision)")
+        }
+    }
+}


### PR DESCRIPTION
Two things, and the second exists because of the first.

## Bump

All three manifests move `097181aa` → `bfcf0e3`, past the ~2× whole-domain purity regression fixed in [SwiftEffectInference#2](https://github.com/Joseph-Cursio/SwiftEffectInference/pull/2).

This repository calls `PurityInferrer` from `ExtractablePureKernelVisitor` and `PureClosureCandidateVisitor` over every function **and closure** in a project, so it is the consumer with the most calls into that path. SwiftInferProperties bumped earlier today and measured five §13 budgets returning to control-arm cost.

**Whether *this* repository was measurably paying is still unmeasured, and the bump is not evidence that it was.** That question (SwiftInferProperties' open item 3) wants its own A/B.

3,157 tests pass.

## Guard

`Package.swift` asks in prose to *"keep this SHA aligned with the nested packages' pins"* and nothing checked it. Three manifests declare SEI by revision — the root, `SwiftProjectLintVisitors`, `SwiftProjectLintIdempotencyRules` — because SEI carries no version tags.

The failure worth guarding is the quiet one: bumping the pin where you happen to be looking and leaving the other two behind. **Not hypothetical — this commit had to edit three files, and the reason the number is three is that nothing was stopping them drifting.**

Parsed from the manifest **text**, not `Package.resolved`: resolved state is a build artefact a stale checkout can carry, while the manifests are the declaration under test. A test reading the resolved file would agree with itself even when the three sources disagreed.

**Watched it fire before trusting it** — reverting one nested manifest to the old revision fails with *"SEI pins disagree across manifests"* and names them. A second test asserts each manifest yields a real 40-character revision, so a parser that silently returned nothing for all three could not pass the agreement check by reading nothing.

## What this cannot see

The **cross-repo** gap. SwiftInferProperties pins SEI independently, and nothing in a single repository can check that two repositories agree. This makes the within-repo half true; the between-repo half stays a convention.

## What a reviewer should scrutinise

- **The parser.** It scans five lines after the `url:` for a `revision:` with 40 hex digits. If a manifest ever formats that differently, the test throws rather than silently passing — but check that is really what it does.
- **Whether the cross-repo half is worth attempting** with a skip-when-absent sibling check, or whether that is the kind of test that passes in CI while proving nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDKCpvBPhx9UtsrkVqVzKw