### PR TITLE
Emit what an upward chain rests on

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -62,7 +62,7 @@ let package = Package(
         // swift-syntax exact 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "bfcf0e3899d014752d4d73389b901f29cf3db6c9"
+            revision: "bc084fb9613c22f1aee94d9d1781b0eca2e67620"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintIdempotencyRules/Package.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // root and SwiftProjectLintVisitors pins.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "bfcf0e3899d014752d4d73389b901f29cf3db6c9"
+            revision: "bc084fb9613c22f1aee94d9d1781b0eca2e67620"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Visitors/IdempotencyViolationVisitor.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Visitors/IdempotencyViolationVisitor.swift
@@ -177,7 +177,7 @@ final class IdempotencyViolationVisitor: CrossFileVisitorBase, CrossFilePatternV
             return
         } else if let upward = symbolTable.upwardInference(for: calleeSignature) {
             calleeEffect = upward.effect
-            provenance = .inferredUpward(depth: upward.depth)
+            provenance = .inferredUpward(depth: upward.depth, anchor: upward.anchor)
         } else if let inferred = HeuristicEffectInferrer.infer(
             call: call,
             imports: siteImportCache.imports(forSiteFile: site.location.filePath),
@@ -219,7 +219,7 @@ final class IdempotencyViolationVisitor: CrossFileVisitorBase, CrossFilePatternV
     ///   or receiver name, Phase 2.2).
     private enum EffectProvenance {
         case declared
-        case inferredUpward(depth: Int)
+        case inferredUpward(depth: Int, anchor: BodyInference.Anchor)
         case inferredDownward(reason: String)
     }
 
@@ -312,9 +312,18 @@ final class IdempotencyViolationVisitor: CrossFileVisitorBase, CrossFilePatternV
             calleeClaim = "which is declared `@lint.effect \(calleeTier)`"
             overrideHint = ""
 
-        case .inferredUpward(let depth):
+        case .inferredUpward(let depth, let chainAnchor):
             let chainHint = depth > 1 ? " via \(depth)-hop chain of un-annotated callees" : ""
-            calleeClaim = "whose effect is inferred `\(calleeTier)` from its body\(chainHint)"
+            // Say what the chain bottoms out on. A reader deciding whether to
+            // trust a multi-hop inference is asking exactly this, and until the
+            // anchor was tracked the diagnostic could not answer: a chain
+            // resting entirely on annotations and one resting on a name match
+            // read identically.
+            let anchorHint = chainAnchor == .declared
+                ? ", resting on a declared effect"
+                : ", resting on a name-based guess"
+            calleeClaim = "whose effect is inferred `\(calleeTier)` from its body"
+                + "\(chainHint)\(anchorHint)"
             overrideHint = " If the inference is wrong, annotate '\(calleeName)' "
                 + "explicitly with `/// @lint.effect <tier>` to override the body-based inference."
 
@@ -401,21 +410,33 @@ final class IdempotencyViolationVisitor: CrossFileVisitorBase, CrossFilePatternV
     ) -> PBTSeedEffect {
         let depth: Int?
         let reason: String?
+        // `nil` for the two provenances where the question does not arise: a
+        // declaration IS the anchor, and a heuristic match is a guess by
+        // construction. Only an upward chain has a bottom worth naming.
+        let anchor: PBTSeedEffect.Anchor?
         let wireProvenance: PBTSeedEffect.Provenance
         switch provenance {
         case .declared:
             wireProvenance = .declared
             depth = nil
+            anchor = nil
             reason = nil
 
-        case let .inferredUpward(hops):
+        case let .inferredUpward(hops, chainAnchor):
             wireProvenance = .inferredUpward
             depth = hops
+            // Carried so a consumer can tell a chain of annotations from one
+            // that bottomed out on a name match. Without it, `inferred-upward`
+            // is honest but unusable: SwiftInferProperties withheld every one,
+            // because this visitor supplies `HeuristicEffectInferrer` as the
+            // anchor resolver and provenance alone describes only the last hop.
+            anchor = chainAnchor == .declared ? .declaration : .heuristic
             reason = nil
 
         case let .inferredDownward(why):
             wireProvenance = .inferredDownward
             depth = nil
+            anchor = nil
             // The heuristic inferrer returns "" when it matched but could not
             // phrase why. Empty is not a reason, and a consumer rendering it
             // would print a dangling "because ." — `nil` says the same thing
@@ -427,6 +448,7 @@ final class IdempotencyViolationVisitor: CrossFileVisitorBase, CrossFilePatternV
             resolved: seedTier(calleeEffect),
             provenance: wireProvenance,
             depth: depth,
+            anchor: anchor,
             reason: reason
         )
     }

