### PR TITLE
Correct the README's rule counts and pin them to the code

### DIFF
--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/LintConfiguration.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/LintConfiguration.swift
@@ -160,8 +160,7 @@ public struct LintConfiguration: Sendable {
         }
 
         // nil means "no filtering" — return nil if we haven't actually restricted anything
-        let allRules = Set(RuleIdentifier.allCases)
-            .subtracting([.unknown, .fileParsingError])
+        let allRules = RuleIdentifier.selectableRules
             .subtracting(Self.optInRules)
         if rules == allRules, cliCategories == nil {
             return nil

--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
@@ -246,6 +246,23 @@ public enum RuleIdentifier: String, CaseIterable, Codable, Sendable {
     case fileParsingError = "File Parsing Error"
     case unknown = "Unknown"
 
+    /// The cases that are actually rules — every case except the two sentinels.
+    ///
+    /// `unknown` and `fileParsingError` are `RuleIdentifier`s for plumbing reasons (a finding needs
+    /// *some* identifier before its rule is resolved, and a file that fails to parse has to be
+    /// reported as something), but a user cannot enable, disable, or select either one. They are
+    /// the whole difference between `allCases.count` and the number of rules this tool has.
+    ///
+    /// Exists because that distinction was previously re-derived by an inline `subtracting` call at
+    /// each site that needed it, which meant the definition of "a rule" was duplicated and the
+    /// count in the README could disagree with the code without anything noticing — it did, by
+    /// roughly a quarter.
+    public static let selectableRules: Set<RuleIdentifier> =
+        Set(allCases).subtracting(sentinels)
+
+    /// Identifiers that exist to carry a state, not to name a rule. See `selectableRules`.
+    public static let sentinels: Set<RuleIdentifier> = [.unknown, .fileParsingError]
+
     /// Returns the kebab-case key used in inline suppression comments.
     ///
     /// Example: `.forceTry` → `"force-try"` → `// swiftprojectlint:disable force-try`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Many of these rules exist just so I can explore the effects. Some rules are bad 
 
 # Swift Project Linter
 
-A static analysis tool for SwiftUI projects that detects architectural issues, performance problems, and code quality concerns. Parses Swift source files using SwiftSyntax AST visitors to identify anti-patterns across 160 rules in 12 categories.
+A static analysis tool for SwiftUI projects that detects architectural issues, performance problems, and code quality concerns. Parses Swift source files using SwiftSyntax AST visitors to identify anti-patterns across 200 rules in 13 categories.
 
 The origin of this project began with a limitation of SwiftLint: it processes a single file at a time and cannot identify cross-file issues.
 
@@ -18,7 +18,7 @@ Motivating example: I was watching the "Quality Coding" channel on YouTube. Jon 
 
 - **SwiftSyntax AST Analysis**: Precise, AST-based pattern detection — no regex
 - **Cross-File Analysis**: Detects issues spanning multiple files (duplicate state, view hierarchies)
-- **160 Lint Rules** across 12 categories
+- **200 Lint Rules** across 13 categories
 - **Three delivery targets**: macOS app GUI, CLI for CI/CD, and a reusable Core library
 - **YAML configuration**: `.swiftprojectlint.yml` for per-project rule customization
 - **Inline suppression**: `// swiftprojectlint:disable` comments for per-line control
@@ -49,21 +49,23 @@ swift run CLI /path/to/project --categories stateManagement,performance --thresh
 
 ## Rules
 
-160 rules across 12 categories. See [Docs/rules/RULES.md](Docs/rules/RULES.md) for the full reference.
+200 rules across 13 categories. See [Docs/rules/RULES.md](Docs/rules/RULES.md) for the full reference.
 
 | Category | Rules |
 |----------|-------|
-| State Management | 10 |
-| Performance | 13 |
+| State Management | 13 |
+| Performance | 14 |
 | Animation | 10 |
-| Architecture | 16 |
-| Code Quality | 48 |
+| Architecture | 32 |
+| Code Quality | 52 |
 | Security | 5 |
-| Accessibility | 15 |
-| Memory Management | 2 |
+| Accessibility | 20 |
+| Memory Management | 3 |
 | Networking | 3 |
-| UI Patterns | 8 |
+| UI Patterns | 7 |
 | Modernization | 25 |
+| Idempotency | 7 |
+| Testability | 9 |
 
 Rules marked **opt-in** are disabled by default and must be explicitly listed under `enabled_only` in `.swiftprojectlint.yml`.
 
@@ -96,7 +98,7 @@ SwiftProjectLint/
     ├── reference.md       # CLI and configuration reference
     ├── user-guide.md      # User guide
     ├── tutorial.md        # Getting started tutorial
-    └── rules/             # Per-rule documentation (150 files)
+    └── rules/             # Per-rule documentation (one file per rule)
 ```
 
 ### Dependency Graph
@@ -227,7 +229,7 @@ let b = result!
 
 ## Documentation
 
-- [Docs/rules/RULES.md](Docs/rules/RULES.md) — Full rule reference (160 rules)
+- [Docs/rules/RULES.md](Docs/rules/RULES.md) — Full rule reference
 - [Docs/user-guide.md](Docs/user-guide.md) — User guide
 - [Docs/architecture.md](Docs/architecture.md) — Architecture deep-dive
 - [Docs/reference.md](Docs/reference.md) — CLI and configuration reference

--- a/Sources/App/Models/ContentViewModel.swift
+++ b/Sources/App/Models/ContentViewModel.swift
@@ -175,8 +175,7 @@ class ContentViewModel {
     /// Builds a `LintConfiguration` from the current GUI state.
     private func buildConfiguration() -> LintConfiguration {
         // Compute disabled rules (all rules not in enabledRuleNames)
-        let allRules = Set(RuleIdentifier.allCases).subtracting([.unknown, .fileParsingError])
-        let disabledRules = allRules.subtracting(enabledRuleNames)
+        let disabledRules = RuleIdentifier.selectableRules.subtracting(enabledRuleNames)
 
         // Build per-rule overrides from exclusion checkboxes
         var overrides: [RuleIdentifier: LintConfiguration.RuleOverride] = [:]

--- a/Tests/CoreTests/Packaging/READMERuleCountTests.swift
+++ b/Tests/CoreTests/Packaging/READMERuleCountTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import SwiftProjectLintModels
+import Testing
+
+/// Every rule count the README states must match the code.
+///
+/// The README claimed **160 rules in 12 categories** while `RuleIdentifier` held 202 cases and 13
+/// categories carried rules — an undercount of roughly a quarter, repeated in four places, plus a
+/// per-category table that had gone stale in nine rows and was missing two categories outright.
+///
+/// **Why a test rather than a one-time correction.** The number is the first thing a reader sees
+/// and it sets their model of what the tool covers; a downstream consumer sizing up the seam read
+/// 160 and took this for a medium-sized linter. Nothing connected the prose to the enum, so the
+/// figure drifted silently with every rule added — and correcting it by hand only resets the clock.
+/// Asserting it here means the next rule that lands either updates the README or fails the suite.
+///
+/// The assertions scan for the *pattern* rather than fixed line numbers, so a fifth mention added
+/// later is covered without touching this file.
+@Suite("Packaging — the README's rule counts match the code")
+struct READMERuleCountTests {
+
+    /// Categories a user can actually ask for. `.other` holds only the two sentinels, so it is not
+    /// a category of rules and the README does not claim it as one.
+    private static var ruleBearingCategories: [PatternCategory] {
+        let categories = RuleIdentifier.selectableRules.map(\.category)
+        return Array(Set(categories)).sorted { "\($0)" < "\($1)" }
+    }
+
+    private static var readme: String {
+        get throws {
+            let url = URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()   // Packaging
+                .deletingLastPathComponent()   // CoreTests
+                .deletingLastPathComponent()   // Tests
+                .deletingLastPathComponent()   // repository root
+                .appendingPathComponent("README.md")
+            return try String(contentsOf: url, encoding: .utf8)
+        }
+    }
+
+    @Test("every stated rule count equals the number of selectable rules")
+    func testStatedRuleCountsMatch() throws {
+        let stated = try Self.numbers(before: "rules", in: Self.readme)
+            + Self.numbers(before: "Lint Rules", in: Self.readme)
+
+        #expect(stated.isEmpty == false, "README should state the rule count somewhere")
+        for count in stated {
+            #expect(count == RuleIdentifier.selectableRules.count)
+        }
+    }
+
+    @Test("every stated category count equals the number of rule-bearing categories")
+    func testStatedCategoryCountsMatch() throws {
+        let stated = try Self.numbers(before: "categories", in: Self.readme)
+
+        #expect(stated.isEmpty == false, "README should state the category count somewhere")
+        for count in stated {
+            #expect(count == Self.ruleBearingCategories.count)
+        }
+    }
+
+    /// The per-category table is where the drift was worst — it summed to 155 and omitted
+    /// Idempotency and Testability entirely, so a reader could not have caught the total from it.
+    @Test("the per-category table names every category, with the right count")
+    func testCategoryTableMatches() throws {
+        let tabled = try Self.categoryTable(in: Self.readme)
+
+        for category in Self.ruleBearingCategories {
+            let expected = RuleIdentifier.selectableRules.filter { $0.category == category }.count
+            guard let name = Self.displayNames[category] else {
+                Issue.record("no README spelling recorded for category \(category)")
+                continue
+            }
+            #expect(tabled[name] == expected, "README table row for '\(name)' should read \(expected)")
+        }
+        #expect(
+            tabled.count == Self.ruleBearingCategories.count,
+            "table rows: \(tabled.keys.sorted())"
+        )
+    }
+
+    /// `| Code Quality | 52 |` → `["Code Quality": 52]`.
+    private static func categoryTable(in readme: String) -> [String: Int] {
+        var rows: [String: Int] = [:]
+        for line in readme.components(separatedBy: "\n") {
+            let cells = line.components(separatedBy: "|")
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { !$0.isEmpty }
+            guard cells.count == 2, let count = Int(cells[1]) else { continue }
+            rows[cells[0]] = count
+        }
+        return rows
+    }
+
+    /// Every integer immediately preceding `word`, e.g. "200 rules" → 200. Bold markers are
+    /// stripped first so `**200 Lint Rules**` is read the same as plain prose.
+    private static func numbers(before word: String, in readme: String) -> [Int] {
+        let text = readme.replacingOccurrences(of: "*", with: "")
+        var found: [Int] = []
+        var searchRange = text.startIndex..<text.endIndex
+        while let match = text.range(of: " \(word)", range: searchRange) {
+            let preceding = text[text.startIndex..<match.lowerBound]
+            let digits = preceding.reversed().prefix(while: \.isNumber).reversed()
+            if let number = Int(String(digits)) { found.append(number) }
+            searchRange = match.upperBound..<text.endIndex
+        }
+        return found
+    }
+
+    /// How each category is spelled in the README's table.
+    ///
+    /// Written out rather than derived by splitting the case name on capitals, because that rule
+    /// gets `uiPatterns` wrong ("Ui Patterns"). The upside of the explicit list is that a new
+    /// category with no entry here fails the lookup below — which is the reminder to give it a
+    /// table row, the omission that left Idempotency and Testability out of the README entirely.
+    private static let displayNames: [PatternCategory: String] = [
+        .stateManagement: "State Management",
+        .performance: "Performance",
+        .architecture: "Architecture",
+        .codeQuality: "Code Quality",
+        .security: "Security",
+        .accessibility: "Accessibility",
+        .memoryManagement: "Memory Management",
+        .networking: "Networking",
+        .uiPatterns: "UI Patterns",
+        .animation: "Animation",
+        .modernization: "Modernization",
+        .idempotency: "Idempotency",
+        .testability: "Testability"
+    ]
+}


### PR DESCRIPTION
Fixes #75.

## Measured at `d0947e1`

| claim | README said | actual |
|---|---|---|
| rules | 160 (×4 places) | **200** selectable (`allCases` 202, minus the 2 sentinels) |
| categories | 12 | **13** carrying rules (`PatternCategory` 14, minus `.other`) |
| per-rule doc files | 150 | 202 — one per rule |

The per-category table was worse than the prose: nine of its eleven rows were stale, it summed to 155, and it omitted **Idempotency** and **Testability** entirely — so a reader could not have recovered the real total from it either.

## What changed

1. **`RuleIdentifier.selectableRules`** — `allCases` minus `[.unknown, .fileParsingError]`. That subtraction was previously written inline at two sites (`LintConfiguration.resolveRules`, `ContentViewModel.buildConfiguration`), both now using the shared definition. The README's number needed an authoritative source, and the definition of "a rule" was duplicated with nothing comparing the copies.
2. **README corrected** — all four count claims, plus the regenerated category table.
3. **`READMERuleCountTests`** — asserts every count the README states matches the enum.

## What a reviewer should scrutinise

- **200, not 202.** `allCases.count` is what the issue proposes as authoritative, but two of those cases are sentinels the config layer explicitly subtracts and a user can neither enable nor disable. Telling a reader "202 rules" overcounts by two things that aren't rules. If you'd rather the README quote `allCases` and explain the gap, that's the call to make here.
- **The test scans for a pattern, not line numbers** — every integer preceding "rules" / "Lint Rules" / "categories" must match. A fifth mention added later is covered automatically; the cost is that an unrelated sentence containing "N categories" would fail the suite.
- **Two counts were deleted rather than pinned** — the doc-file tally and the rule count in a link caption. Neither told a reader anything the linked file doesn't, and each was one more thing to keep true.

## Verification

- Full suite: **3191 tests passing** (3188 + 3 new). SwiftLint clean on changed files.
- Tests confirmed non-vacuous: setting the README to 201 rules / 12 categories and one table row to 51 fails all three tests with the expected diagnostics, then passes on revert.

## Noted, not fixed

`RuleIdentifier.swift:239` carries a pre-existing `identifier_name` warning (`observableEnvironmentViewMissingInspectionHook`, 45 chars against a 40 limit). Untouched — it predates this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrHtiV3Um3p3jECQeZ6BqU