### PR TITLE
Assert every declared rule is reachable by the engine

### DIFF
--- a/Tests/CoreTests/Registry/RuleRegistrationResidualTests.swift
+++ b/Tests/CoreTests/Registry/RuleRegistrationResidualTests.swift
@@ -1,0 +1,105 @@
+@testable import Core
+import Testing
+
+/// Every declared rule must be reachable by the engine, and every exception must say why.
+///
+/// Nothing checked this, and the arithmetic people reach for gives the wrong answer. Counting the
+/// enum against `SwiftProjectLintRules` yields "10 declared but never registered", which is false
+/// twice over: it misses the sibling `SwiftProjectLintIdempotencyRules` package, and it misses the
+/// `ruleName:` emission path used where one visitor raises two findings. A downstream document
+/// carried that wrong conclusion as a live finding until someone scanned by hand (issue #73).
+///
+/// **Asserted against the live registry rather than by scanning source text.** A grep for
+/// `name: .foo` answers "is this identifier mentioned somewhere", which is not the question — an
+/// identifier can be mentioned in a registrar that is never wired into a category, and would then
+/// pass a textual check while reaching no analysis. `PatternRegistryFactory.createConfiguredSystem()`
+/// builds the same registry the CLI uses, so what it contains is what the engine can actually run.
+@Suite("Registry — every declared rule is reachable")
+struct RuleRegistrationResidualTests {
+
+    /// Rules the engine can run: one registered pattern each.
+    private static var registeredRules: Set<RuleIdentifier> {
+        let system = PatternRegistryFactory.createConfiguredSystem()
+        return Set(system.detector.registry.getAllPatterns().map(\.name))
+    }
+
+    /// Declared rules that are deliberately *not* registered patterns, and the reason for each.
+    ///
+    /// The list is the point of this test. An identifier missing from the registry is either a
+    /// rule that silently reaches nothing — a real defect — or a deliberate arrangement someone
+    /// has to have thought about. Writing the reason down is what tells the next reader which.
+    private static let unregisteredByDesign: [RuleIdentifier: String] = [
+        .onTapGestureMissingAccessibility:
+            "Emitted with `ruleName:` by OnTapGestureInsteadOfButtonVisitor, which is registered "
+            + "under .onTapGestureInsteadOfButton. One visitor, two findings: a tap gesture that "
+            + "should be a Button is also invisible to VoiceOver, and the two are found by the "
+            + "same walk. Consequence, measured: selecting this rule on its own resolves to it "
+            + "and then runs zero patterns, because the detector filters patterns by name and "
+            + "this rule has none — so it cannot be enabled in isolation, only alongside its host."
+    ]
+
+    @Test("every selectable rule is registered, or documented as to why not")
+    func testEverySelectableRuleIsReachable() {
+        let unreachable = RuleIdentifier.selectableRules
+            .subtracting(Self.registeredRules)
+            .subtracting(Self.unregisteredByDesign.keys)
+
+        let names = unreachable.map(\.rawValue).sorted()
+        #expect(
+            unreachable.isEmpty,
+            "declared but registered nowhere — wire it up, or record why not: \(names)"
+        )
+    }
+
+    /// The reverse direction, which is the one that rots quietly.
+    ///
+    /// If a rule on the exception list later gains a registered pattern, the entry becomes a lie
+    /// that still passes the test above. Failing here forces it to be removed.
+    @Test("no exception is stale")
+    func testNoExceptionIsActuallyRegistered() {
+        let registered = Self.registeredRules
+        let stale = Self.unregisteredByDesign.keys.filter { registered.contains($0) }
+
+        #expect(
+            stale.isEmpty,
+            "now registered — drop from unregisteredByDesign: \(stale.map(\.rawValue).sorted())"
+        )
+    }
+
+    /// The sentinels are not rules and must never acquire a pattern.
+    ///
+    /// `unknown` is used as a placeholder `name:` by several multi-purpose visitors, so it is
+    /// genuinely written in registrar-adjacent code — which is exactly why a textual check would
+    /// have counted it as registered. It must not reach the registry.
+    @Test("no sentinel is registered as a rule")
+    func testSentinelsAreNotRegistered() {
+        let registered = RuleIdentifier.sentinels.intersection(Self.registeredRules)
+
+        #expect(
+            registered.isEmpty,
+            "sentinels are not rules: \(registered.map(\.rawValue).sorted())"
+        )
+    }
+
+    /// Guards the count the README states from the other side.
+    ///
+    /// `READMERuleCountTests` pins the prose to `selectableRules`; this pins `selectableRules` to
+    /// what the engine will actually run. Together they mean the advertised number cannot drift
+    /// from the shipped behaviour in either direction.
+    /// Compared as two small difference sets rather than `accounted == selectableRules`, because
+    /// the equality form prints both 200-element sets on failure and the difference is the only
+    /// part anyone reads.
+    @Test("the registry accounts for every selectable rule exactly once")
+    func testRegistryAccountsForEveryRule() {
+        let accounted = Self.registeredRules.union(Self.unregisteredByDesign.keys)
+        let unaccounted = RuleIdentifier.selectableRules.subtracting(accounted)
+        let unexpected = accounted.subtracting(RuleIdentifier.selectableRules)
+
+        #expect(unaccounted.isEmpty, "no pattern and no recorded reason: \(names(unaccounted))")
+        #expect(unexpected.isEmpty, "accounted for but not a selectable rule: \(names(unexpected))")
+    }
+
+    private func names(_ rules: Set<RuleIdentifier>) -> [String] {
+        rules.map(\.rawValue).sorted()
+    }
+}