--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/PBTSeedEffect.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/PBTSeedEffect.swift
@@ -59,7 +59,8 @@ public struct PBTSeedEffect: Codable, Sendable, Equatable {
 
         /// Resolved by walking bodies up the call graph — the lattice join of a
         /// function's callees, iterated to a fixed point across files. Carries a
-        /// `depth`; see that field for why it is not decoration.
+        /// `depth`; see that field for why it is not decoration, and an
+        /// `anchor`, without which a consumer cannot act on it at all.
         case inferredUpward = "inferred-upward"
 
         /// Matched by the heuristic name/framework inferrer (`save` on a Fluent
@@ -94,6 +95,35 @@ public struct PBTSeedEffect: Codable, Sendable, Equatable {
     /// that wants to weight by confidence has no other way to.
     public let depth: Int?
 
+    /// For an upward inference, whether the chain bottomed out on annotations
+    /// or on a guess. `nil` for the other two provenances, where the question
+    /// does not arise — a declaration *is* the anchor, and a heuristic match is
+    /// a guess by construction.
+    ///
+    /// **This is what makes `inferred-upward` usable rather than merely
+    /// reported.** `provenance` names the final hop; it says how the immediate
+    /// callee's effect was known and nothing about the chain beneath it. Because
+    /// `IdempotencyViolationVisitor` supplies `HeuristicEffectInferrer` as the
+    /// anchor resolver to `applyBodyInference`, an upward chain can bottom out
+    /// on a name guess — so a consumer reading provenance alone had to withhold
+    /// every upward tier, which SwiftInferProperties did, keeping only the
+    /// direct-callee case. This field separates the two, and a
+    /// `declaration`-anchored multi-hop chain is precisely the signal a consumer
+    /// cannot compute for itself: its own pass runs one hop against a 2-second
+    /// budget.
+    public let anchor: Anchor?
+
+    /// What an upward chain rests on. Mirrors
+    /// `SwiftEffectInference.BodyInference.Anchor`, translated rather than
+    /// shared for the same reason `Tier` is: the manifest is a versioned wire
+    /// format and must not move because a dependency renamed a case.
+    public enum Anchor: String, Codable, Sendable {
+        /// Every step justifying the tier was a human annotation.
+        case declaration
+        /// At least one step was a name or framework guess.
+        case heuristic
+    }
+
     /// For a heuristic match, the phrase naming what matched — *"from the callee
     /// name `save`"*, *"from the known-idempotent Fluent type `QueryBuilder`"*.
     ///
@@ -108,12 +138,14 @@ public struct PBTSeedEffect: Codable, Sendable, Equatable {
         resolved: Tier,
         provenance: Provenance,
         depth: Int? = nil,
+        anchor: Anchor? = nil,
         reason: String? = nil
     ) {
         self.declared = declared
         self.resolved = resolved
         self.provenance = provenance
         self.depth = depth
+        self.anchor = anchor
         self.reason = reason
     }
 
@@ -130,6 +162,7 @@ public struct PBTSeedEffect: Codable, Sendable, Equatable {
         self.resolved = try container.decode(Tier.self, forKey: .resolved)
         self.provenance = try container.decode(Provenance.self, forKey: .provenance)
         self.depth = try container.decodeIfPresent(Int.self, forKey: .depth)
+        self.anchor = try container.decodeIfPresent(Anchor.self, forKey: .anchor)
         self.reason = try container.decodeIfPresent(String.self, forKey: .reason)
     }
 }

--- a/Packages/SwiftProjectLintVisitors/Package.swift
+++ b/Packages/SwiftProjectLintVisitors/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "bfcf0e3899d014752d4d73389b901f29cf3db6c9"
+            revision: "bc084fb9613c22f1aee94d9d1781b0eca2e67620"
         )
     ],
     targets: [

--- a/Tests/CLITests/PBTSeedEffectTests.swift
+++ b/Tests/CLITests/PBTSeedEffectTests.swift
@@ -170,3 +170,101 @@ struct PBTSeedEffectTests {
         }
     }
 }
