### PR TITLE
Carry the effect tier into the seed manifest

### DIFF
--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/LintConfiguration.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/LintConfiguration.swift
@@ -218,6 +218,15 @@ public struct LintConfiguration: Sendable {
             // outright, which silently empties the seed manifest for any rule a
             // user configures a severity on. This is exactly the shape the
             // `lossyStructRebuild` rule exists to flag; keep it exhaustive.
+            //
+            // **The comment was right and the code had drifted anyway.** It was
+            // written when `symbol` was the only seed-bearing field, and stayed
+            // accurate in spirit while `role` and `testReachability` were added
+            // above it and silently dropped here — so configuring a severity on
+            // `pureFunctionCandidate` cost the manifest its role classification
+            // and its restriction remedy, leaving the seed present but stripped
+            // of everything a consumer acts on. A warning to be exhaustive does
+            // not stay true by itself; only the enumeration does.
             if let severity = override.severity {
                 return LintIssue(
                     severity: severity,
@@ -225,7 +234,10 @@ public struct LintConfiguration: Sendable {
                     locations: issue.locations,
                     suggestion: issue.suggestion,
                     ruleName: issue.ruleName,
-                    symbol: issue.symbol
+                    symbol: issue.symbol,
+                    role: issue.role,
+                    effect: issue.effect,
+                    testReachability: issue.testReachability
                 )
             }
 

--- a/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Visitors/IdempotencyViolationVisitor.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Visitors/IdempotencyViolationVisitor.swift
@@ -375,8 +375,74 @@ final class IdempotencyViolationVisitor: CrossFileVisitorBase, CrossFilePatternV
             ruleName: .idempotencyViolation,
             // The violating function is itself the idempotence property-test
             // subject — surfaced as a seed for `--format pbt-seeds`.
-            symbol: callerName
+            symbol: callerName,
+            // …and the lattice position it was judged on travels with it. The
+            // seed already said *that* the claim failed; this says what was
+            // claimed, what the body reached, and how confidently the rule
+            // knows — the last of which no consumer can recompute, because the
+            // resolution is cross-file and multi-hop.
+            effect: seedEffect(callerEffect: site.effect, calleeEffect: calleeEffect, provenance: provenance)
         )
+    }
+
+    /// Project the rule's own effect vocabulary onto the manifest's.
+    ///
+    /// A deliberate translation rather than a shared type. `DeclaredEffect` is
+    /// SwiftEffectInference's enum and `EffectProvenance` is private to this
+    /// visitor; making either one Codable to save this function would put the
+    /// manifest's wire format at the mercy of a rename in a dependency, and the
+    /// manifest is a published contract with a version number. The exhaustive
+    /// switches are the point: adding a tier upstream should fail to compile
+    /// here rather than silently emit a case a consumer has never seen.
+    private func seedEffect(
+        callerEffect: DeclaredEffect,
+        calleeEffect: DeclaredEffect,
+        provenance: EffectProvenance
+    ) -> PBTSeedEffect {
+        let depth: Int?
+        let reason: String?
+        let wireProvenance: PBTSeedEffect.Provenance
+        switch provenance {
+        case .declared:
+            wireProvenance = .declared
+            depth = nil
+            reason = nil
+
+        case let .inferredUpward(hops):
+            wireProvenance = .inferredUpward
+            depth = hops
+            reason = nil
+
+        case let .inferredDownward(why):
+            wireProvenance = .inferredDownward
+            depth = nil
+            // The heuristic inferrer returns "" when it matched but could not
+            // phrase why. Empty is not a reason, and a consumer rendering it
+            // would print a dangling "because ." — `nil` says the same thing
+            // honestly.
+            reason = why.isEmpty ? nil : why
+        }
+        return PBTSeedEffect(
+            declared: seedTier(callerEffect),
+            resolved: seedTier(calleeEffect),
+            provenance: wireProvenance,
+            depth: depth,
+            reason: reason
+        )
+    }
+
+    /// Lattice position → wire spelling. Mirrors `effectLabel`, which produces
+    /// the same tokens for human prose; both exist because one is a `String` for
+    /// a sentence and the other is a typed case in a published schema, and
+    /// collapsing them would let a reworded diagnostic change the manifest.
+    private func seedTier(_ effect: DeclaredEffect) -> PBTSeedEffect.Tier {
+        switch effect {
+        case .pure: return .pure
+        case .idempotent: return .idempotent
+        case .observational: return .observational
+        case .externallyIdempotent: return .externallyIdempotent
+        case .nonIdempotent: return .nonIdempotent
+        }
     }
 
     private func effectLabel(_ effect: DeclaredEffect) -> String {

--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/LintIssue.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/LintIssue.swift
@@ -44,6 +44,11 @@ public struct LintIssue: Identifiable, Sendable {
     /// tool has to guess. `nil` for rules that classify nothing.
     public let role: PBTSeedRole?
 
+    /// Where this issue's symbol sits on the effect lattice, when the rule
+    /// resolved it. Only the idempotency family populates it; see
+    /// `PBTSeedEffect` for why the tier travels with its provenance.
+    public let effect: PBTSeedEffect?
+
     /// Whether a test could call the symbol this issue names — `.unknown` unless a rule determined
     /// it.
     ///
@@ -78,6 +83,7 @@ public struct LintIssue: Identifiable, Sendable {
         ruleName: RuleIdentifier,
         symbol: String? = nil,
         role: PBTSeedRole? = nil,
+        effect: PBTSeedEffect? = nil,
         testReachability: TestReachability = .unknown
     ) {
         self.severity = severity
@@ -87,6 +93,7 @@ public struct LintIssue: Identifiable, Sendable {
         self.ruleName = ruleName
         self.symbol = symbol
         self.role = role
+        self.effect = effect
         self.testReachability = testReachability
     }
 
@@ -109,6 +116,7 @@ public struct LintIssue: Identifiable, Sendable {
         ruleName: RuleIdentifier,
         symbol: String? = nil,
         role: PBTSeedRole? = nil,
+        effect: PBTSeedEffect? = nil,
         testReachability: TestReachability = .unknown
     ) {
         self.severity = severity
@@ -118,6 +126,7 @@ public struct LintIssue: Identifiable, Sendable {
         self.ruleName = ruleName
         self.symbol = symbol
         self.role = role
+        self.effect = effect
         self.testReachability = testReachability
     }
 }

--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/PBTSeedEffect.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/PBTSeedEffect.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+/// The effect-lattice position of a seeded symbol, as the linter resolved it.
+///
+/// ## Why the manifest needs this
+///
+/// `PBTSeedKind.idempotency` tells a consumer *that* a symbol violated its
+/// idempotency claim. It does not say what the claim was, what the body turned
+/// out to be, or how confidently the linter knows — and those are the three
+/// things a downstream tool needs before it may act.
+///
+/// SwiftInferProperties records the gap from the other side. Its
+/// `IdempotenceTemplate+DeclaredEffect` reads the author's annotation off the
+/// declaration and notes that the linter *"computes strictly more from the same
+/// vocabulary — an `EffectSymbolTable` resolving cross-file, multi-hop upward
+/// inference through the call graph, and a heuristic inferrer for unannotated
+/// callees — and none of that crosses into `.pbt/seeds.json`, which carries the
+/// idempotency violation but not the tier."* This type is that crossing.
+///
+/// The valuable half is `resolved`, not `declared`. A consumer parsing the same
+/// source can read the declaration itself; what it cannot reproduce is a
+/// cross-file, multi-hop resolution of what the body actually reaches. That is
+/// knowledge only the linter has, and it dies at the manifest boundary without
+/// this field.
+///
+/// ## Why provenance travels with the tier
+///
+/// The consumer's treatments are not the same: a declaration **vetoes** a
+/// proposed law, an inference **demotes** it. Emitting a bare tier would force
+/// the consumer to guess which it was holding, and either guess is a real cost —
+/// treating an inference as a declaration suppresses laws that might be true,
+/// and treating a declaration as an inference dilutes the strongest signal the
+/// author ever gave. A tier without its provenance is not a weaker version of
+/// this field; it is one the consumer cannot safely use.
+public struct PBTSeedEffect: Codable, Sendable, Equatable {
+
+    /// One position on the effect lattice, spelled as the annotation grammar
+    /// spells it.
+    ///
+    /// The raw values are the doc-comment tokens (`non_idempotent`, not
+    /// `nonIdempotent`) because that grammar is the interoperability surface
+    /// this whole pipeline shares — humans write it, the linter enforces it, and
+    /// SwiftEffectInference parses it. A second spelling in the manifest would
+    /// be a fourth dialect of a vocabulary that already has one too many.
+    public enum Tier: String, Codable, Sendable {
+        case pure
+        case idempotent
+        case observational
+        case externallyIdempotent = "externally_idempotent"
+        case nonIdempotent = "non_idempotent"
+    }
+
+    /// How the linter came to know `resolved` — and therefore how much weight a
+    /// consumer may put on it.
+    public enum Provenance: String, Codable, Sendable {
+        /// The author annotated the callee. The strongest signal available, and
+        /// the only one that should veto rather than demote.
+        case declared
+
+        /// Resolved by walking bodies up the call graph — the lattice join of a
+        /// function's callees, iterated to a fixed point across files. Carries a
+        /// `depth`; see that field for why it is not decoration.
+        case inferredUpward = "inferred-upward"
+
+        /// Matched by the heuristic name/framework inferrer (`save` on a Fluent
+        /// `Model`, `upsert`, a logger receiver). Weakest of the three: it is a
+        /// claim about a name, not about a body, so `reason` travels with it so
+        /// a reader can judge the match rather than take it.
+        case inferredDownward = "inferred-downward"
+    }
+
+    /// What the seeded symbol *claims* — the effect annotated on its own
+    /// declaration.
+    ///
+    /// Always present for an `idempotency` seed: the rule only analyses
+    /// functions carrying an effect annotation, so a violation cannot exist
+    /// without one.
+    public let declared: Tier
+
+    /// What the linter found the body actually reaches, and the reason the claim
+    /// was judged violated.
+    public let resolved: Tier
+
+    /// How `resolved` was arrived at.
+    public let provenance: Provenance
+
+    /// Hops back to a declared or heuristic anchor, counting this function as
+    /// one. `nil` unless `provenance == .inferredUpward`.
+    ///
+    /// Confidence, not trivia. `depth: 1` means every contributing callee was
+    /// itself annotated — nearly as good as a declaration. `depth: 4` means the
+    /// tier survived three intermediate functions nobody annotated, and each hop
+    /// is somewhere the inference could have taken a wrong branch. A consumer
+    /// that wants to weight by confidence has no other way to.
+    public let depth: Int?
+
+    /// For a heuristic match, the phrase naming what matched — *"from the callee
+    /// name `save`"*, *"from the known-idempotent Fluent type `QueryBuilder`"*.
+    ///
+    /// Carried because a name-based inference is the one a reader most often
+    /// needs to overrule, and overruling it requires knowing which name fired.
+    /// `nil` for the other two provenances, where the answer is "the author said
+    /// so" or "the call graph said so".
+    public let reason: String?
+
+    public init(
+        declared: Tier,
+        resolved: Tier,
+        provenance: Provenance,
+        depth: Int? = nil,
+        reason: String? = nil
+    ) {
+        self.declared = declared
+        self.resolved = resolved
+        self.provenance = provenance
+        self.depth = depth
+        self.reason = reason
+    }
+
+    /// `depth` and `reason` decode leniently; the other three are required.
+    ///
+    /// The asymmetry is the same one `PBTSeed` applies to `kind` versus `role`:
+    /// a field whose absence has an honest reading ("no hop count, because this
+    /// was not an upward inference") may be optional, and a field whose absence
+    /// would have to be guessed may not. Guessing a tier or a provenance would
+    /// invent a claim the linter never made.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.declared = try container.decode(Tier.self, forKey: .declared)
+        self.resolved = try container.decode(Tier.self, forKey: .resolved)
+        self.provenance = try container.decode(Provenance.self, forKey: .provenance)
+        self.depth = try container.decodeIfPresent(Int.self, forKey: .depth)
+        self.reason = try container.decodeIfPresent(String.self, forKey: .reason)
+    }
+}

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/BasePatternVisitor.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/BasePatternVisitor.swift
@@ -310,6 +310,7 @@ open class BasePatternVisitor: SyntaxVisitor, PatternVisitorProtocol {
         ruleName: RuleIdentifier?,
         symbol: String? = nil,
         role: PBTSeedRole? = nil,
+        effect: PBTSeedEffect? = nil,
         testReachability: TestReachability = .unknown
     ) {
         let issue = LintIssue(
@@ -321,6 +322,7 @@ open class BasePatternVisitor: SyntaxVisitor, PatternVisitorProtocol {
             ruleName: ruleName ?? pattern.name,
             symbol: symbol,
             role: role,
+            effect: effect,
             testReachability: testReachability
         )
         detectedIssues.append(issue)

--- a/Sources/Core/Export/PBTSeedsFormatter.swift
+++ b/Sources/Core/Export/PBTSeedsFormatter.swift
@@ -124,6 +124,20 @@ public struct PBTSeed: Codable, Sendable {
     /// byte-identical to one written before this field existed.
     public let restriction: TestRestriction?
 
+    /// Where the seeded symbol sits on the effect lattice — what it claimed,
+    /// what its body reached, and how the linter knows.
+    ///
+    /// Only `idempotency` seeds carry one; the other kinds are about purity and
+    /// callability, which the lattice does not speak to. Encoded only when
+    /// present, so every other seed stays byte-identical to one written before
+    /// this field existed.
+    ///
+    /// This is the field that closes the gap SwiftInferProperties named from the
+    /// other side: the linter resolves effects cross-file and multi-hop, the
+    /// consumer can only read the declaration in front of it, and until now none
+    /// of the difference crossed the manifest boundary.
+    public let effect: PBTSeedEffect?
+
     public init(
         file: String,
         line: Int,
@@ -131,7 +145,8 @@ public struct PBTSeed: Codable, Sendable {
         rule: String,
         kind: PBTSeedKind,
         role: PBTSeedRole? = nil,
-        restriction: TestRestriction? = nil
+        restriction: TestRestriction? = nil,
+        effect: PBTSeedEffect? = nil
     ) {
         self.file = file
         self.line = line
@@ -140,6 +155,7 @@ public struct PBTSeed: Codable, Sendable {
         self.kind = kind
         self.role = role
         self.restriction = restriction
+        self.effect = effect
     }
 
     /// `kind` is **required**, mirroring the consumer.
@@ -164,6 +180,10 @@ public struct PBTSeed: Codable, Sendable {
         // Same reasoning as `role`: absent is honestly unknown, and only a `restricted-function`
         // ever carries one. A consumer that ignores it loses the remedy, not the finding.
         self.restriction = try container.decodeIfPresent(TestRestriction.self, forKey: .restriction)
+        // Same reasoning again: only the idempotency family resolves a lattice
+        // position, so absence is an honest "this kind of seed has none" rather
+        // than a value to guess at.
+        self.effect = try container.decodeIfPresent(PBTSeedEffect.self, forKey: .effect)
     }
 }
 
@@ -314,7 +334,8 @@ public struct PBTSeedsFormatter: IssueFormatterProtocol {
                 rule: issue.ruleName.rawValue,
                 kind: kind,
                 role: issue.role,
-                restriction: issue.testReachability.restriction
+                restriction: issue.testReachability.restriction,
+                effect: issue.effect
             )
         }
 

--- a/Tests/CLITests/PBTSeedEffectTests.swift
+++ b/Tests/CLITests/PBTSeedEffectTests.swift
@@ -1,0 +1,172 @@
+import Core
+import Foundation
+import Testing
+
+/// The effect tier crossing the manifest boundary.
+///
+/// `PBTSeedKind.idempotency` says a symbol violated its claim. It does not say
+/// what was claimed, what the body reached, or how confidently the linter knows
+/// — and SwiftInferProperties named that gap from the other side, observing that
+/// this linter resolves effects cross-file and multi-hop while *"none of that
+/// crosses into `.pbt/seeds.json`, which carries the idempotency violation but
+/// not the tier."*
+///
+/// The valuable half is `resolved`, not `declared`: a consumer parsing the same
+/// source can read the annotation itself, but cannot reproduce a multi-hop
+/// resolution of what the body actually reaches.
+@Suite("PBT seeds — the effect tier and its provenance")
+struct PBTSeedEffectTests {
+
+    // MARK: - Helpers
+
+    private func violation(
+        symbol: String = "confirmOrder",
+        effect: PBTSeedEffect?
+    ) -> LintIssue {
+        LintIssue(
+            severity: .error,
+            message: "`\(symbol)` claims idempotence but calls non-idempotent work",
+            filePath: "Orders.swift",
+            lineNumber: 11,
+            suggestion: "Route it through an idempotency key",
+            ruleName: .idempotencyViolation,
+            symbol: symbol,
+            effect: effect
+        )
+    }
+
+    private func decodedSeeds(_ issues: [LintIssue]) throws -> [PBTSeed] {
+        let json = PBTSeedsFormatter().format(issues: issues)
+        let data = try #require(json.data(using: .utf8))
+        return try JSONDecoder().decode(PBTSeedManifest.self, from: data).seeds
+    }
+
+    // MARK: - The tier reaches the manifest
+
+    @Test("a violation seed carries the claimed and resolved tiers")
+    func carriesBothTiers() throws {
+        let seeds = try decodedSeeds([
+            violation(effect: PBTSeedEffect(
+                declared: .idempotent, resolved: .nonIdempotent, provenance: .declared
+            ))
+        ])
+        let effect = try #require(seeds.first?.effect)
+        #expect(effect.declared == .idempotent)
+        #expect(effect.resolved == .nonIdempotent)
+        #expect(effect.provenance == .declared)
+    }
+
+    /// Depth is confidence, not decoration: `depth: 1` means every contributing
+    /// callee was itself annotated, `depth: 4` means the tier survived three
+    /// functions nobody annotated. A consumer weighting by confidence has no
+    /// other signal to weight on.
+    @Test("an upward inference carries its hop count")
+    func upwardCarriesDepth() throws {
+        let seeds = try decodedSeeds([
+            violation(effect: PBTSeedEffect(
+                declared: .idempotent, resolved: .nonIdempotent,
+                provenance: .inferredUpward, depth: 3
+            ))
+        ])
+        let effect = try #require(seeds.first?.effect)
+        #expect(effect.provenance == .inferredUpward)
+        #expect(effect.depth == 3)
+    }
+
+    /// A name-based inference is the one a reader most often needs to overrule,
+    /// and overruling it requires knowing which name fired.
+    @Test("a heuristic inference carries the phrase that matched")
+    func downwardCarriesReason() throws {
+        let seeds = try decodedSeeds([
+            violation(effect: PBTSeedEffect(
+                declared: .idempotent, resolved: .nonIdempotent,
+                provenance: .inferredDownward, reason: "from the callee name `save`"
+            ))
+        ])
+        let effect = try #require(seeds.first?.effect)
+        #expect(effect.provenance == .inferredDownward)
+        #expect(effect.reason == "from the callee name `save`")
+        #expect(effect.depth == nil)
+    }
+
+    // MARK: - The wire vocabulary
+
+    /// The raw values are the annotation-grammar tokens, not Swift case names.
+    /// That grammar is the interoperability surface humans, this linter, and
+    /// SwiftEffectInference already share; a second spelling in the manifest
+    /// would be a fourth dialect of a vocabulary that has one too many.
+    @Test("tiers are spelled as the annotation grammar spells them")
+    func tiersUseGrammarSpelling() throws {
+        let json = PBTSeedsFormatter().format(issues: [
+            violation(effect: PBTSeedEffect(
+                declared: .externallyIdempotent, resolved: .nonIdempotent, provenance: .declared
+            ))
+        ])
+        #expect(json.contains("\"externally_idempotent\""))
+        #expect(json.contains("\"non_idempotent\""))
+        #expect(!json.contains("externallyIdempotent"))
+        #expect(!json.contains("nonIdempotent"))
+    }
+
+    @Test("provenance is spelled in the manifest's kebab-case style")
+    func provenanceUsesKebabCase() throws {
+        let json = PBTSeedsFormatter().format(issues: [
+            violation(effect: PBTSeedEffect(
+                declared: .idempotent, resolved: .nonIdempotent,
+                provenance: .inferredUpward, depth: 1
+            ))
+        ])
+        #expect(json.contains("\"inferred-upward\""))
+    }
+
+    // MARK: - Absence
+
+    /// Every other seed must stay byte-identical to one written before this
+    /// field existed, or an additive change becomes a breaking one for any
+    /// consumer diffing manifests.
+    @Test("a seed without an effect omits the key entirely")
+    func absentEffectIsOmitted() throws {
+        let pureCandidate = LintIssue(
+            severity: .info,
+            message: "`add(…)` looks pure and total",
+            filePath: "Math.swift",
+            lineNumber: 3,
+            suggestion: "Run swift-infer discover",
+            ruleName: .pureFunctionCandidate,
+            symbol: "add"
+        )
+        let json = PBTSeedsFormatter().format(issues: [pureCandidate])
+        #expect(!json.contains("\"effect\""))
+        let seeds = try decodedSeeds([pureCandidate])
+        #expect(seeds.first?.effect == nil)
+    }
+
+    /// `depth` and `reason` decode leniently; the three that would have to be
+    /// guessed do not. Guessing a tier or a provenance invents a claim the
+    /// linter never made.
+    @Test("an effect without depth or reason decodes")
+    func minimalEffectDecodes() throws {
+        let json = """
+        {"version":2,"seeds":[{"file":"A.swift","line":1,"symbol":"f","rule":"Idempotency Violation",
+        "kind":"idempotency","effect":{"declared":"idempotent","resolved":"non_idempotent",
+        "provenance":"declared"}}]}
+        """
+        let data = try #require(json.data(using: .utf8))
+        let manifest = try JSONDecoder().decode(PBTSeedManifest.self, from: data)
+        let effect = try #require(manifest.seeds.first?.effect)
+        #expect(effect.depth == nil)
+        #expect(effect.reason == nil)
+    }
+
+    @Test("an effect missing its provenance is rejected rather than guessed")
+    func missingProvenanceIsRejected() throws {
+        let json = """
+        {"version":2,"seeds":[{"file":"A.swift","line":1,"symbol":"f","rule":"Idempotency Violation",
+        "kind":"idempotency","effect":{"declared":"idempotent","resolved":"non_idempotent"}}]}
+        """
+        let data = try #require(json.data(using: .utf8))
+        #expect(throws: (any Error).self) {
+            _ = try JSONDecoder().decode(PBTSeedManifest.self, from: data)
+        }
+    }
+}

--- a/Tests/CoreTests/Configuration/OverrideSeedFieldPreservationTests.swift
+++ b/Tests/CoreTests/Configuration/OverrideSeedFieldPreservationTests.swift
@@ -1,0 +1,114 @@
+import Core
+import Foundation
+import Testing
+
+/// A severity override must not cost a seed the fields a consumer acts on.
+///
+/// `applyOverrides` rebuilds `LintIssue` field by field, which is the shape the
+/// `lossyStructRebuild` rule exists to flag — and this exact site has already
+/// caused the bug once: it dropped `symbol`, and because `PBTSeedsFormatter`
+/// discards symbol-less issues outright, configuring a severity on any
+/// seed-bearing rule silently emptied that rule's contribution to the manifest.
+/// A confident zero at the entry point of the whole adoption loop.
+///
+/// The fix at the time added `symbol` and a comment saying to keep the list
+/// exhaustive. **The comment stayed true and the code drifted anyway**: `role`
+/// and `testReachability` were added to `LintIssue` afterwards and never
+/// carried here, so an override left the seed present but stripped of its role
+/// classification and its restriction remedy. A warning to be exhaustive does
+/// not stay true by itself — only an enumeration that fails does.
+///
+/// So these tests enumerate. One per field, so a future addition that forgets
+/// this site fails on the field it forgot rather than on a vague count.
+@Suite("Override application — a severity change preserves every seed field")
+struct OverrideSeedFieldPreservationTests {
+
+    private func seedBearingIssue() -> LintIssue {
+        LintIssue(
+            severity: .error,
+            message: "`confirmOrder` claims idempotence but calls non-idempotent work",
+            filePath: "Orders.swift",
+            lineNumber: 11,
+            suggestion: "Route it through an idempotency key",
+            ruleName: .idempotencyViolation,
+            symbol: "confirmOrder",
+            role: .predicate,
+            effect: PBTSeedEffect(
+                declared: .idempotent,
+                resolved: .nonIdempotent,
+                provenance: .inferredUpward,
+                depth: 3
+            ),
+            testReachability: .unknown
+        )
+    }
+
+    private func overridden(_ issue: LintIssue) -> LintIssue? {
+        let configuration = LintConfiguration(
+            ruleOverrides: [.idempotencyViolation: .init(severity: .warning)]
+        )
+        return configuration.applyOverrides(to: [issue]).first
+    }
+
+    @Test("the override applies at all")
+    func severityIsOverridden() throws {
+        let result = try #require(overridden(seedBearingIssue()))
+        #expect(result.severity == .warning)
+    }
+
+    /// The original bug. Without this the manifest silently loses the seed.
+    @Test("symbol survives")
+    func symbolSurvives() throws {
+        let result = try #require(overridden(seedBearingIssue()))
+        #expect(result.symbol == "confirmOrder")
+    }
+
+    /// Added after the comment, dropped by the code.
+    @Test("role survives")
+    func roleSurvives() throws {
+        let result = try #require(overridden(seedBearingIssue()))
+        #expect(result.role == .predicate)
+    }
+
+    /// Same.
+    @Test("test reachability survives")
+    func reachabilitySurvives() throws {
+        let issue = LintIssue(
+            severity: .info,
+            message: "`normalise(…)` looks pure and total",
+            filePath: "Text.swift",
+            lineNumber: 4,
+            suggestion: "Run swift-infer discover",
+            ruleName: .idempotencyViolation,
+            symbol: "normalise",
+            testReachability: .unreachable(.declaration)
+        )
+        let result = try #require(overridden(issue))
+        #expect(result.testReachability.isUnreachable)
+        #expect(result.testReachability.restriction == .declaration)
+    }
+
+    /// The newest field, and the reason this suite exists now rather than later.
+    @Test("the effect tier survives, with its provenance and depth")
+    func effectSurvives() throws {
+        let result = try #require(overridden(seedBearingIssue()))
+        let effect = try #require(result.effect)
+        #expect(effect.declared == .idempotent)
+        #expect(effect.resolved == .nonIdempotent)
+        #expect(effect.provenance == .inferredUpward)
+        #expect(effect.depth == 3)
+    }
+
+    /// An issue that passes through untouched keeps everything by construction —
+    /// pinned so a future refactor cannot make the no-override path lossy while
+    /// the override path stays correct.
+    @Test("an issue with no override is returned intact")
+    func untouchedIssueIsIntact() throws {
+        let issue = seedBearingIssue()
+        let configuration = LintConfiguration()
+        let result = try #require(configuration.applyOverrides(to: [issue]).first)
+        #expect(result.symbol == issue.symbol)
+        #expect(result.role == issue.role)
+        #expect(result.effect == issue.effect)
+    }
+}


### PR DESCRIPTION
`PBTSeedKind.idempotency` said *that* a symbol violated its idempotency claim. It did not say what was claimed, what the body reached, or how confidently the linter knew.

SwiftInferProperties named this gap from the other side. Its `IdempotenceTemplate+DeclaredEffect` reads the author's annotation off the declaration and notes that this linter *"computes strictly more from the same vocabulary — an `EffectSymbolTable` resolving cross-file, multi-hop upward inference through the call graph, and a heuristic inferrer for unannotated callees — and none of that crosses into `.pbt/seeds.json`, which carries the idempotency violation but not the tier."*

## What it emits

On `idempotency` seeds only. Real output from a fixture exercising all three provenance paths:

```json
"confirmOrder"   → {"declared":"idempotent","resolved":"non_idempotent",
                    "provenance":"inferred-upward","depth":1}
"directClaim"    → {"declared":"idempotent","resolved":"non_idempotent",
                    "provenance":"declared"}
"heuristicClaim" → {"declared":"idempotent","resolved":"non_idempotent",
                    "provenance":"inferred-downward",
                    "reason":"from the callee-name prefix `create` (in `createUser`)"}
```

Additive and optional — every other seed stays byte-identical to one written before the field existed.

## What a reviewer should scrutinise

**Provenance travels with the tier, and that is the design decision to check.** The consumer's treatments differ: a declaration vetoes a proposed law, an inference demotes it. A bare tier would force a guess, and both guesses cost — an inference read as a declaration suppresses laws that may be true; a declaration read as an inference dilutes the strongest signal the author ever gave. A tier without provenance is not a weaker version of this field, it is one the consumer cannot safely use.

**`resolved` is the valuable half, not `declared`.** A consumer parsing the same source can read the annotation itself. What it cannot reproduce is a cross-file, multi-hop resolution of what the body actually reaches — that is knowledge only this linter has.

**A known limitation, surfaced by wiring the consumer.** `provenance` describes the **final hop** — how the immediate callee's effect was known — not whether the chain beneath it was declaration-anchored. Because `IdempotencyViolationVisitor` passes `HeuristicEffectInferrer` as the anchor resolver to `applyBodyInference`, an `inferred-upward` tier can bottom out on a name guess. The consumer therefore acts only on `provenance: declared` and withholds the other two, since it has already decided (in `EffectResolver`) that a veto built on a name guess is worse than no veto. Making `inferred-upward` actionable means tracking anchor purity through `BodyEffectInferrer` and emitting it — a follow-up in SwiftEffectInference, and the change that would unlock the multi-hop reach the consumer most wants.

## Second commit: a live bug

`applyOverrides` rebuilds `LintIssue` field by field and carries a comment warning to keep the list exhaustive — written after it dropped `symbol` and silently emptied the manifest for any rule a user set a severity on.

**The comment stayed true and the code drifted anyway.** `role` and `testReachability` were added to `LintIssue` afterwards and never carried here, so an override left the seed present but stripped of its role classification and its restriction remedy — the two fields a consumer acts on. A warning to be exhaustive does not stay true by itself; only an enumeration that fails does. Now enumerated, one test per field.

## Testing

3174 tests in 383 suites, all passing. Both changes mutation-checked: reverting the formatter wiring fails 5 tests, reverting the override fix fails 4.

Paired with the consumer change in SwiftInferProperties, so the field is not dead on arrival.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Hcz8BEtHaZtgHma89mKHU