### PR TITLE
Carry test reachability on idempotency seeds, and pin the demotion's boundary

### DIFF
--- a/Docs/rules/extractable-pure-kernel.md
+++ b/Docs/rules/extractable-pure-kernel.md
@@ -235,6 +235,22 @@ Unlike the two candidate rules, this rule **is** listed in the default text repo
 specific place and proposes a refactor that can be wrong, which is worth reading each time; a
 candidate rule only nominates.
 
+**The seed carries no test-reachability claim, and its absence means nothing here.** Seeds whose
+kind is analysable — `pure-function`, `idempotency` — are demoted to `restricted-function` when the
+symbol they name is `private` or sits inside a `private` type, so a consumer knows one named refactor
+stands between it and verification. `extractable-kernel` is not analysable, so that demotion never
+applies: the export layer returns before consulting reachability.
+
+That is deliberate. The symbol on a kernel seed names *where the kernel is trapped*, not a function a
+consumer could call — and the refactor this rule asks for **creates** the declaration that would be
+called, so the reader chooses its access level while extracting. Reporting "widen this declaration"
+would name a keyword the fix replaces anyway.
+
+The one case this does leave unsaid: a kernel trapped inside a `private` **type** stays unreachable
+after extraction, because the container decides. The manifest does not currently distinguish that
+from an ordinary kernel, so treat the absence of a reachability signal on a kernel seed as *"not
+asked"*, never as *"reachable"*.
+
 ### Known Limitations
 
 - **It is not a dataflow analysis, on purpose.** A kernel has no syntactic boundary — it is whatever

