### PR TITLE
Re-pin SEI and forward the capture-write verdict

### DIFF
--- a/Docs/design/unreachable-effect-closure-rule-design.md
+++ b/Docs/design/unreachable-effect-closure-rule-design.md
@@ -99,7 +99,8 @@ Report a `ClosureExprSyntax` when **all** hold:
    folding four separate refuters — `async`/`throws`, impurity markers, totality, and capture
    mutation (`SwiftEffectInference/PurityInferrer.swift:194-205`). Inverting it over-reports:
    `.onHover { print(x) }` is impure and has no captured write. The predicate this rule actually
-   wants is the last of the four alone. See *Feasibility* for what that costs.
+   wants is the last of the four alone, and it is now available as
+   `PurityInferrer.mutatesCapturedState(_ closure:)` — see *Feasibility*.
 3. **Not already extracted.** The body is more than a single call expression.
 
 Condition 3 is what makes the rule converge. `.onKeyPress(.escape) { clearSelection() }` is the
@@ -206,29 +207,31 @@ numbers showing what the exclusion misses.
 ## Feasibility
 
 Structural AST, per-file. No cross-file graph, no flow analysis. The only genuinely new machinery is
-"assignment whose LHS roots in a capture" — and that machinery **exists but is not reachable from
-this repo**, which is the real cost of v1.
+"assignment whose LHS roots in a capture" — and **that prerequisite is now done**, via the upstream
+route rather than a local reimplementation, so one definition of the predicate serves both rules.
 
