### PR TITLE
Emit findings in a fixed order

### DIFF
--- a/Docs/user/reference.md
+++ b/Docs/user/reference.md
@@ -55,6 +55,22 @@ Used with `--categories`:
 | `1` | One or more issues at or above the threshold |
 | `2` | Invalid arguments |
 
+### Output Order
+
+Findings are emitted in a fixed order — by file path, then line number, then rule name — in every
+format. Two runs over unchanged sources produce byte-identical output, so a report can be diffed
+against an earlier one to see what a change actually fixed:
+
+```bash
+swiftprojectlint /path/to/MyApp > before.txt
+# ...make a change...
+swiftprojectlint /path/to/MyApp > after.txt
+diff before.txt after.txt
+```
+
+Analysis itself is concurrent, so this ordering is applied to the results rather than being a
+by-product of the order files happened to finish in.
+
 ### Examples
 
 ```bash

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
@@ -125,8 +125,13 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
             files: perFile.files
         ))
 
-        // Apply per-rule overrides (severity changes, per-rule path exclusions)
-        return effectiveConfiguration.applyOverrides(to: issues, projectRoot: path)
+        // Apply per-rule overrides (severity changes, per-rule path exclusions), then put the
+        // findings in reporting order. Per-file analysis collects results as tasks *complete*, so
+        // without this the same project yields the same findings in a different sequence on every
+        // run — see `LintIssue.precedes`.
+        return effectiveConfiguration
+            .applyOverrides(to: issues, projectRoot: path)
+            .sortedForReporting()
     }
 
     /// Splits discovery into the files that may be *reported on* and the files that may only

--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/LintIssue+Ordering.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/LintIssue+Ordering.swift
@@ -1,0 +1,47 @@
+/// A stable reporting order for findings, so two runs over unchanged sources emit the same report.
+///
+/// Per-file analysis runs in a `TaskGroup` and collects results as they *complete*, which is a
+/// different order on every run. The findings themselves were already stable — same files, same
+/// lines, same rules — but roughly 83% of them landed in a different position run to run, which
+/// makes the obvious regression check impossible: `diff old.txt new.txt` after a change reports
+/// hundreds of spurious differences, so a reader cannot tell what their edit actually fixed.
+///
+/// Sorting is done once, at the end of analysis, rather than per formatter. Every output format
+/// inherits the same order that way, and the ordering guarantee belongs to the analysis result
+/// rather than to whichever renderer happens to be asked for it.
+extension LintIssue {
+
+    /// Whether `lhs` sorts before `rhs` in a report.
+    ///
+    /// Path and line come first, because a reader scanning one file wants its findings together and
+    /// in source order. The components after them exist to make the order **total**: `sorted(by:)`
+    /// is not guaranteed stable, so any two findings that compare equal may still swap places
+    /// between runs. Comparing on everything the text report prints — rule, message, suggestion —
+    /// means findings that tie are byte-identical in the output, so their relative order cannot be
+    /// observed. `symbol` is the last resort for the machine-readable formats, which carry fields
+    /// the text report does not.
+    ///
+    /// Written as a chain of comparisons rather than one tuple comparison because a tuple wide
+    /// enough to hold all six components is both a `large_tuple` violation and the kind of
+    /// expression that has timed out this project's type-checker on slower toolchains.
+    public static func precedes(_ lhs: LintIssue, _ rhs: LintIssue) -> Bool {
+        if lhs.filePath != rhs.filePath { return lhs.filePath < rhs.filePath }
+        if lhs.lineNumber != rhs.lineNumber { return lhs.lineNumber < rhs.lineNumber }
+        if lhs.ruleName != rhs.ruleName { return lhs.ruleName.rawValue < rhs.ruleName.rawValue }
+        if lhs.message != rhs.message { return lhs.message < rhs.message }
+
+        let leftSuggestion = lhs.suggestion ?? ""
+        let rightSuggestion = rhs.suggestion ?? ""
+        if leftSuggestion != rightSuggestion { return leftSuggestion < rightSuggestion }
+
+        return (lhs.symbol ?? "") < (rhs.symbol ?? "")
+    }
+}
+
+extension Array where Element == LintIssue {
+
+    /// The findings in reporting order — see `LintIssue.precedes`.
+    public func sortedForReporting() -> [LintIssue] {
+        sorted(by: LintIssue.precedes)
+    }
+}

--- a/Tests/CoreTests/ProjectLinterOrderingTests.swift
+++ b/Tests/CoreTests/ProjectLinterOrderingTests.swift
@@ -1,0 +1,169 @@
+@testable import Core
+import Foundation
+import Testing
+
+/// Findings come back in a fixed order, so two runs over unchanged sources can be diffed.
+///
+/// Per-file analysis collects `TaskGroup` results as they complete, which is a different order on
+/// every run. That left the report's *contents* stable while ~83% of its lines moved position, so
+/// `diff` between two runs reported hundreds of differences that no edit had caused — and the only
+/// way to compare two reports was to sort them first, which nothing told the reader to do.
+struct ProjectLinterOrderingTests {
+
+    @Test func testIssuesComeBackInReportingOrder() async {
+        let projectPath = makeMultiFileProject(named: "OrderingProject")
+        defer { try? FileManager.default.removeItem(atPath: projectPath) }
+
+        let system = PatternRegistryFactory.createConfiguredSystem()
+        let issues = await ProjectLinter().analyzeProject(
+            at: projectPath, detector: system.detector
+        )
+
+        #expect(issues.count > 1, "fixture must produce enough findings for order to be observable")
+        #expect(firstOutOfOrderPair(in: issues) == nil)
+    }
+
+    /// The end-to-end guarantee the report actually rests on: same input, same bytes out.
+    ///
+    /// Asserted on rendered text rather than on the issue array because the byte-for-byte report is
+    /// what a reader diffs, and it is the artifact the ordering exists to protect.
+    @Test func testRepeatedRunsRenderIdenticalText() async {
+        let projectPath = makeMultiFileProject(named: "OrderingRepeatProject")
+        defer { try? FileManager.default.removeItem(atPath: projectPath) }
+
+        let linter = ProjectLinter()
+        let formatter = TextFormatter()
+        let system = PatternRegistryFactory.createConfiguredSystem()
+
+        var renders: [String] = []
+        for _ in 0..<3 {
+            let issues = await linter.analyzeProject(at: projectPath, detector: system.detector)
+            renders.append(formatter.format(issues: issues))
+        }
+
+        #expect(renders.first?.isEmpty == false, "fixture must produce a report to compare")
+        #expect(firstDifferingLine(renders[0], renders[1]) == nil)
+        #expect(firstDifferingLine(renders[1], renders[2]) == nil)
+    }
+
+    /// Sorting is by path, then line, then rule — so one file's findings arrive together and in
+    /// source order, which is how a reader scans them.
+    @Test func testSortedForReportingOrdersByPathThenLineThenRule() {
+        let unsorted = [
+            makeIssue(filePath: "B.swift", lineNumber: 1, rule: .forceUnwrap),
+            makeIssue(filePath: "A.swift", lineNumber: 9, rule: .forceUnwrap),
+            makeIssue(filePath: "A.swift", lineNumber: 2, rule: .missingAccessibilityLabel),
+            makeIssue(filePath: "A.swift", lineNumber: 2, rule: .forceUnwrap)
+        ]
+
+        let sorted = unsorted.sortedForReporting()
+
+        let keys = sorted.map { "\($0.filePath):\($0.lineNumber):\($0.ruleName.rawValue)" }
+        #expect(keys == [
+            "A.swift:2:\(RuleIdentifier.forceUnwrap.rawValue)",
+            "A.swift:2:\(RuleIdentifier.missingAccessibilityLabel.rawValue)",
+            "A.swift:9:\(RuleIdentifier.forceUnwrap.rawValue)",
+            "B.swift:1:\(RuleIdentifier.forceUnwrap.rawValue)"
+        ])
+    }
+
+    /// The order has to be *total*, not merely by path and line: `sorted(by:)` is not guaranteed
+    /// stable, so findings that compare equal could still swap places between runs. Sorting a
+    /// shuffled array must land in the same place every time.
+    @Test func testOrderIsTotalAcrossShuffles() {
+        let issues = [
+            makeIssue(filePath: "A.swift", lineNumber: 1, rule: .forceUnwrap, message: "first"),
+            makeIssue(filePath: "A.swift", lineNumber: 1, rule: .forceUnwrap, message: "second"),
+            makeIssue(filePath: "A.swift", lineNumber: 1, rule: .forceUnwrap, message: "third")
+        ]
+
+        let expected = issues.sortedForReporting().map(\.message)
+        for _ in 0..<20 {
+            #expect(issues.shuffled().sortedForReporting().map(\.message) == expected)
+        }
+    }
+
+    /// The first place the sequence goes backwards, named in one line.
+    ///
+    /// Returned as a short description rather than asserted with a predicate over the array so a
+    /// failure reports the offending pair instead of dumping every `LintIssue` in the fixture.
+    private func firstOutOfOrderPair(in issues: [LintIssue]) -> String? {
+        for (earlier, later) in zip(issues, issues.dropFirst())
+        where LintIssue.precedes(later, earlier) {
+            return "\(describe(later)) follows \(describe(earlier))"
+        }
+        return nil
+    }
+
+    private func describe(_ issue: LintIssue) -> String {
+        "\(issue.filePath):\(issue.lineNumber) [\(issue.ruleName.rawValue)]"
+    }
+
+    /// Where two reports first diverge — the line number plus both sides, rather than two full
+    /// reports in the failure output.
+    private func firstDifferingLine(_ lhs: String, _ rhs: String) -> String? {
+        let lhsLines = lhs.components(separatedBy: "\n")
+        let rhsLines = rhs.components(separatedBy: "\n")
+        for index in 0..<max(lhsLines.count, rhsLines.count)
+        where lhsLines.indices.contains(index) != rhsLines.indices.contains(index)
+            || (lhsLines.indices.contains(index) && lhsLines[index] != rhsLines[index]) {
+            let lhsLine = lhsLines.indices.contains(index) ? lhsLines[index] : "<missing>"
+            let rhsLine = rhsLines.indices.contains(index) ? rhsLines[index] : "<missing>"
+            return "line \(index + 1): '\(lhsLine)' vs '\(rhsLine)'"
+        }
+        return nil
+    }
+
+    private func makeIssue(
+        filePath: String,
+        lineNumber: Int,
+        rule: RuleIdentifier,
+        message: String = "message"
+    ) -> LintIssue {
+        LintIssue(
+            severity: .warning,
+            message: message,
+            filePath: filePath,
+            lineNumber: lineNumber,
+            suggestion: nil,
+            ruleName: rule
+        )
+    }
+
+    /// Enough files, each with several findings, that per-file results genuinely interleave.
+    ///
+    /// Given its own directory rather than sharing one: tests that point the linter at a directory
+    /// they do not own end up analysing whatever else is in it.
+    private func makeMultiFileProject(named name: String) -> String {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(name)-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        for index in 0..<12 {
+            let source = """
+            import SwiftUI
+
+            struct View\(index): View {
+                @State private var isLoading = false
+                @State private var counter = 0
+                let values: [String]? = nil
+
+                var body: some View {
+                    VStack {
+                        Image("icon\(index)")
+                        Text(values![0])
+                        Button("Increment") { counter += 1 }
+                        Image("badge\(index)")
+                    }
+                }
+            }
+            """
+            try? source.write(
+                to: root.appendingPathComponent("View\(index).swift"),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+        return root.path
+    }
+}


### PR DESCRIPTION
Fixes #69.

## What changed

`LintIssue.precedes` defines a total order over findings — `(filePath, lineNumber, ruleName, message, suggestion, symbol)` — and `ProjectLinter.analyzeProject` applies it as its last step, after `applyOverrides`.

The nondeterminism came from `runPerFileAnalysis`, which collects `TaskGroup` results as they *complete*. The cross-file half already walked in path order as of #68, so this closes the residual.

`Docs/user/reference.md` gains an "Output Order" section showing the diff-two-runs workflow.

## Why sort at the analysis boundary rather than in `TextFormatter`

The issue is filed against text output, but the same nondeterminism reaches JSON, CSV, HTML and the `pbt-seeds` manifest (whose seed array is a `compactMap` over the issues, so it inherited the input order). Sorting once in `analyzeProject` means every format gets it, and the ordering guarantee belongs to the analysis result rather than to whichever renderer happens to be asked for it.

## What a reviewer should scrutinise

- **Whether the order needs to be total.** It compares six components, not the two the issue suggests. `sorted(by:)` is not documented as stable, so findings that compare equal may still swap between runs; comparing on everything the text report prints means any two findings that tie are byte-identical in the output, so their relative order cannot be observed. If you think `(path, line, rule)` is enough, that argument is the thing to check.
- **The comparison is a chain of `if`s, not a tuple compare.** A six-element tuple trips `large_tuple`, and wide tuple comparisons are the shape that has previously timed out this project's type-checker on CI toolchains.
- **Interleaving of cross-file and per-file findings.** Cross-file issues used to land at the end of the array; they now sort in by path like everything else. Nothing depended on the old grouping as far as I can tell, but it is a visible change to the report's shape.

## Verification

- `Tests/CoreTests/ProjectLinterOrderingTests.swift`, 4 tests: findings come back in reporting order, three runs render byte-identical text, the sort orders by path/line/rule, and the order survives 20 shuffles.
- The two integration tests were confirmed **non-vacuous** — with the sort removed they fail (`View9.swift:10 [Missing Accessibility Label] follows View9.swift:12 [Hardcoded Strings]`) and pass with it restored.
- Full suite: 3188 tests passing. SwiftLint clean on all changed files.
- A byte-identity check against the issue's own corpus (`SwiftInferProperties`) was still running when this was opened; the unit-scale fixture already covers the guarantee.

## Unrelated, found while verifying

`SourcePatternRegistryConcurrencyTests` — "every concurrent caller of initialize() observes a fully populated registry" — fails about 1 run in 5. Confirmed pre-existing on unmodified `main` with these changes removed. Not touched here; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrHtiV3Um3p3jECQeZ6BqU