--- a/Docs/rules/idempotency-violation.md
+++ b/Docs/rules/idempotency-violation.md
@@ -178,6 +178,20 @@ All three variants suggest annotating the callee explicitly with `/// @lint.effe
 ### Interpretation of Zero Findings
 This rule was annotation-gated in Phase 1; Phase 2's heuristic inference adds a fallback for un-annotated callees. Zero findings on un-annotated source now has a narrower meaning: "no caller annotated with `@lint.effect idempotent/observational/externally_idempotent` calls a callee either declared non-idempotent (or inferred non-idempotent by the allowlist)." A zero-finding result still tells you about annotation coverage on the caller side — the inference fallback does not itself produce diagnostics without an annotated caller context.
 
+### As a Property-Test Seed
+A finding from this rule is exported by `--format pbt-seeds` with `kind: idempotency` — the violating function is itself the subject of the idempotence property, so a consumer can point analysis straight at it.
+
+That holds only if a test can *call* it. When the function is `private`/`fileprivate`, or sits inside a type that is, the seed is demoted to `kind: restricted-function` and carries a `restriction` field naming what would have to widen:
+
+| what is restricted | `restriction` | what the fix has to touch |
+|---|---|---|
+| the function itself | `declaration` | widen the function |
+| an enclosing type | `enclosing-type` | the type — widening the function changes nothing |
+
+`enclosing-type` wins when both apply, because it names the binding constraint: a `private` func inside a `private` struct is still unreachable after the func is widened.
+
+The seed is still reported — a private helper is often the *best* property target, since an app's pure logic tends to live in them. The demotion says "reachable after one named refactor", not "not worth testing".
+
 ### Remediation
 - **Swap the callee.** Replace a `non_idempotent` function with an idempotent alternative (e.g. `create` → `upsert`, `insert` → `setIfAbsent`).
 - **Weaken the caller's annotation.** If the function genuinely does not guarantee idempotency, `@lint.effect non_idempotent` is the correct declaration.

--- a/Docs/rules/pure-closure-candidate.md
+++ b/Docs/rules/pure-closure-candidate.md
@@ -240,6 +240,13 @@ line 42". `comparator` and `predicate` are role-*entailed*: a correct implementa
 their law. `transform` and `reducer` are conjectures, and the manifest says so rather than
 overclaiming.
 
+For the same reason the seed carries **no test-reachability claim**. Analysable kinds are demoted to
+`restricted-function` when their symbol is out of `@testable import`'s reach; `extractable-kernel` is
+not analysable, so the export layer returns before consulting reachability. A closure has no
+declaration to widen, and lifting it into a named function — which is the whole ask — creates one
+whose access level the reader picks. Read the absence of a reachability signal as *"not asked"*,
+never as *"reachable"*.
+
 ### Not listed in the default report
 
 This rule is a **census**, and on a real codebase it is a large one: 464 findings here, alongside

--- a/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Visitors/IdempotencyViolationVisitor.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Visitors/IdempotencyViolationVisitor.swift
@@ -46,6 +46,13 @@ final class IdempotencyViolationVisitor: CrossFileVisitorBase, CrossFilePatternV
         let body: Syntax
         let effect: DeclaredEffect
         let location: CapturedSiteLocation
+        /// What would have to widen for a test to call `callerName`, or `nil` if nothing does.
+        ///
+        /// Captured here, from the declaration itself, rather than recomputed at emit time from
+        /// `body`: a closure site's body is the closure's statements, whose parent is a
+        /// `ClosureExprSyntax` and not a declaration, so the `private let` binding that carries the
+        /// annotation would go unnoticed. The declaration is in hand at capture; keep it.
+        let restriction: TestRestriction?
     }
 
     // MARK: - Walk phase: accumulate only
@@ -66,7 +73,8 @@ final class IdempotencyViolationVisitor: CrossFileVisitorBase, CrossFilePatternV
                 callerName: node.name.text,
                 body: Syntax(body),
                 effect: callerEffect,
-                location: captureSiteLocation(rootedAt: node)
+                location: captureSiteLocation(rootedAt: node),
+                restriction: PropertyTestCandidacy.restriction(of: node)
             )
         )
         return .visitChildren
@@ -90,7 +98,8 @@ final class IdempotencyViolationVisitor: CrossFileVisitorBase, CrossFilePatternV
                 callerName: name,
                 body: Syntax(closure.statements),
                 effect: callerEffect,
-                location: captureSiteLocation(rootedAt: node)
+                location: captureSiteLocation(rootedAt: node),
+                restriction: PropertyTestCandidacy.restriction(of: node)
             )
         )
         return .visitChildren
@@ -390,7 +399,15 @@ final class IdempotencyViolationVisitor: CrossFileVisitorBase, CrossFilePatternV
             // claimed, what the body reached, and how confidently the rule
             // knows — the last of which no consumer can recompute, because the
             // resolution is cross-file and multi-hop.
-            effect: seedEffect(callerEffect: site.effect, calleeEffect: calleeEffect, provenance: provenance)
+            effect: seedEffect(callerEffect: site.effect, calleeEffect: calleeEffect, provenance: provenance),
+            // Whether a test can reach the symbol above, so the export layer can demote an
+            // otherwise-analysable seed to `restricted-function`. Without this the demotion was
+            // reachable only from `pureFunctionCandidate`, the one visitor that computed it, and
+            // an idempotency seed naming a `private` function was handed over as analysable — a
+            // subject the consumer cannot call. `.idempotency` is an analysable kind, so the
+            // demotion path is live here; the kernel rules are excluded by `effectiveKind` for a
+            // different reason and correctly leave this `.unknown`.
+            testReachability: site.restriction.map(TestReachability.unreachable) ?? .reachable
         )
     }
 

--- a/Sources/Core/Export/PBTSeedsFormatter.swift
+++ b/Sources/Core/Export/PBTSeedsFormatter.swift
@@ -17,7 +17,7 @@ import SwiftProjectLintModels
 /// purity), and reports `kept 0` for a codebase that has property-testable logic in it. That is
 /// exactly the failure this whole pipeline was rebuilt to eliminate, arriving by a new route. Hence
 /// the field, and hence `isAnalysable`.
-public enum PBTSeedKind: String, Codable, Sendable {
+public enum PBTSeedKind: String, Codable, Sendable, CaseIterable {
     /// A pure, total function. Index it, propose laws for it, run them.
     case pureFunction = "pure-function"
 

--- a/Tests/CoreTests/Export/SeedKindDemotionBoundaryTests.swift
+++ b/Tests/CoreTests/Export/SeedKindDemotionBoundaryTests.swift
@@ -1,0 +1,76 @@
+@testable import Core
+import SwiftProjectLintModels
+import Testing
+
+/// Which seed kinds the `restricted-function` demotion can reach, and which it deliberately cannot.
+///
+/// The demotion is load-bearing downstream: `restriction` rides on it, and it is what tells a
+/// consumer whether widening one declaration could unblock anything. So the *absence* of
+/// `restricted-function` on a seed has to mean something definite, and it means two different
+/// things depending on the kind:
+///
+/// - **`pure-function`, `idempotency`** — analysable, so the demotion applies. Absence means the
+///   rule looked and the symbol is reachable.
+/// - **`extractable-kernel`** — not analysable, so `effectiveKind` returns early whatever the
+///   reachability says. Absence carries **no information at all**: nothing was asked.
+///
+/// That second case is deliberate rather than an oversight, and the reason is worth stating because
+/// it is the one a reader is most likely to mistake for a bug (issue #74 read it as one). A kernel
+/// is refactor-pending — the reader is told to lift it into a new declaration, and *chooses that
+/// declaration's access level while doing so*. Reporting "widen this declaration" would name a
+/// keyword the fix replaces anyway. What would still bind after extraction is a `private` enclosing
+/// *type*, and that is a narrower claim than the demotion makes; it is not made here today.
+@Suite("Export — the demotion's reach across seed kinds")
+struct SeedKindDemotionBoundaryTests {
+
+    @Test("analysable kinds demote when the symbol is unreachable", arguments: [
+        PBTSeedKind.pureFunction, .idempotency
+    ])
+    func testAnalysableKindsDemote(kind: PBTSeedKind) {
+        let demoted = PBTSeedsFormatter.effectiveKind(
+            kind, reachability: .unreachable(.declaration)
+        )
+
+        #expect(demoted == .restrictedFunction)
+    }
+
+    @Test("analysable kinds are left alone when the symbol is reachable", arguments: [
+        PBTSeedKind.pureFunction, .idempotency
+    ])
+    func testAnalysableKindsSurviveWhenReachable(kind: PBTSeedKind) {
+        #expect(PBTSeedsFormatter.effectiveKind(kind, reachability: .reachable) == kind)
+    }
+
+    /// `.unknown` must read as reachable. Demoting on "the rule did not look" would silently shrink
+    /// the analysable manifest every time a rule forgot to compute reachability — which, before
+    /// #74, was every rule but one.
+    @Test("unknown reachability does not demote", arguments: [
+        PBTSeedKind.pureFunction, .idempotency
+    ])
+    func testUnknownDoesNotDemote(kind: PBTSeedKind) {
+        #expect(PBTSeedsFormatter.effectiveKind(kind, reachability: .unknown) == kind)
+    }
+
+    /// The boundary itself: a kernel never demotes, however unreachable its location.
+    @Test("extractable-kernel never demotes", arguments: [
+        TestReachability.reachable, .unknown,
+        .unreachable(.declaration), .unreachable(.enclosingType)
+    ])
+    func testKernelsNeverDemote(reachability: TestReachability) {
+        let result = PBTSeedsFormatter.effectiveKind(.extractableKernel, reachability: reachability)
+
+        #expect(result == .extractableKernel)
+    }
+
+    /// Guards the claim the two tests above split on, so adding an analysable kind forces a
+    /// decision about whether the demotion should reach it rather than inheriting one silently.
+    @Test("every seed kind is accounted for by one of the two behaviours")
+    func testEveryKindIsClassified() {
+        let analysable = PBTSeedKind.allCases.filter(\.isAnalysable).map(\.rawValue).sorted()
+        let refactorPending = PBTSeedKind.allCases.filter { !$0.isAnalysable }
+            .map(\.rawValue).sorted()
+
+        #expect(analysable == ["idempotency", "pure-function", "restricted-function"])
+        #expect(refactorPending == ["extractable-kernel"])
+    }
+}

--- a/Tests/CoreTests/Idempotency/IdempotencySeedReachabilityTests.swift
+++ b/Tests/CoreTests/Idempotency/IdempotencySeedReachabilityTests.swift
@@ -1,0 +1,125 @@
+@testable import Core
+import SwiftParser
+@testable import SwiftProjectLintIdempotencyRules
+import SwiftProjectLintModels
+import SwiftSyntax
+import Testing
+
+/// An idempotency seed naming a function no test can call is not an analysable seed.
+///
+/// `testReachability` was computed by exactly one visitor — `PureFunctionCandidateVisitor` — so the
+/// `restricted-function` demotion in `PBTSeedsFormatter.effectiveKind` was reachable only from
+/// `pureFunctionCandidate` seeds. Every other seeding rule left the field at its `.unknown` default,
+/// which `effectiveKind` treats as reachable (correctly — demoting on "the rule did not look" would
+/// silently shrink the manifest). So an idempotency seed naming a `private` function was handed to
+/// the consumer as an analysable subject it cannot call (issue #74).
+///
+/// **Why this rule and not the two kernel rules.** The gap is not uniform across the four seeding
+/// rules, and the difference is in `effectiveKind`'s own guard: only an *analysable* kind can be
+/// demoted. `.idempotencyViolation` maps to `.idempotency`, which is analysable, so the demotion
+/// path is live and was simply never fed. Both kernel rules map to `.extractableKernel`, which is
+/// **not** analysable — `effectiveKind` returns early whatever the reachability — because a kernel
+/// is refactor-pending and its access level is not the obstacle: the reader extracting it chooses
+/// the new declaration's access level, so reporting "widen this declaration" would name a keyword
+/// the fix replaces anyway. Wiring reachability into those two would be dead data. That boundary is
+/// pinned by `SeedKindDemotionBoundaryTests`.
+@Suite("Idempotency seeds carry test reachability")
+struct IdempotencySeedReachabilityTests {
+
+    private func findings(_ source: String) -> [LintIssue] {
+        let cache = ["Service.swift": Parser.parse(source: source)]
+        let visitor = IdempotencyViolationVisitor(fileCache: cache)
+        for (path, tree) in cache {
+            visitor.setFilePath(path)
+            visitor.setSourceLocationConverter(
+                SourceLocationConverter(fileName: path, tree: tree)
+            )
+            visitor.walk(tree)
+        }
+        visitor.finalizeAnalysis()
+        return visitor.detectedIssues.filter { $0.ruleName == .idempotencyViolation }
+    }
+
+    /// The non-idempotent callee every fixture violates its contract by calling.
+    private static let callee = """
+    /// @lint.effect non_idempotent
+    func appendEntry(_ value: Int) {}
+    """
+
+    /// Three fixtures differing only in what puts the caller out of a test's reach.
+    private static let internalCaller = """
+    \(callee)
+
+    /// @lint.effect idempotent
+    func recordOnce(_ value: Int) {
+        appendEntry(value)
+    }
+    """
+
+    private static let privateCaller = """
+    \(callee)
+
+    /// @lint.effect idempotent
+    private func recordOnce(_ value: Int) {
+        appendEntry(value)
+    }
+    """
+
+    private static let callerInPrivateType = """
+    \(callee)
+
+    private struct Ledger {
+        /// @lint.effect idempotent
+        func recordOnce(_ value: Int) {
+            appendEntry(value)
+        }
+    }
+    """
+
+    @Test("an internal caller stays reachable")
+    func testInternalCallerIsReachable() throws {
+        let issues = findings(Self.internalCaller)
+
+        let issue = try #require(issues.first, "fixture must produce a violation")
+        #expect(issue.symbol == "recordOnce")
+        #expect(issue.testReachability == .reachable)
+    }
+
+    @Test("a private caller is unreachable, and names the declaration as the fix")
+    func testPrivateCallerIsRestrictedByDeclaration() throws {
+        let issues = findings(Self.privateCaller)
+
+        let issue = try #require(issues.first, "fixture must produce a violation")
+        #expect(issue.testReachability == .unreachable(.declaration))
+    }
+
+    /// The binding constraint, and the reason `TestRestriction` is not a `Bool`: widening the
+    /// function inside a `private` type changes nothing, so the patch has to name the type.
+    @Test("a caller inside a private type names the enclosing type as the fix")
+    func testCallerInPrivateTypeIsRestrictedByEnclosingType() throws {
+        let issues = findings(Self.callerInPrivateType)
+
+        let issue = try #require(issues.first, "fixture must produce a violation")
+        #expect(issue.testReachability == .unreachable(.enclosingType))
+    }
+
+    /// The end the consumer actually reads: an unreachable idempotency seed must arrive demoted,
+    /// carrying what would have to widen.
+    @Test("an unreachable idempotency seed is exported as restricted-function")
+    func testUnreachableSeedIsDemotedInTheManifest() {
+        let issues = findings(Self.privateCaller)
+        let manifest = PBTSeedsFormatter().format(issues: issues)
+
+        #expect(manifest.contains("\"kind\" : \"restricted-function\""))
+        #expect(manifest.contains("\"restriction\" : \"declaration\""))
+    }
+
+    @Test("a reachable idempotency seed keeps its kind")
+    func testReachableSeedKeepsItsKind() {
+        let issues = findings(Self.internalCaller)
+        let manifest = PBTSeedsFormatter().format(issues: issues)
+
+        #expect(manifest.contains("\"kind\" : \"idempotency\""))
+        #expect(manifest.contains("restricted-function") == false)
+    }
+}


### PR DESCRIPTION
Fixes #74.

## The gap is real, but it is not uniform across the four seeding rules

The issue proposes either (1) computing reachability in the shared visitor base so every seeding rule gets it, or (2) recording that it is pure-function-only. Reading `effectiveKind`'s own guard says the answer is **one of each**, split by seed kind:

| rule | kind | analysable? | demotion |
|---|---|---|---|
| `pureFunctionCandidate` | `pure-function` | yes | already worked |
| `idempotencyViolation` | `idempotency` | **yes** | **path was live and never fed — fixed here** |
| `extractablePureKernel` | `extractable-kernel` | no | `effectiveKind` returns early — excluded by design |
| `pureClosureCandidate` | `extractable-kernel` | no | same |

`effectiveKind` guards on `declared.isAnalysable`. So wiring reachability into the two kernel rules would produce **dead data** — the export layer discards it before looking. Option 1 applied uniformly would have written code that changes no output.

And the exclusion is right, not an oversight. A kernel is refactor-pending, and the refactor **creates** the declaration a consumer would call — so the reader picks its access level while extracting. Reporting "widen this declaration" would name a keyword the fix replaces anyway. `effectiveKind`'s existing comment already said this (*"a kernel is already refactor-pending, and its reachability is not the obstacle"*); nothing outside that one line did.

So: **option 1 for `idempotencyViolation`, option 2 for the two kernel rules.**

## What changed

1. `IdempotencyViolationVisitor` captures `PropertyTestCandidacy.restriction(of:)` at both site-capture paths and passes `testReachability` through. An idempotency seed naming a `private` function now arrives as `restricted-function` with `restriction: declaration` (or `enclosing-type`, which wins when both apply).
2. `SeedKindDemotionBoundaryTests` pins both halves. `PBTSeedKind` gains `CaseIterable` so the *classification* is pinned too — flipping `extractableKernel` to analysable compiles past `isAnalysable`'s exhaustive switch, and now fails a test instead.
3. All three rule docs updated.

## What a reviewer should scrutinise

- **The restriction is captured at the site, not recomputed at emit time.** A closure site's `body` is the closure's *statements*, whose parent is a `ClosureExprSyntax` and not a declaration — so `restriction(of: body)` would miss the `private let` binding carrying the annotation and silently report reachable. The declaration is in hand at capture; that is the reason.
- **The kernel case I deliberately left unsaid.** A kernel trapped inside a `private` **type** *does* stay unreachable after extraction, because the container decides. That is a narrower claim than the demotion makes, and the manifest cannot express it today. Both kernel docs now say to read a missing reachability signal as *"not asked"*, never *"reachable"* — but if you want that case represented, it needs a new field, not this demotion.
- **`.unknown` still reads as reachable**, and must: demoting on "the rule did not look" would silently shrink the analysable manifest — which, before this change, meant every rule but one.

## Verification

- Full suite **3208 passing** (3198 + 10). SwiftLint clean on changed files (two pre-existing `pattern_matching_keywords` warnings in the visitor left alone).
- Non-vacuous: removing the `testReachability` argument fails 4 of the 5 idempotency tests, each reporting `.unknown` — the issue's diagnosis, reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrHtiV3Um3p3jECQeZ6BqU