-`PurityInferrer` does decide the predicate, in a `CaptureMutationChecker` walk
-(`SwiftEffectInference/PurityInferrer.swift:256-260`). But that type is `private final class` at
-`PurityInferrer.swift:392`, visible only to the file that folds it into `isPure(_:)`. It lives in
-`SwiftEffectInference`, a separate repository pinned here by revision (`bc084fb` in
-`Package.resolved`), and reached only through the forwarding `PurityInferrer` in the Visitors package
-— which exposes the folded Bool and nothing finer. Two ways out:
+`PurityInferrer.mutatesCapturedState(_ closure:)` is public in SwiftEffectInference as of `fc82ec4`
+(SEI PR #6), forwarded here on `SwiftProjectLintVisitors.PurityInferrer`, with all three manifests
+re-pinned. `CaptureMutationChecker` stays private — only the verdict crossed the boundary. The
+implementation reads it directly; there is nothing left to build for condition 2.
 
-- **Expose it upstream.** A PR to SwiftEffectInference publishing the capture-mutation verdict —
-  either `CaptureMutationChecker` itself or a `mutatesCapturedState(_ closure:)` member on
-  `PurityInferrer` — then re-pin here and add a forwarding member to
-  `SwiftProjectLintVisitors.PurityInferrer`. Correct long-term: it keeps one definition of the
-  predicate, which is the whole reason the oracle was relocated to SEI in the first place. Costs a
-  cross-repo round trip and a pin bump before this rule can build.
-- **Reimplement locally.** A ~40-line visitor in this package. Ships without touching SEI, at the
-  price of a second definition of "writes to a capture" that can drift from the one that refutes
-  `pure-closure-candidate` — and these two rules are supposed to partition the same space, so drift
-  between them is exactly the failure that matters.
+Two things the prerequisite turned up that the rule must know:
 
-Prefer the upstream route, and treat the SEI PR as a prerequisite of this one rather than a
-follow-up.
+- **Inverting `isPure` was never going to work.** That Bool folds four refuters — `async`/`throws`,
+  markers, totality, capture mutation — and three are unrelated to captures. `{ print(x) }` is impure
+  and mutates nothing. Pinned by `theCaptureClauseIsIndependentOfTheOtherRefuters` in
+  `PurityOracleLawsTests`.
+- **The predicate had a bug the audit found, now fixed.** Nested closures' *parameters* were not
+  counted as locals, though their `let`/`var` were, so a nested `reduce(into:) { acc, x in acc += x }`
+  read as a captured write — exactly the case this rule's own refutation list says must not fire.
+  It measured as a no-op on both available corpora (SwiftProjectLint 10 → 10,
+  SwiftInferProperties 250 → 250 `pure-closure-candidate` findings), so it changed nothing for the
+  pure sibling; it was only ever going to matter for this rule.
+
+One caveat carried over from SEI and worth re-reading before writing the visitor: the bound-name set
+is **flat — scopes are not tracked**. A genuine captured write to `total` goes unrecorded if some
+unrelated nested closure also binds a `total`. That errs toward *not* reporting, which is the right
+direction for a rule making a positive claim, but it is the known soundness hole.
 
 Main false-positive risk is condition 1's allowlist drifting behind SwiftUI. Prefer under-reporting:
 an unlisted modifier is a missed finding, whereas inferring "any trailing closure on a member access

--- a/Package.swift
+++ b/Package.swift
@@ -62,7 +62,7 @@ let package = Package(
         // swift-syntax exact 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "bc084fb9613c22f1aee94d9d1781b0eca2e67620"
+            revision: "fc82ec440e38c3467cf2621666937510ebde5301"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintIdempotencyRules/Package.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // root and SwiftProjectLintVisitors pins.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "bc084fb9613c22f1aee94d9d1781b0eca2e67620"
+            revision: "fc82ec440e38c3467cf2621666937510ebde5301"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintVisitors/Package.swift
+++ b/Packages/SwiftProjectLintVisitors/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "bc084fb9613c22f1aee94d9d1781b0eca2e67620"
+            revision: "fc82ec440e38c3467cf2621666937510ebde5301"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/PurityInferrer.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/PurityInferrer.swift
@@ -48,6 +48,20 @@ public struct PurityInferrer: Sendable {
         underlying.isPure(closure)
     }
 
+    /// Whether a closure assigns to something it captured, asked on its own.
+    ///
+    /// The capture-write clause of `isPure(_ closure:)`, unfolded from the other three refuters
+    /// (`async`/`throws`, impurity markers, totality). A caller cannot recover it by inverting
+    /// `isPure`: `{ print(x) }` is impure and mutates no capture.
+    ///
+    /// `pure-closure-candidate` uses this verdict to **refute** a property-test seed, where
+    /// over-reporting costs only a missed candidate. A rule reporting *because* a closure's effect
+    /// escapes into captured state makes the opposite, positive claim and pays for a wrong answer
+    /// with a wrong finding — so read SEI's note on the flat bound-name set before consuming it.
+    public func mutatesCapturedState(_ closure: ClosureExprSyntax) -> Bool {
+        underlying.mutatesCapturedState(closure)
+    }
+
     /// Whether a **computed property's getter** is referentially transparent.
     ///
     /// Answers the effect half only — markers and totality. `SelfAccessAnalyzer` resolves the state

--- a/Tests/CoreTests/Visitors/PurityOracleLawsTests.swift
+++ b/Tests/CoreTests/Visitors/PurityOracleLawsTests.swift
@@ -167,6 +167,48 @@ struct PurityOracleLawsTests {
         }
     }
 
+    /// The capture-write clause must not be recoverable by inverting `isPure` — which is the whole
+    /// reason it is forwarded separately.
+    ///
+    /// A caller wanting "does this closure's effect escape into captured state?" and reaching for
+    /// `!isPure(closure)` gets every impure-but-capture-free closure wrong. Each source below is
+    /// refuted by a *different* one of the other three clauses, so this pins the independence rather
+    /// than one instance of it.
+    @Test(arguments: [
+        "let logged = items.map { item in print(item) }",     // impurity marker
+        "let stamped = items.map { item in Date() }",         // nondeterminism
+        "let names = items.map { item in item.name! }"        // partiality
+    ])
+    func theCaptureClauseIsIndependentOfTheOtherRefuters(source: String) throws {
+        let closure = try #require(
+            Self.descendants(of: ClosureExprSyntax.self, in: Parser.parse(source: source)).first
+        )
+        let inferrer = PurityInferrer()
+        #expect(inferrer.isPure(closure) == false)
+        #expect(inferrer.mutatesCapturedState(closure) == false)
+    }
+
+    /// The forwarder answers what the shared oracle answers.
+    ///
+    /// `SwiftProjectLintVisitors.PurityInferrer` restates SEI's members rather than aliasing the
+    /// type, so each one is a hand-written call that can be wired to the wrong thing. This is the
+    /// module-boundary check, not a re-test of the predicate — SEI owns that.
+    @Test
+    func theForwarderAgreesWithTheSharedOracle() {
+        let tree = Parser.parse(source: """
+        items.forEach { item in total += item.amount }
+        let children = files.filter { file in file.path.hasPrefix(currentPath) }
+        let totals = groups.map { group in group.values.reduce(into: 0) { acc, v in acc += v } }
+        """)
+        let closures = Self.descendants(of: ClosureExprSyntax.self, in: tree)
+        let mutates = closures.map { PurityInferrer().mutatesCapturedState($0) }
+
+        // The captured write, the read-only capture, and — since the pin this landed on — a nested
+        // `reduce(into:)` accumulator, whose parameter is a local and not a capture.
+        #expect(mutates.first == true)
+        #expect(mutates.dropFirst().contains(true) == false)
+    }
+
     /// A concrete anchor for the agreement, on the shape the contract is about: a closure passed to
     /// an escaping-by-policy callee, and one that is an ordinary `map`.
     @Test