+
+/// `anchor` — what an `inferred-upward` chain bottoms out on.
+///
+/// `provenance` names the **final hop**: how the immediate callee's effect was
+/// known, and nothing about the chain beneath it. Because
+/// `IdempotencyViolationVisitor` supplies `HeuristicEffectInferrer` as the anchor
+/// resolver to `applyBodyInference`, an upward chain can bottom out on a name
+/// guess. A consumer reading provenance alone therefore had to withhold *every*
+/// upward tier — SwiftInferProperties did exactly that, keeping only the
+/// direct-callee case it could verify itself, and the multi-hop reach this
+/// linter uniquely has went unused.
+///
+/// This field separates the two. A `declaration`-anchored multi-hop chain is
+/// precisely the signal a consumer cannot compute for itself: its own pass runs
+/// one hop against a 2-second budget.
+@Suite("PBT seeds — what an upward chain rests on")
+struct PBTSeedAnchorTests {
+
+    private func seed(_ effect: PBTSeedEffect) -> LintIssue {
+        LintIssue(
+            severity: .error,
+            message: "`confirmOrder` claims idempotence but calls non-idempotent work",
+            filePath: "Orders.swift",
+            lineNumber: 11,
+            suggestion: "Route it through an idempotency key",
+            ruleName: .idempotencyViolation,
+            symbol: "confirmOrder",
+            effect: effect
+        )
+    }
+
+    private func decoded(_ effect: PBTSeedEffect) throws -> PBTSeed {
+        let json = PBTSeedsFormatter().format(issues: [seed(effect)])
+        let data = try #require(json.data(using: .utf8))
+        let manifest = try JSONDecoder().decode(PBTSeedManifest.self, from: data)
+        return try #require(manifest.seeds.first)
+    }
+
+    @Test("a declaration-anchored chain says so")
+    func declarationAnchorSurvives() throws {
+        let seed = try decoded(PBTSeedEffect(
+            declared: .idempotent, resolved: .nonIdempotent,
+            provenance: .inferredUpward, depth: 3, anchor: .declaration
+        ))
+        #expect(seed.effect?.anchor == .declaration)
+        #expect(seed.effect?.depth == 3)
+    }
+
+    @Test("a guess-anchored chain says so")
+    func heuristicAnchorSurvives() throws {
+        let seed = try decoded(PBTSeedEffect(
+            declared: .idempotent, resolved: .nonIdempotent,
+            provenance: .inferredUpward, depth: 3, anchor: .heuristic
+        ))
+        #expect(seed.effect?.anchor == .heuristic)
+    }
+
+    /// **Depth and anchor are independent, and this is the pair that shows why.**
+    /// Same tier, same distance, different trustworthiness — before this field a
+    /// consumer saw these two as identical documents.
+    @Test("depth alone cannot distinguish the two")
+    func depthDoesNotImplyAnchor() throws {
+        let clean = try decoded(PBTSeedEffect(
+            declared: .idempotent, resolved: .nonIdempotent,
+            provenance: .inferredUpward, depth: 4, anchor: .declaration
+        ))
+        let tainted = try decoded(PBTSeedEffect(
+            declared: .idempotent, resolved: .nonIdempotent,
+            provenance: .inferredUpward, depth: 4, anchor: .heuristic
+        ))
+        #expect(clean.effect?.depth == tainted.effect?.depth)
+        #expect(clean.effect?.anchor != tainted.effect?.anchor)
+    }
+
+    /// A declaration *is* the anchor; a heuristic match is a guess by
+    /// construction. Emitting the field for either would be noise a consumer has
+    /// to learn to ignore, and every key that must be ignored is one a future
+    /// reader may act on by mistake.
+    @Test("the other provenances omit the key entirely", arguments: [
+        PBTSeedEffect.Provenance.declared, .inferredDownward
+    ])
+    func otherProvenancesOmitAnchor(provenance: PBTSeedEffect.Provenance) throws {
+        let json = PBTSeedsFormatter().format(issues: [seed(PBTSeedEffect(
+            declared: .idempotent, resolved: .nonIdempotent, provenance: provenance
+        ))])
+        #expect(!json.contains("anchor"))
+    }
+
+    /// The wire spelling is `declaration`, not the producer's internal
+    /// `declared` — deliberately distinct from `Provenance.declared`, which is a
+    /// different question about a different hop. Two fields whose values read
+    /// the same invite exactly the conflation this whole field exists to undo.
+    @Test("the anchor spelling is distinct from the provenance spelling")
+    func anchorSpellingIsDistinct() {
+        #expect(PBTSeedEffect.Anchor.declaration.rawValue == "declaration")
+        #expect(PBTSeedEffect.Provenance.declared.rawValue == "declared")
+    }
+}

