### PR TITLE
Seed the domain-type rules as carrier seeds

### DIFF
--- a/Docs/rules/primitive-bypassing-its-domain-type.md
+++ b/Docs/rules/primitive-bypassing-its-domain-type.md
@@ -108,4 +108,22 @@ var replayCache: [String: Response] = [:]    // ← flagged: bypasses Idempotenc
 **Suggestion:** Key `replayCache` by `IdempotencyKey` too, so the dedup identity is enforced by
 the type rather than a bare `String` any value can impersonate.
 
+### As a Property-Test Seed
+
+A finding is exported by `--format pbt-seeds` with `kind: carrier` and a `symbol` naming the
+**domain type** — not the mistyped position, and not a function. A carrier is a type that owes laws
+the raw primitive cannot state: `Percentage` can own `0...100`; `Int` cannot.
+
+Two things a consumer needs to know about this kind:
+
+- **The `symbol` is a type name.** Every other analysable kind names something callable. Templates
+  that state laws over a carrier type (round-trip, model laws, value semantics) are the consumers
+  this kind is for; anything expecting a function should skip it.
+- **The `file` is the *use site*, not the type's declaration.** The rule fires where the primitive
+  is used, and the domain type it names usually lives in another file. A consumer joining on
+  `(file, symbol)` will miss; join on the type name.
+
+`carrier` is analysable — the subject can be named and laws proposed for it — but it never demotes
+to `restricted-function`, which promises a callable.
+
 ---