### PR DESCRIPTION
The prerequisite the `unreachable-effect-closure` design doc named for itself. Downstream half of
[SwiftEffectInference#6](https://github.com/Joseph-Cursio/SwiftEffectInference/pull/6), which
published `PurityInferrer.mutatesCapturedState(_ closure:)`.

No rule is implemented here — this makes the predicate reachable and records that condition 2 has
nothing left to build.

## What changed

1. **Pins bumped to `fc82ec4`** across all three manifests, as `SEIPinAgreementTests` requires.
2. **`mutatesCapturedState(_ closure:)` forwarded** on `SwiftProjectLintVisitors.PurityInferrer`,
   alongside the existing members. `CaptureMutationChecker` stays private upstream; only the verdict
   crossed the boundary.
3. **Design doc's Feasibility section rewritten** from "here is what this would cost" to what is
   available, plus the two findings from doing it.

## Why a separate member rather than inverting `isPure`

`isPure(_ closure:)` folds four refuters into one Bool and three are unrelated to captures.
`{ print(x) }` is impure and mutates nothing. `theCaptureClauseIsIndependentOfTheOtherRefuters`
drives that with one closure per unrelated clause — marker, nondeterminism, partiality — asserting
impure-and-capture-free on each.

## What a reviewer should scrutinise

- **The SEI audit found a real bug**, fixed upstream: nested closures' parameters weren't counted as
  locals though their `let`/`var` were, so a nested `reduce(into:) { acc, x in acc += x }` read as a
  captured write — the exact case this rule's refutation list says must not fire. It measured as a
  **no-op on both corpora** (SwiftProjectLint 10 → 10, SwiftInferProperties 250 → 250
  `pure-closure-candidate` findings), so nothing changes for the pure sibling. Worth confirming you
  agree that fix belonged upstream rather than as a local filter.
- **The flat bound-name set** is the remaining hole and is now written into the doc: scopes aren't
  tracked, so a captured write to `total` goes unrecorded if an unrelated nested closure also binds
  a `total`. Errs toward silence, which suits a positive-claim rule, but it is a real limit.
- **`Package.resolved` is gitignored here**, so only the manifests move. That matches what
  `SEIPinAgreementTests` deliberately parses — manifest text, not resolved state.

Full suite green: 3222 tests, clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUZfgeKNsoL9GgCVVnuB8n