--- a/Tests/CoreTests/Idempotency/IdempotencyAnchorEmissionTests.swift
+++ b/Tests/CoreTests/Idempotency/IdempotencyAnchorEmissionTests.swift
@@ -1,0 +1,112 @@
+import SwiftParser
+@testable import SwiftProjectLintIdempotencyRules
+import SwiftProjectLintModels
+import SwiftProjectLintVisitors
+import SwiftSyntax
+import Testing
+
+/// The visitor's own mapping from `BodyInference.Anchor` to the wire `Anchor`,
+/// driven on real source.
+///
+/// **These exist because the manifest-level tests could not catch a wrong
+/// mapping.** Those construct a `PBTSeedEffect` directly and check it survives
+/// encoding — so replacing the visitor's `chainAnchor == .declared ? ... : ...`
+/// with a constant `.declaration` left them all green. A test that builds the
+/// value it then asserts on can only confirm the encoder; the translation is
+/// only exercised by running the rule.
+@Suite("Idempotency violation — the emitted anchor reflects the real chain")
+struct IdempotencyAnchorEmissionTests {
+
+    /// The `fileCache:` constructor, not the `pattern:`-only one. The simpler
+    /// harness leaves `applyBodyInference`'s source list empty and **silently
+    /// skips inference**, so every upward-anchored assertion below would fail on
+    /// a nil issue rather than a wrong anchor — which is how the first draft of
+    /// this suite failed, and is documented on
+    /// `ClosureBindingCrossReferenceTests.runEffect` for the same reason.
+    private func emittedEffect(for source: String) -> PBTSeedEffect? {
+        let path = "Test.swift"
+        let parsed = Parser.parse(source: source)
+        let visitor = IdempotencyViolationVisitor(fileCache: [path: parsed])
+        visitor.setFilePath(path)
+        visitor.setSourceLocationConverter(
+            SourceLocationConverter(fileName: path, tree: parsed)
+        )
+        visitor.walk(parsed)
+        visitor.finalizeAnalysis()
+        return visitor.detectedIssues.first?.effect
+    }
+
+    /// A chain of un-annotated functions ending at an annotation. This is the
+    /// case a consumer wants and cannot compute for itself: its own resolver
+    /// runs one hop.
+    @Test("a chain bottoming out on an annotation is declaration-anchored")
+    func declaredChainEmitsDeclaration() throws {
+        let effect = try #require(emittedEffect(for: """
+        /// @lint.effect non_idempotent
+        func chargeCard() {}
+
+        func settle() { chargeCard() }
+
+        /// @lint.effect idempotent
+        func confirmOrder() { settle() }
+        """))
+        #expect(effect.provenance == .inferredUpward)
+        #expect(effect.anchor == .declaration)
+    }
+
+    /// The same shape, the same tier, the same distance — but the bottom of the
+    /// chain is a name match rather than something a human wrote. A consumer
+    /// that treats this like the case above is vetoing on a guess, which is the
+    /// failure the whole field exists to prevent.
+    @Test("a chain bottoming out on a name guess is heuristic-anchored")
+    func guessedChainEmitsHeuristic() throws {
+        let effect = try #require(emittedEffect(for: """
+        func settle() { createUser() }
+
+        /// @lint.effect idempotent
+        func confirmOrder() { settle() }
+        """))
+        #expect(effect.provenance == .inferredUpward)
+        #expect(effect.anchor == .heuristic)
+    }
+
+    /// A directly-annotated callee is not an upward inference at all, so there
+    /// is no chain to describe.
+    @Test("a directly declared callee carries no anchor")
+    func declaredCalleeCarriesNoAnchor() throws {
+        let effect = try #require(emittedEffect(for: """
+        /// @lint.effect non_idempotent
+        func sendEmail() {}
+
+        /// @lint.effect idempotent
+        func notify() { sendEmail() }
+        """))
+        #expect(effect.provenance == .declared)
+        #expect(effect.anchor == nil)
+    }
+
+    @Test("a name-heuristic callee carries no anchor")
+    func heuristicCalleeCarriesNoAnchor() throws {
+        let effect = try #require(emittedEffect(for: """
+        /// @lint.effect idempotent
+        func register() { createUser() }
+        """))
+        #expect(effect.provenance == .inferredDownward)
+        #expect(effect.anchor == nil)
+    }
+
+    /// The claimed tier is the caller's own annotation, not the callee's — the
+    /// pair `(declared, resolved)` is the claim and what contradicts it.
+    @Test("the declared tier is the caller's claim")
+    func declaredTierIsTheCallersClaim() throws {
+        let effect = try #require(emittedEffect(for: """
+        /// @lint.effect non_idempotent
+        func chargeCard() {}
+
+        /// @lint.effect observational
+        func audit() { chargeCard() }
+        """))
+        #expect(effect.declared == .observational)
+        #expect(effect.resolved == .nonIdempotent)
+    }
+}


### PR DESCRIPTION
`provenance` names the **final hop** — how the immediate callee's effect was known — and says nothing about the chain beneath it. Because `IdempotencyViolationVisitor` supplies `HeuristicEffectInferrer` as the anchor resolver to `applyBodyInference`, an `inferred-upward` tier can bottom out on a name guess.

A consumer reading provenance alone therefore had to withhold **every** upward tier. SwiftInferProperties did exactly that when it began consuming the manifest (#134): it kept only the direct-callee case it could verify itself, and the multi-hop cross-file reach — the one thing this linter offers that a one-hop pass against a 2-second budget cannot — went unused.

`anchor` separates the two. Pins bumped to `SwiftEffectInference@bc084fb`, which tracks it through `BodyInference`.

## Design points worth a look

**Emitted only for `inferred-upward`.** A declaration *is* the anchor and a heuristic match is a guess by construction, so the key would be noise on the other two — and every key a consumer must learn to ignore is one a later reader may act on by mistake.

**Spelled `declaration`, not `declared`**, to stay visibly distinct from `Provenance.declared`. Two fields whose values read identically invite exactly the conflation this field exists to undo.

**The diagnostic prose now says it too** — *"resting on a declared effect"* vs *"resting on a name-based guess"*. A reader deciding whether to trust a multi-hop inference is asking precisely that, and until the anchor was tracked the message could not answer.

## Two test suites, because one could not do it

The manifest-level tests construct a `PBTSeedEffect` and check it survives encoding. Replacing the visitor's `chainAnchor == .declared ? … : …` with a constant `.declaration` left **all of them green** — a test that builds the value it then asserts on can only confirm the encoder.

The visitor-level suite runs the rule on real source and catches that mutation, plus an anchor wrongly emitted on the declared path. It uses the `fileCache:` constructor: the `pattern:`-only harness leaves the inference source list empty and *silently skips inference*, which is how the first draft of the suite failed — a trap `ClosureBindingCrossReferenceTests` already documents.

## Testing

**3184 tests green on a clean build.** Worth noting why "clean" is emphasised: partway through this work, incremental SwiftPM stopped rebuilding across the local path-dependency boundary after a stored property was added to `PBTSeedEffect`, and `LintIssue` began reading the field through a stale layout — surfacing as `Optional(PBTSeedEffect.Anchor())`, an enum with no case. Several rounds went into chasing that as a logic bug before `swift package clean` fixed it with no source change. The tell was that the value was not wrong but *impossible*: a `String`-backed enum cannot print as `Anchor()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Hcz8BEtHaZtgHma89mKHU