### PR TITLE
Report cross-file findings at their own file's line

### DIFF
--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/CrossFileAnalysis/CrossFileAnalysisEngine.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/CrossFileAnalysis/CrossFileAnalysisEngine.swift
@@ -38,6 +38,17 @@ public class CrossFileAnalysisEngine: CrossFileAnalyzerProtocol {
         self.registry = registry
     }
 
+    /// The cached files in a fixed order, so every run walks them the same way.
+    ///
+    /// `fileCache` is a dictionary, and iterating one yields its elements in an order derived
+    /// from the process's hash seed — different on every launch. Any visitor state that depends
+    /// on which file came first or last then varies run to run for the same input. Sorting by
+    /// path costs one sort per visitor and removes the whole class of drift; a cross-file
+    /// visitor that reports "the first of these" now reports the same one every time.
+    private var orderedFileCache: [(fileName: String, sourceFile: SourceFileSyntax)] {
+        fileCache.sorted { $0.key < $1.key }.map { (fileName: $0.key, sourceFile: $0.value) }
+    }
+
     /// Detects patterns across multiple Swift files with cross-file analysis capabilities.
     ///
     /// This method analyzes multiple files and can detect patterns that span
@@ -75,7 +86,7 @@ public class CrossFileAnalysisEngine: CrossFileAnalyzerProtocol {
                 let visitor = crossFileVisitor.init(fileCache: fileCache)
                 configureBaseVisitor(visitor, visitorType: visitorType, categories: categories)
 
-                for (fileName, sourceFile) in fileCache {
+                for (fileName, sourceFile) in orderedFileCache {
                     if let baseVisitor = visitor as? BasePatternVisitor {
                         baseVisitor.setFilePath(fileName)
                         baseVisitor.setSourceLocationConverter(
@@ -158,7 +169,7 @@ public class CrossFileAnalysisEngine: CrossFileAnalyzerProtocol {
                     baseVisitor.enabledFrameworkAllowlists = enabledFrameworkAllowlists
                     baseVisitor.executableSourcePaths = executableSourcePaths
                 }
-                for (fileName, sourceFile) in fileCache {
+                for (fileName, sourceFile) in orderedFileCache {
                     if let baseVisitor = visitor as? BasePatternVisitor {
                         baseVisitor.setFilePath(fileName)
                         baseVisitor.setSourceLocationConverter(

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/CrossFileVisitorBase.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/CrossFileVisitorBase.swift
@@ -34,4 +34,46 @@ open class CrossFileVisitorBase: BasePatternVisitor {
         super.setFilePath(filePath)
         currentFilePath = filePath
     }
+
+    /// Converters keyed by the identity of the tree they were built for, so a node
+    /// can be resolved against its own file rather than the current one.
+    private var convertersByRoot: [SyntaxIdentifier: SourceLocationConverter] = [:]
+
+    /// The path each cached file was parsed from, keyed by its tree's identity — the inverse of
+    /// `fileCache`, which is keyed the wrong way round to answer "which file is this node from?".
+    /// Only names the converters built below; a converter carrying one file's name and another
+    /// file's tree would be a trap for anyone who later reads its `file` rather than its `line`.
+    private lazy var pathsByRoot: [SyntaxIdentifier: String] =
+        Dictionary(fileCache.map { (Syntax($0.value).id, $0.key) }) { first, _ in first }
+
+    /// The 1-based line `node` begins on, read from *its own* file.
+    ///
+    /// The inherited implementation reads `sourceLocationConverter`, which the analysis engine
+    /// resets before walking each file. That is correct during the walk and wrong afterwards:
+    /// cross-file visitors collect declarations while walking and emit them from
+    /// `finalizeAnalysis()`, by which point the installed converter belongs to whichever file
+    /// happened to be walked last. A node from any other file was then measured against a
+    /// stranger's line table — and since the engine iterates `fileCache`, an unordered
+    /// dictionary, "last" changed with the hash seed, so the same binary reported the same
+    /// finding at different lines on different runs.
+    ///
+    /// A node knows its own tree, so ask that instead. `node.root` is the `SourceFileSyntax`
+    /// the node was parsed from, and a converter built from it is the only one that can be
+    /// right. Converters are cached by root identity, so at most one is built per file that
+    /// actually carries a finding — the walk-phase path stays on the engine's own converter,
+    /// which already matches.
+    override open func getLineNumber(for node: Syntax) -> Int {
+        let root = node.root
+        if let cached = convertersByRoot[root.id] {
+            return cached.location(for: node.positionAfterSkippingLeadingTrivia).line
+        }
+        guard root.is(SourceFileSyntax.self) else { return super.getLineNumber(for: node) }
+
+        let converter = SourceLocationConverter(
+            fileName: pathsByRoot[root.id] ?? currentFilePath,
+            tree: root
+        )
+        convertersByRoot[root.id] = converter
+        return converter.location(for: node.positionAfterSkippingLeadingTrivia).line
+    }
 }

--- a/Tests/CoreTests/CrossFileAnalysis/CrossFileLineNumberDeterminismTests.swift
+++ b/Tests/CoreTests/CrossFileAnalysis/CrossFileLineNumberDeterminismTests.swift
@@ -95,4 +95,42 @@ struct CrossFileLineNumberDeterminismTests {
             #expect(finding?.lineNumber == Self.declaredLine + 1)
         }
     }
+
+    /// A rule that quotes one member of a cluster must quote the same one every run.
+    ///
+    /// Parallel Enum Shape prints the spellings of whichever twin it recorded first, so the walk
+    /// order picked the wording. On the SwiftInferProperties corpus the same two enums were
+    /// reported as `(Int, Int16, …)` on some runs and `(int, int16, …)` on others — four findings
+    /// changing text with the hash seed. The engine now walks the cache in path order, so the
+    /// alphabetically-first file supplies the wording.
+    @Test func parallelEnumShapeQuotesTheAlphabeticallyFirstFile() {
+        let registry = PatternVisitorRegistry()
+        registry.register(pattern: ParallelEnumShape().pattern)
+        let engine = CrossFileAnalysisEngine(registry: registry)
+
+        // Every enum here normalises to the same case set; only the spelling differs, and only
+        // in `A_first.swift`. Seven files rather than two on purpose: the walk order is fixed
+        // within a process, so a two-file corpus would have caught an unsorted walk only on the
+        // coin-flip where the wrong file came first. With seven, an unsorted walk quotes the
+        // lowercase spelling only if it happens to lead — one chance in seven.
+        let lowercaseFirst = ProjectFile(
+            name: "A_first.swift",
+            content: "enum KindA { case alpha, bravo, charlie }"
+        )
+        let others = ["B", "C", "D", "E", "F", "G"].map { letter in
+            ProjectFile(
+                name: "\(letter)_later.swift",
+                content: "enum Kind\(letter) { case Alpha, Bravo, Charlie }"
+            )
+        }
+
+        let issues = engine.detectCrossFilePatterns(
+            projectFiles: others + [lowercaseFirst],
+            ruleIdentifiers: [.parallelEnumShape]
+        )
+
+        #expect(issues.isEmpty == false)
+        #expect(issues.allSatisfy { $0.message.contains("alpha, bravo, charlie") })
+        #expect(issues.contains { $0.message.contains("Alpha, Bravo, Charlie") } == false)
+    }
 }

--- a/Tests/CoreTests/CrossFileAnalysis/CrossFileLineNumberDeterminismTests.swift
+++ b/Tests/CoreTests/CrossFileAnalysis/CrossFileLineNumberDeterminismTests.swift
@@ -1,0 +1,98 @@
+@testable import Core
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+/// A cross-file finding must be reported at the line it occupies in *its own* file, whichever
+/// file the visitor happened to walk last.
+///
+/// Cross-file visitors collect declarations during the walk and emit them from
+/// `finalizeAnalysis()`. The line lookup used to read the converter installed on the visitor,
+/// which by then belonged to whatever file came last — and the analysis engine iterates an
+/// unordered dictionary, so "last" changed with the process hash seed. Two runs of the same
+/// binary over the same corpus reported 12% of findings at different lines (issue #67).
+///
+/// Each test below walks the same two files in both orders and expects the same, correct line.
+/// The two files are shaped so a wrong converter cannot accidentally agree: the declaration
+/// sits on line 9 of its own file, while the other file is a single long line, so measuring
+/// the declaration's byte offset against it yields line 1.
+@Suite
+struct CrossFileLineNumberDeterminismTests {
+
+    /// A file whose only declaration begins on line 9.
+    private static let declaringSource = """
+    // padding line 1
+    // padding line 2
+    // padding line 3
+    // padding line 4
+    // padding line 5
+    // padding line 6
+    // padding line 7
+    // padding line 8
+    struct OnlyUsedHere {
+        func unreferencedHelper() -> Int { 1 }
+        var describedElsewhere: Int { unreferencedHelper() }
+    }
+    """
+
+    /// A single-line file long enough to cover the declaring file's byte offsets, so a lookup
+    /// against the wrong converter resolves to line 1 rather than landing past end-of-file.
+    private static let bystanderSource =
+        "struct Bystander { func stir() -> Int { 2 } } // "
+            + String(repeating: "x", count: 400)
+
+    private static let declaredLine = 9
+
+    /// Both walk orders of the two-file corpus, so a test can assert the reported line does not
+    /// depend on which file the visitor saw last.
+    private static func bothWalkOrders() -> [[(name: String, ast: SourceFileSyntax)]] {
+        let declaring = (name: "Declaring.swift", ast: Parser.parse(source: declaringSource))
+        let bystander = (name: "Bystander.swift", ast: Parser.parse(source: bystanderSource))
+        return [[declaring, bystander], [bystander, declaring]]
+    }
+
+    private static func walk(
+        _ visitor: some CrossFilePatternVisitorProtocol,
+        over files: [(name: String, ast: SourceFileSyntax)]
+    ) {
+        for file in files {
+            if let base = visitor as? BasePatternVisitor {
+                base.setFilePath(file.name)
+                base.setSourceLocationConverter(
+                    SourceLocationConverter(fileName: file.name, tree: file.ast)
+                )
+            }
+            visitor.walk(file.ast)
+        }
+        visitor.finalizeAnalysis()
+    }
+
+    @Test func couldBePrivateReportsDeclaringFileLineInEitherWalkOrder() {
+        for order in Self.bothWalkOrders() {
+            let cache = Dictionary(uniqueKeysWithValues: order.map { ($0.name, $0.ast) })
+            let visitor = CouldBePrivateVisitor(fileCache: cache)
+            visitor.setPattern(CouldBePrivate().pattern)
+            Self.walk(visitor, over: order)
+
+            let issues = visitor.detectedIssues.filter { $0.ruleName == .couldBePrivate }
+            let finding = issues.first { $0.message.contains("OnlyUsedHere") }
+            #expect(finding?.filePath == "Declaring.swift")
+            #expect(finding?.lineNumber == Self.declaredLine)
+        }
+    }
+
+    @Test func couldBePrivateMemberReportsDeclaringFileLineInEitherWalkOrder() {
+        for order in Self.bothWalkOrders() {
+            let cache = Dictionary(uniqueKeysWithValues: order.map { ($0.name, $0.ast) })
+            let visitor = CouldBePrivateMemberVisitor(fileCache: cache)
+            visitor.setPattern(CouldBePrivateMember().pattern)
+            Self.walk(visitor, over: order)
+
+            let issues = visitor.detectedIssues.filter { $0.ruleName == .couldBePrivateMember }
+            let finding = issues.first { $0.message.contains("unreferencedHelper") }
+            #expect(finding?.filePath == "Declaring.swift")
+            #expect(finding?.lineNumber == Self.declaredLine + 1)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #67.

## What was wrong

Cross-file visitors collect declarations while walking each file, then emit them from `finalizeAnalysis()`. The line lookup there read `sourceLocationConverter` — the converter the engine installs before each file — so by emit time it belonged to **whichever file was walked last**. A node from any other file was measured against a stranger's line table.

The engine iterates `fileCache`, an unordered dictionary, so "last" changed with the process hash seed. Hence the report: the same binary, same corpus, different lines.

Two independent defects, fixed in one commit each:

**1. Wrong converter at emit time.** `CrossFileVisitorBase.getLineNumber` now resolves `node.root` — the `SourceFileSyntax` the node was actually parsed from — caching one converter per root. Nodes reached *during* the walk already agreed with the installed converter, so only the emit phase changes.

This is the same defect `CapturedSiteLocation` was written to solve for the five idempotency visitors; fixing it in the shared base covers all seven remaining call sites (both could-be-private rules, Protocol Could Be Private, Single Implementation Protocol, Mirror Protocol, Circular Dependency, Test Missing Macro) and anything added later.

**2. Unordered walk.** Rules that quote one member of a group — Parallel Enum Shape prints the case spellings of whichever twin it saw first — had their *wording* chosen by the hash seed. The engine now walks in path order.

## Measured on the corpus from the issue

| | pre-fix | post-fix |
|---|---:|---:|
| differing lines, run 1 vs 2 | 470 | **0** |
| distinct outputs, 5 runs | 5 | **1** |

Findings are 3,860 rather than the issue's 3,844 — the pre-fix binary reports 3,860 on today's corpus too, so that delta is SwiftInferProperties moving in the intervening day, not this change. Stripping line numbers, the finding *set* is identical before and after except for the four Parallel Enum Shape messages, whose spelling is now pinned.

Locations are not merely stable but correct. `SwiftInferEntry.swift` now reports `SwiftInferEntry.main` at line 8, which is where `static func main()` is; pre-fix it drifted across lines 5, 6 and 7.

## What a reviewer should scrutinise

- **`node.root` as the key.** The claim is that a node's root is its own file's tree, so its converter is the only correct one. The fallback when the root is not a `SourceFileSyntax` (a detached fixture) defers to the old behaviour, which keeps existing unit tests that set a converter directly working.
- **Whether sorting the walk changed any finding.** It changed four messages, all Parallel Enum Shape, all spelling-only — that is the point of the change, but it is a behaviour change and worth confirming it is the one intended.
- **Test strength.** Both were checked by reverting the fix: the line tests fail with exactly the reported symptom (line 1 for a declaration on line 9); the walk-order test fails 5 of 6 runs. It is 5-of-6 rather than always because walk order is fixed within a process — hence seven files rather than two.

## Not fixed here

The `pbt-seeds` manifest emits its `seeds` array in a **different order every run** (contents identical — a sorted diff is empty). The issue called the manifest stable, which is true of its multiset but not of its bytes. It comes from per-file analysis ordering, not this code path, so it is untouched here and wants its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbX9hgEQFYarhihR6GHHvU