### PR TITLE
Register a pattern for onTapGesture Missing Accessibility

### DIFF
--- a/Docs/rules/RULES.md
+++ b/Docs/rules/RULES.md
@@ -173,6 +173,7 @@ Rules marked **opt-in** are disabled by default and must be explicitly listed un
 | [Long Text Accessibility](long-text-accessibility.md) | Info |
 | [Hardcoded Font Size](hardcoded-font-size.md) | Warning |
 | [onTapGesture Instead of Button](on-tap-gesture-instead-of-button.md) | Warning |
+| [onTapGesture Missing Accessibility](on-tap-gesture-missing-accessibility.md) | Info |
 | [Tap Target Too Small](tap-target-too-small.md) | Warning |
 | [Missing Dynamic Type Support](missing-dynamic-type-support.md) | Info *(opt-in)* |
 | [Decorative Image Missing Trait](decorative-image-missing-trait.md) | Info *(opt-in)* |

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/Accessibility.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/Accessibility.swift
@@ -85,6 +85,31 @@ class Accessibility: BasePatternRegistrar {
                 description: "Detects .onTapGesture calls that bypass button "
                     + "accessibility traits, keyboard focus, and haptic feedback"
             ),
+            // The same visitor's second finding, registered so the rule can be selected.
+            //
+            // `OnTapGestureInsteadOfButtonVisitor` raises two findings from one walk: a tap gesture
+            // that should be a Button, and an *allowed* multi-tap gesture that VoiceOver cannot
+            // discover. Only the first had a pattern, and `SourcePatternDetector.runVisitors`
+            // filters a visitor's output to the requested rule names — so the second was produced
+            // and then dropped on every default run. The rule fired only for a user who named it
+            // in `enabled_only` alongside this one, which required already knowing both that it
+            // existed and that it was coupled.
+            //
+            // Costs no extra work: `runVisitors` groups patterns by visitor type and walks once,
+            // so this entry adds a name to the requested set and nothing else. The visitor passes
+            // an explicit severity for each finding and never reads `pattern.severity`, so which
+            // of the two patterns happens to initialise it does not matter.
+            SyntaxPattern(
+                name: .onTapGestureMissingAccessibility,
+                visitor: OnTapGestureInsteadOfButtonVisitor.self,
+                severity: .info,
+                category: .accessibility,
+                messageTemplate: "Multi-tap or location-aware onTapGesture is invisible to VoiceOver",
+                suggestion: "Add .accessibilityAddTraits(.isButton) and "
+                    + ".accessibilityLabel(\"description\")",
+                description: "Detects allowed multi-tap and location-aware .onTapGesture calls "
+                    + "that VoiceOver users cannot discover"
+            ),
             SyntaxPattern(
                 name: .tapTargetTooSmall,
                 visitor: TapTargetTooSmallVisitor.self,

--- a/Tests/CoreTests/Accessibility/OnTapGestureSecondFindingTests.swift
+++ b/Tests/CoreTests/Accessibility/OnTapGestureSecondFindingTests.swift
@@ -1,0 +1,83 @@
+@testable import Core
+import Foundation
+import Testing
+
+/// A visitor's second finding must survive the pipeline that runs it.
+///
+/// `OnTapGestureInsteadOfButtonVisitor` raises two findings from one walk. Only the first had a
+/// registered pattern, and `SourcePatternDetector.runVisitors` filters a visitor's output to the
+/// *requested rule names* — a set built from the selected patterns. So the second finding was
+/// produced correctly and then dropped, on every run, for every user.
+///
+/// **The shape of the bug is why this test goes through `ProjectLinter` rather than the visitor.**
+/// Driven directly the visitor always emitted both findings, so a visitor-level test passed
+/// throughout and proved nothing. The defect only existed at the seam between the visitor and the
+/// detector's filter, and only an end-to-end run crosses it (issue #82).
+@Suite("Accessibility — onTapGesture's second finding reaches the report")
+struct OnTapGestureSecondFindingTests {
+
+    /// Multi-tap is an *allowed* gesture — `Button` cannot express it — so the host rule stays
+    /// silent and only the accessibility finding applies. That makes it the case that isolates the
+    /// second finding: if it is dropped, this file reports nothing at all.
+    private static let multiTapSource = """
+    import SwiftUI
+
+    struct MultiTapView: View {
+        var body: some View {
+            Text("Hello").onTapGesture(count: 2) { _ = 1 }
+        }
+    }
+    """
+
+    private func analyse(_ configuration: LintConfiguration?) async -> [RuleIdentifier] {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OnTapGesture-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try? Self.multiTapSource.write(
+            to: root.appendingPathComponent("MultiTapView.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let system = PatternRegistryFactory.createConfiguredSystem()
+        let issues: [LintIssue]
+        if let configuration {
+            issues = await ProjectLinter().analyzeProject(
+                at: root.path, detector: system.detector, configuration: configuration
+            )
+        } else {
+            issues = await ProjectLinter().analyzeProject(
+                at: root.path, detector: system.detector
+            )
+        }
+        return issues.map(\.ruleName).filter { $0 == .onTapGestureMissingAccessibility }
+    }
+
+    @Test("it fires on a default run")
+    func testFiresWithNoConfiguration() async {
+        #expect(await analyse(nil) == [.onTapGestureMissingAccessibility])
+    }
+
+    @Test("it fires under an empty configuration")
+    func testFiresWithEmptyConfiguration() async {
+        #expect(await analyse(LintConfiguration()) == [.onTapGestureMissingAccessibility])
+    }
+
+    /// The selection it could not previously satisfy: asked for on its own, it now runs on its own.
+    /// Before, this resolved to the rule and then matched zero patterns.
+    @Test("it can be selected on its own")
+    func testCanBeEnabledInIsolation() async {
+        let config = LintConfiguration(enabledOnlyRules: [.onTapGestureMissingAccessibility])
+
+        #expect(await analyse(config) == [.onTapGestureMissingAccessibility])
+    }
+
+    @Test("it can be disabled on its own")
+    func testCanBeDisabledInIsolation() async {
+        let config = LintConfiguration(disabledRules: [.onTapGestureMissingAccessibility])
+
+        #expect(await analyse(config).isEmpty)
+    }
+}

--- a/Tests/CoreTests/Registry/RuleRegistrationResidualTests.swift
+++ b/Tests/CoreTests/Registry/RuleRegistrationResidualTests.swift
@@ -28,15 +28,15 @@ struct RuleRegistrationResidualTests {
     /// The list is the point of this test. An identifier missing from the registry is either a
     /// rule that silently reaches nothing — a real defect — or a deliberate arrangement someone
     /// has to have thought about. Writing the reason down is what tells the next reader which.
-    private static let unregisteredByDesign: [RuleIdentifier: String] = [
-        .onTapGestureMissingAccessibility:
-            "Emitted with `ruleName:` by OnTapGestureInsteadOfButtonVisitor, which is registered "
-            + "under .onTapGestureInsteadOfButton. One visitor, two findings: a tap gesture that "
-            + "should be a Button is also invisible to VoiceOver, and the two are found by the "
-            + "same walk. Consequence, measured: selecting this rule on its own resolves to it "
-            + "and then runs zero patterns, because the detector filters patterns by name and "
-            + "this rule has none — so it cannot be enabled in isolation, only alongside its host."
-    ]
+    /// Empty, and worth keeping that way.
+    ///
+    /// It held one entry — `.onTapGestureMissingAccessibility`, emitted with `ruleName:` by a
+    /// visitor registered under a different name. Writing the reason down is what exposed it as a
+    /// defect rather than an arrangement: a rule with no pattern is filtered out of its own
+    /// visitor's output by `SourcePatternDetector.runVisitors`, so it never fired on a default run.
+    /// It now has a pattern, and `testNoExceptionIsActuallyRegistered` is what forced this entry to
+    /// be removed rather than left behind as a stale excuse.
+    private static let unregisteredByDesign: [RuleIdentifier: String] = [:]
 
     @Test("every selectable rule is registered, or documented as to why not")
     func testEverySelectableRuleIsReachable() {


### PR DESCRIPTION
Fixes #82.

## The rule was dead, and the visitor was never at fault

`OnTapGestureInsteadOfButtonVisitor` raises two findings from one walk: a tap gesture that should be a `Button`, and an *allowed* multi-tap/location-aware gesture that VoiceOver cannot discover. Only the first had a registered pattern.

`SourcePatternDetector.runVisitors` (`:211`) filters a visitor's output to the requested rule names, and that set is built from the **selected patterns**:

```swift
var issues = visitor.detectedIssues.filter { requestedRules.contains($0.ruleName) }
```

So the second finding was produced correctly and discarded a line later.

| configuration | before | after |
|---|---|---|
| no config | — | **fires** |
| empty `LintConfiguration()` | — | **fires** |
| `enabled_only: [the rule]` | — (resolved, then matched zero patterns) | **fires** |
| `disabled_rules: [the rule]` | n/a | correctly silent |
| `enabled_only: [rule + host]` | fired | fires |

Before this, the only way to see the finding was to name it in `enabled_only` alongside its host — which required already knowing it existed *and* that it was coupled to another rule. It is not in `optInRules`, and its doc page describes it as an ordinary rule.

## Why it stayed hidden

- No pattern, so nothing in the registry named it.
- No row in `Docs/rules/RULES.md` — the index listed the host only.
- `Docs/rules/on-tap-gesture-missing-accessibility.md` exists and reads like any other rule.

## What a reviewer should scrutinise

- **Runtime cost is nil, and the reason is worth confirming.** `runVisitors` groups patterns by visitor type and instantiates one visitor per group, so a second pattern on the same visitor adds no walk. It initialises the visitor with `patterns[0]`, but this visitor passes an explicit severity to each `addIssue` and never reads `pattern.severity` — so which of the two patterns wins that slot changes nothing. If that ever stops being true, the grouping makes it a silent problem.
- **Real-world impact is approximately zero, measured.** Across three SwiftUI codebases (`MacCloud_client_MacOS`, `LintStudioUI`, `SwiftLintRuleStudio`) the newly-live rule produces **0** findings — multi-tap and location-aware gestures are simply rare. Verified it does fire via the built CLI on a synthetic fixture. So this is low-risk to land; the value is that the rule stops being dead for whoever writes one.
- **The exception list is now empty.** `RuleRegistrationResidualTests.testNoExceptionIsActuallyRegistered` is what forced the entry out — it fails when a listed rule gains a pattern, exactly so an excuse cannot outlive its reason. That test came from #73 and this is its first real use.

## Verification

- Full suite **3212 passing** (3208 + 4). SwiftLint clean on changed files.
- The four new tests go through `ProjectLinter`, not the visitor, deliberately: driven directly the visitor always emitted both findings, so a visitor-level test passed throughout and proved nothing. The defect lived only at the seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrHtiV3Um3p3jECQeZ6BqU