### PR DESCRIPTION
Fixes #73.

## Result

**The catalogue is healthy, and now something says so.** 199 of the 200 selectable rules have a registered pattern; the one residual is deliberate and recorded with its reason.

| | |
|---|---|
| `RuleIdentifier.allCases` | 202 |
| selectable rules (`allCases` − sentinels) | 200 |
| registered patterns | **199** |
| documented exceptions | **1** |

## Asserted against the registry, not against source text

The issue proposes scanning for identifiers referenced via `name:` / `ruleName:`. I went with the live registry — `PatternRegistryFactory.createConfiguredSystem()`, the same one the CLI builds — because a grep answers *"is this identifier mentioned somewhere"*, which is not the question. An identifier can be mentioned in a registrar that is never wired into its category registrar, and would pass a textual check while reaching no analysis at all. What the registry contains is what the engine can actually run.

It also sidesteps the two traps that made the hand-scan hard: sibling packages are included automatically, and `.unknown` — written as a placeholder `name:` by several multi-purpose visitors, so textually "referenced" — is correctly absent.

## The one exception

`.onTapGestureMissingAccessibility` is emitted with `ruleName:` by `OnTapGestureInsteadOfButtonVisitor` (`:97`), which is registered under `.onTapGestureInsteadOfButton`. One visitor, two findings, one walk — a tap gesture that should be a Button is also invisible to VoiceOver.

**A consequence worth knowing, which I measured rather than assumed:** selecting that rule on its own resolves to it and then runs **zero patterns**, because `SourcePatternDetector` filters patterns by name and this rule has none. So it cannot be enabled in isolation — only alongside its host. That is a real user-visible limitation, recorded in the exception's reason. **Not fixed here** — the fix is either registering a pattern for it or teaching the detector about secondary emissions, and both are larger than a test PR.

## Four tests, and why each exists

1. Every selectable rule is registered, or listed with a reason.
2. **No exception is stale** — if a listed rule later gains a pattern, the entry becomes a lie that still passes test 1. This fails instead, forcing it to be pruned.
3. No sentinel is registered. `unknown` is genuinely written in registrar-adjacent code, which is exactly why a textual check would have miscounted it.
4. The registry accounts for every selectable rule, in both directions.

Together with `READMERuleCountTests` from #75, the advertised number now cannot drift from shipped behaviour in either direction: that pins the prose to `selectableRules`, this pins `selectableRules` to what the engine runs.

## Verification

- Full suite: **3198 passing** (3194 + 4). SwiftLint clean.
- Non-vacuous: emptying the exception list fails tests 1 and 4, naming `onTapGestureMissingAccessibility` in both.
- Test 4 compares two small difference sets rather than the sets themselves — the equality form printed both 200-element sets on failure, which is unreadable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrHtiV3Um3p3jECQeZ6BqU