### PR TITLE
Ignore swift-infer working state and the seed manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,21 @@ Docs/roadtest/output/lint-report.json
 Docs/roadtest/output/seed-manifest.json
 Docs/roadtest/output/discover-SwiftProjectLintVisitors.txt
 Docs/roadtest/output/discover-SwiftProjectLintRules.txt
+
+# swift-infer working state. `index.json` / `verify-evidence.json` are a cache
+# of a scan, and `verify-workdir/` holds one synthesized SwiftPM package per
+# surveyed suggestion — measured at 640 MB–1.1 GB per package directory during
+# a `prove-then-show` run, and several GB across this repo's seven packages.
+# All of it is reproducible by re-running the tool.
+.swiftinfer/
+
+# The seed manifest, produced on demand by `--format pbt-seeds` and consumed by
+# `swift-infer discover --seeds`.
+#
+# Added because SwiftInferProperties had already assumed it: `SeedManifest.swift`
+# argues that no v1 manifest can still exist because "manifests are generated on
+# demand rather than archived (SwiftProjectLint gitignores its own)" — and that
+# parenthesis was not true until this line. The conclusion held anyway (nothing
+# here ever committed one), but it rested on a fact about this repo that this
+# repo had not established. Now it has.
+.pbt/


### PR DESCRIPTION
Neither `.swiftinfer/` nor `.pbt/` was ignored, so running the pipeline against this repo left seven untracked directories in `git status` and invited someone to commit them.

**`.swiftinfer/`** is a cache of a scan plus `verify-workdir/`, which holds one synthesized SwiftPM package per surveyed suggestion — measured at 640 MB–1.1 GB per package directory during a `prove-then-show` run, and several GB across this repo's seven packages. All reproducible by re-running the tool.

**`.pbt/`** is the seed manifest, produced on demand by `--format pbt-seeds`. It is included because the consumer had already assumed it: SwiftInferProperties' `SeedManifest.swift` justifies making `kind` a *required* field by arguing that no v1 manifest can still exist, because *"manifests are generated on demand rather than archived (SwiftProjectLint gitignores its own)."* That parenthesis was not true until this commit.

The conclusion held anyway — nothing here ever committed a manifest — but a decision in one repo was resting on a fact about this repo that this repo had not established. One line makes it true rather than lucky. Drop the `.pbt/` hunk if you'd rather keep the change to `.swiftinfer/` alone.

No code changes; `git check-ignore` confirms all seven directories are now matched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Hcz8BEtHaZtgHma89mKHU