--- a/Docs/rules/primitive-named-for-its-domain-type.md
+++ b/Docs/rules/primitive-named-for-its-domain-type.md
@@ -103,4 +103,22 @@ struct Session {
 **Suggestion:** Type the position as the domain newtype (`IdempotencyKey`, `UserID`) so the
 identity is enforced by the type instead of a bare primitive any value can impersonate.
 
+### As a Property-Test Seed
+
+A finding is exported by `--format pbt-seeds` with `kind: carrier` and a `symbol` naming the
+**domain type** — not the mistyped position, and not a function. A carrier is a type that owes laws
+the raw primitive cannot state: `Percentage` can own `0...100`; `Int` cannot.
+
+Two things a consumer needs to know about this kind:
+
+- **The `symbol` is a type name.** Every other analysable kind names something callable. Templates
+  that state laws over a carrier type (round-trip, model laws, value semantics) are the consumers
+  this kind is for; anything expecting a function should skip it.
+- **The `file` is the *use site*, not the type's declaration.** The rule fires where the primitive
+  is used, and the domain type it names usually lives in another file. A consumer joining on
+  `(file, symbol)` will miss; join on the type name.
+
+`carrier` is analysable — the subject can be named and laws proposed for it — but it never demotes
+to `restricted-function`, which promises a callable.
+
 ---

--- a/Docs/rules/shared-domain-enum-field.md
+++ b/Docs/rules/shared-domain-enum-field.md
@@ -114,4 +114,26 @@ struct ValidationIssue {
 IssueSeverity { get }` and conform each type to it, so sorting, filtering, and grouping keyed
 on `IssueSeverity` are written once over `Sequence where Element: SeverityRanked`.
 
+### As a Property-Test Seed
+
+A finding is exported by `--format pbt-seeds` with `kind: carrier` and a `symbol` naming the
+**type this finding is anchored on** — the cluster member carrying the shared field, one seed per
+member, not a function.
+
+Note what the symbol is *not*: the protocol the rule asks you to extract. That protocol does not
+exist yet, and a manifest names what is there. Once it exists, the types conforming to it are still
+the carriers — the seed does not become stale, it becomes better grounded.
+
+Two things a consumer needs to know about this kind:
+
+- **The `symbol` is a type name.** Every other analysable kind names something callable. Templates
+  that state laws over a carrier type (round-trip, model laws, value semantics) are the consumers
+  this kind is for; anything expecting a function should skip it.
+- **The `file` is the *use site*, not the type's declaration.** The rule fires where the primitive
+  is used, and the domain type it names usually lives in another file. A consumer joining on
+  `(file, symbol)` will miss; join on the type name.
+
+`carrier` is analysable — the subject can be named and laws proposed for it — but it never demotes
+to `restricted-function`, which promises a callable.
+
 ---

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/PrimitiveBypassingDomainTypeVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/PrimitiveBypassingDomainTypeVisitor.swift
@@ -146,7 +146,12 @@ final class PrimitiveBypassingDomainTypeVisitor: CrossFileVisitorBase, CrossFile
                 lineNumber: usage.line,
                 suggestion: "Key this map by '\(names)' too, so the identity is enforced by the "
                     + "type instead of a bare '\(usage.key)' that any value can impersonate.",
-                ruleName: .primitiveBypassingItsDomainType
+                ruleName: .primitiveBypassingItsDomainType,
+                // The domain type being bypassed, which is what owes the laws — not the map or the
+                // raw key. Where several wrappers exist over the same carrier the message names
+                // them all and the seed takes the first in sorted order: a manifest names one
+                // subject, and picking deterministically beats picking by hash.
+                symbol: wrappersForValue.min()
             )
         }
     }

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/PrimitiveNamedForDomainTypeVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/PrimitiveNamedForDomainTypeVisitor.swift
@@ -193,7 +193,10 @@ final class PrimitiveNamedForDomainTypeVisitor: CrossFileVisitorBase, CrossFileP
                 lineNumber: position.line,
                 suggestion: "Type '\(position.name)' as '\(wrapper.name)' so the identity is "
                     + "enforced by the type instead of a bare '\(position.carrier)'.",
-                ruleName: .primitiveNamedForItsDomainType
+                ruleName: .primitiveNamedForItsDomainType,
+                // The domain type, not the mistyped property: it is the type that owes the laws
+                // the raw primitive cannot state. Exported as a `carrier` seed.
+                symbol: wrapper.name
             )
         }
     }

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/SharedDomainEnumFieldVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/SharedDomainEnumFieldVisitor.swift
@@ -157,7 +157,11 @@ final class SharedDomainEnumFieldVisitor: CrossFileVisitorBase, CrossFilePattern
                     suggestion: "Extract a protocol requiring '\(fieldText)' and conform "
                         + "\(conformNames) to it, so behavior keyed on "
                         + "\(signature.typeName) (sorting, filtering, grouping) is written once.",
-                    ruleName: .sharedDomainEnumField
+                    ruleName: .sharedDomainEnumField,
+                    // The type this finding is anchored on. One issue is raised per member of the
+                    // cluster, so each seed names the type at its own location rather than the
+                    // protocol that does not exist yet — a manifest names what is there.
+                    symbol: shape.name
                 )
             }
         }

--- a/Sources/Core/Export/PBTSeedsFormatter.swift
+++ b/Sources/Core/Export/PBTSeedsFormatter.swift
@@ -29,6 +29,26 @@ public enum PBTSeedKind: String, Codable, Sendable, CaseIterable {
     /// symbol names the *enclosing* function, which is where to look, not what to test.
     case extractableKernel = "extractable-kernel"
 
+    /// A **type** that owes laws — the domain-type rules' subject. `symbol` names a type, not a
+    /// function, and that is the whole point of the case.
+    ///
+    /// Every other kind assumes the consumer's subject is a callable. It often is not:
+    /// `CodableRoundTripTemplate`, `ModelLawTemplate` and the `verify-value-semantics` command all
+    /// state laws over a *carrier type* with no free function anywhere. A newtype over a primitive
+    /// is exactly that shape — `Percentage` can own `0...100` and `String` cannot — which is the
+    /// argument the domain-type rules already make in prose.
+    ///
+    /// **Analysable**, for the same reason `restrictedFunction` is: the consumer can name the
+    /// subject and propose laws for it. What it cannot do is *call* it, and nothing here claims
+    /// otherwise — a carrier is a type, and the templates that consume one know that.
+    ///
+    /// **No schema bump.** A consumer built before this case decodes it as unrecognised and skips
+    /// it *loudly* — `SwiftInferProperties.SeedKind` has an explicit `case unrecognised(String)`
+    /// with `isAnalysable == false`, chosen because guessing "analysable" for an unknown kind is
+    /// the silent failure and guessing "not" is the spoken one. So an older consumer degrades to
+    /// the behaviour it had before this case existed, which is what a version bump would buy.
+    case carrier = "carrier"
+
     /// A pure, total, **named** function that no test can call: `private` or `fileprivate`.
     ///
     /// `@testable import` reaches `internal` and no further. This codebase has always known that —
@@ -69,7 +89,7 @@ public enum PBTSeedKind: String, Codable, Sendable, CaseIterable {
     /// The symbol is a location, not a subject.
     public var isAnalysable: Bool {
         switch self {
-        case .pureFunction, .idempotency, .restrictedFunction:
+        case .pureFunction, .idempotency, .restrictedFunction, .carrier:
             return true
 
         case .extractableKernel:
@@ -247,7 +267,11 @@ public struct PBTSeedsFormatter: IssueFormatterProtocol {
         .pureFunctionCandidate: .pureFunction,
         .idempotencyViolation: .idempotency,
         .extractablePureKernel: .extractableKernel,
-        .pureClosureCandidate: .extractableKernel
+        .pureClosureCandidate: .extractableKernel,
+        // The domain-type family. Their symbol is a type name — see `PBTSeedKind.carrier`.
+        .primitiveBypassingItsDomainType: .carrier,
+        .primitiveNamedForItsDomainType: .carrier,
+        .sharedDomainEnumField: .carrier
     ]
 
     /// Demote an otherwise-analysable seed whose symbol no test can call.
@@ -258,7 +282,16 @@ public struct PBTSeedsFormatter: IssueFormatterProtocol {
     static func effectiveKind(
         _ declared: PBTSeedKind, reachability: TestReachability
     ) -> PBTSeedKind {
-        guard declared.isAnalysable, reachability.isUnreachable else { return declared }
+        // `.carrier` is excluded even though it is analysable, because the kind it would demote to
+        // names a *function* — "a pure, total, **named** function that no test can call" — and a
+        // carrier's symbol is a type. Demoting one would hand a consumer a type name under a kind
+        // that promises a callable, which is the same category error the kind split exists to stop.
+        // A private *type* is a real obstacle and deserves saying, but it needs its own vocabulary,
+        // not this one. No domain-type rule computes reachability today, so nothing is lost now;
+        // the guard is here so that adding one later fails visibly instead of mislabelling.
+        guard declared.isAnalysable, declared != .carrier, reachability.isUnreachable else {
+            return declared
+        }
         return .restrictedFunction
     }
 

--- a/Tests/CoreTests/Export/CarrierSeedTests.swift
+++ b/Tests/CoreTests/Export/CarrierSeedTests.swift
@@ -1,0 +1,93 @@
+@testable import Core
+import Foundation
+import Testing
+
+/// The domain-type rules reach the seed manifest, as `carrier` seeds naming a **type**.
+///
+/// They printed and never seeded. The reason on record was that "the carrier they create has no
+/// callable function attached, so a `pure-function` kind would be a lie" — true about the kind,
+/// false about the consumer, which was the half that mattered: `CodableRoundTripTemplate`,
+/// `ModelLawTemplate` and `verify-value-semantics` all state laws over a carrier type with no free
+/// function anywhere. A newtype over a primitive is exactly that shape (issue #76).
+///
+/// So the seed's `symbol` is a type name, and `PBTSeedKind.carrier` exists to say so rather than
+/// letting a consumer read it as a callable.
+@Suite("Export — the domain-type rules seed as carriers")
+struct CarrierSeedTests {
+
+    /// `Percentage` is declared in one file and the finding is raised in **another** — which is the
+    /// normal case, not a contrived one: the rule fires where the raw primitive is used, and the
+    /// domain type it names lives wherever it was declared.
+    private static let files: [String: String] = [
+        "Domain.swift": """
+        struct Percentage {
+            let value: Int
+            init(value: Int) { self.value = value }
+        }
+        """,
+        "Report.swift": """
+        struct Report {
+            let percentage: Int
+            let title: String
+        }
+        """
+    ]
+
+    private func analyse() async -> [LintIssue] {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CarrierSeed-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        for (name, source) in Self.files {
+            try? source.write(
+                to: root.appendingPathComponent(name), atomically: true, encoding: .utf8
+            )
+        }
+        let system = PatternRegistryFactory.createConfiguredSystem()
+        return await ProjectLinter().analyzeProject(at: root.path, detector: system.detector)
+    }
+
+    @Test("the finding names the domain type as its symbol")
+    func testSymbolIsTheDomainType() async throws {
+        let issues = await analyse()
+        let finding = try #require(
+            issues.first { $0.ruleName == .primitiveNamedForItsDomainType },
+            "fixture must trigger the rule"
+        )
+
+        #expect(finding.symbol == "Percentage")
+    }
+
+    @Test("it is exported as a carrier seed")
+    func testExportedAsCarrier() async {
+        let manifest = PBTSeedsFormatter().format(issues: await analyse())
+
+        #expect(manifest.contains("\"kind\" : \"carrier\""))
+        #expect(manifest.contains("\"symbol\" : \"Percentage\""))
+    }
+
+    /// **The seed's `file` is the use site, not the declaration.** Recorded because it decides how
+    /// a consumer may join: `SeedFocus` keys function seeds on `(file basename, symbol)`, and doing
+    /// that to a carrier would miss whenever the type is declared elsewhere — which is most of the
+    /// time. A carrier has to join on the type name alone.
+    @Test("the seed is anchored at the use site, not the type's declaration")
+    func testSeedFileIsTheUseSite() async throws {
+        let issues = await analyse()
+        let finding = try #require(issues.first { $0.ruleName == .primitiveNamedForItsDomainType })
+
+        #expect(finding.filePath == "Report.swift")
+        #expect(finding.filePath != "Domain.swift")
+    }
+
+    /// A carrier is analysable — a consumer may name the subject and propose laws for it — but it
+    /// must never demote to `restricted-function`, which promises a callable.
+    @Test("a carrier seed stays a carrier and is analysable")
+    func testCarrierIsAnalysableAndNeverDemoted() {
+        #expect(PBTSeedKind.carrier.isAnalysable)
+        #expect(
+            PBTSeedsFormatter.effectiveKind(.carrier, reachability: .unreachable(.declaration))
+                == .carrier
+        )
+    }
+}

--- a/Tests/CoreTests/Export/SeedKindDemotionBoundaryTests.swift
+++ b/Tests/CoreTests/Export/SeedKindDemotionBoundaryTests.swift
@@ -62,15 +62,48 @@ struct SeedKindDemotionBoundaryTests {
         #expect(result == .extractableKernel)
     }
 
-    /// Guards the claim the two tests above split on, so adding an analysable kind forces a
-    /// decision about whether the demotion should reach it rather than inheriting one silently.
+    /// A carrier does not demote either, and for a different reason than a kernel — which is why
+    /// it gets its own test rather than joining the one above.
+    ///
+    /// A kernel is excluded because it is *not analysable*. A carrier **is** analysable; it is
+    /// excluded because `restrictedFunction` names a function and a carrier's symbol is a type.
+    /// Demotion would hand a consumer a type name under a kind promising a callable. A private
+    /// type is a real obstacle, but saying so needs its own vocabulary.
+    @Test("carrier never demotes", arguments: [
+        TestReachability.reachable, .unknown,
+        .unreachable(.declaration), .unreachable(.enclosingType)
+    ])
+    func testCarriersNeverDemote(reachability: TestReachability) {
+        #expect(PBTSeedsFormatter.effectiveKind(.carrier, reachability: reachability) == .carrier)
+    }
+
+    /// Guards the claim the tests above split on, so adding a kind forces a decision about whether
+    /// the demotion should reach it rather than inheriting one silently.
+    ///
+    /// It has already done that once: adding `.carrier` failed this test, which is how the
+    /// question "should a type-named seed demote to a function-named kind?" got asked at all
+    /// instead of being answered by whichever branch `isAnalysable` happened to fall into.
     @Test("every seed kind is accounted for by one of the two behaviours")
     func testEveryKindIsClassified() {
         let analysable = PBTSeedKind.allCases.filter(\.isAnalysable).map(\.rawValue).sorted()
         let refactorPending = PBTSeedKind.allCases.filter { !$0.isAnalysable }
             .map(\.rawValue).sorted()
 
-        #expect(analysable == ["idempotency", "pure-function", "restricted-function"])
+        #expect(analysable == ["carrier", "idempotency", "pure-function", "restricted-function"])
         #expect(refactorPending == ["extractable-kernel"])
+    }
+
+    /// Analysable is not the same as demotable, now that the two have come apart.
+    ///
+    /// Asked as "which kinds *change*" rather than "which end up as `restrictedFunction`", because
+    /// a seed that is already `restrictedFunction` demotes to itself and would otherwise be
+    /// counted as a third demotable kind — true of the expression, false of the behaviour.
+    @Test("only function-subject kinds demote")
+    func testOnlyFunctionSubjectKindsDemote() {
+        let changed = PBTSeedKind.allCases.filter {
+            PBTSeedsFormatter.effectiveKind($0, reachability: .unreachable(.declaration)) != $0
+        }
+
+        #expect(changed.map(\.rawValue).sorted() == ["idempotency", "pure-function"])
     }
 }


### PR DESCRIPTION
Producer half of #76. The consumer-side `SeedFocus` join follows in SwiftInferProperties; this is inert until then, by design.

## What changed

`PBTSeedKind.carrier` — a **type** that owes laws. `symbol` names a type rather than a function, and the three domain-type rules map onto it:

| rule | symbol |
|---|---|
| `Primitive Named For Its Domain Type` | the domain type (`Percentage`) |
| `Primitive Bypassing Its Domain Type` | the domain type being bypassed |
| `Shared Domain-Enum Field` | the cluster member the finding is anchored on |

None of the three emitted a `symbol` at all before, so they would have been dropped by `droppedSeeds` even if mapped.

Verified end to end:

```
$ swiftprojectlint <fixture> --format pbt-seeds
{ "file": "Report.swift", "kind": "carrier", "line": 2,
  "rule": "Primitive Named For Its Domain Type", "symbol": "Percentage" }
```

## What a reviewer should scrutinise

- **The seed's `file` is the use site, not the type's declaration.** In the fixture above `Percentage` is declared in `Domain.swift` and the seed points at `Report.swift`, because the rule fires where the raw primitive is used. That is normal, not contrived — and it decides the consumer's join: `SeedFocus` keys function seeds on `(file basename, symbol)`, and doing that to a carrier would miss whenever the type lives elsewhere, which is most of the time. **A carrier must join on the type name alone.** Pinned by a test and written into all three rule docs, because it is the sort of thing a consumer would otherwise discover as a mysterious zero.
- **`carrier` is analysable but never demotes.** `effectiveKind` now excludes it explicitly: the kind it would demote to, `restricted-function`, is documented as "a pure, total, **named** function", and handing a consumer a type name under that promise is the same category error the kind split exists to prevent. No domain-type rule computes reachability today so nothing is lost now; the guard makes a later addition fail visibly rather than mislabel. A private *type* is a real obstacle and deserves its own vocabulary.
- **Where several wrappers exist over one carrier**, the message names them all and the seed takes `min()` — a manifest names one subject, and picking deterministically beats picking by hash.
- **No schema bump**, and this was verified rather than assumed: `SwiftInferProperties.SeedKind.init(from:)` maps unknown raw strings to `case unrecognised(String)` with `isAnalysable == false`. An older consumer skips a carrier seed *loudly*, which is what the bump would have bought. Note the producer here is stricter than the consumer — `PBTSeed.init(from:)` hard-decodes `kind` and would throw on an unknown one — an asymmetry that matters only if a third consumer appears.

## Verification

- Full suite **3220 passing** (3216 + 4). SwiftLint clean.
- The seed-kind classification test from #74 earned its keep immediately: adding `.carrier` failed it, which is how "should a type-named seed demote to a function-named kind?" got asked at all rather than answered by whichever branch `isAnalysable` happened to fall into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrHtiV3Um3p3jECQeZ6BqU