### PR TITLE
Implement unreachable-effect-closure

### DIFF
--- a/Docs/rules/RULES.md
+++ b/Docs/rules/RULES.md
@@ -264,6 +264,7 @@ Rules marked **opt-in** are disabled by default and must be explicitly listed un
 | [Impure Call in View Body](impure-call-in-view-body.md) | Warning |
 | [ViewHosting Before Inspection](view-hosting-before-inspection.md) | Error |
 | [Observable Environment View Missing Inspection Hook](observable-environment-view-missing-inspection-hook.md) | Info |
+| [Unreachable Effect Closure](unreachable-effect-closure.md) | Info |
 
 ---
 

--- a/Docs/rules/unreachable-effect-closure.md
+++ b/Docs/rules/unreachable-effect-closure.md
@@ -1,0 +1,89 @@
+[← Back to Rules](RULES.md)
+
+## Unreachable Effect Closure
+
+**Identifier:** `Unreachable Effect Closure`
+**Category:** Testability
+**Severity:** Info
+
+### Rationale
+
+**An inline closure cannot be tested.** Not *is hard to test* — cannot. There is no name to call, no signature to satisfy, no seam to reach it through.
+
+[Pure Closure Property-Test Candidate](pure-closure-candidate.md) opens with that argument and then narrows to *pure* closures, refuting anything that writes to what it captured. For a property-test seed that refutal is correct: you cannot generate inputs for a closure whose job is a side effect.
+
+But the unreachability claim never depended on purity. The refutal is scoped to the wrong conclusion — it should refuse *property-test candidacy*, not refuse *extraction*. This rule is the other half: a closure that **writes to captured state**, is **registered as a callback** rather than called inline, and therefore has no seam through which any test can observe its effect.
+
+For effectful closures the argument is stronger, not weaker. A silent regression in a side effect on shared state is precisely what a test exists to catch.
+
+```swift
+// Before — nothing can reach these
+.onContinuousHover { phase in
+    switch phase {
+    case .active(let location):
+        viewport.hoveredNodeId = hitNode(at: location)?.id
+    case .ended:
+        viewport.hoveredNodeId = nil
+    }
+}
+.onKeyPress(.escape) {
+    viewport.selectedNodeId = nil
+    return .handled
+}
+
+// After — the effect has a name a test can invoke
+.onContinuousHover { updateHover($0) }
+.onKeyPress(.escape) { clearSelection() }
+
+func updateHover(_ phase: HoverPhase) { … }
+func clearSelection() -> KeyPress.Result { … }
+```
+
+Measured in SwiftUMLStudio (`NativeDiagramView`, `NativeSequenceDiagramView`), both files sat at **0% coverage**: `ImageRenderer` drives a real draw pass but never fires gestures or key presses, and ViewInspector cannot traverse those views at all — their bodies are `GeometryReader`s. After extraction, three real contracts became assertable: tapping empty canvas clears the selection, the pointer leaving the canvas clears the hover highlight, and an arrow key on an empty graph returns `.ignored` rather than being swallowed. None could be stated as a test before; all three are one careless edit from regressing.
+
+### Discussion
+
+`UnreachableEffectClosureVisitor` reports a `ClosureExprSyntax` when all three hold.
+
+**1. Registered, not called.** Two surfaces, matched by an explicit allowlist:
+
+- **View modifiers** — `onTapGesture`, `onLongPressGesture`, `onKeyPress`, `onContinuousHover`, `onHover`, `onChange`, `onSubmit`, `onDrag`, `onDrop`, and the gesture callbacks `onEnded` / `onChanged` / `updating`.
+- **`Button` actions** — a `DeclReferenceExprSyntax` call rather than a member access, so it needs its own arm. Which closure is the action depends on the spelling: an explicit `action:` argument wins when present, because in `Button(action: { … }) { Text("Go") }` the *trailing* closure is the label, a `@ViewBuilder` and not a callback at all.
+
+The allowlist is deliberate. Inferring "any trailing closure on a member access in a view body" would sweep in `Toggle`, `ForEach` and every custom view builder. **Prefer under-reporting**: an unlisted modifier is a missed finding, while a wrong inference is a finding the reader has to argue with. The cost is that the list drifts behind SwiftUI.
+
+**2. Effectful on captured state.** The body assigns to something rooted in a capture rather than a parameter or a local. This consumes `PurityInferrer.mutatesCapturedState(_:)` from SwiftEffectInference — the same verdict [Pure Closure Property-Test Candidate](pure-closure-candidate.md) uses to *refute*, asked for the opposite purpose, so the two rules cannot disagree about what a captured write is.
+
+Note that inverting `isPure` would **not** work: it folds four refuters into one Bool, and three of them have nothing to do with captures. `{ print(x) }` is impure and mutates no capture.
+
+**3. Not already extracted.** The body is more than a single call expression.
+
+This is what makes the rule converge. `.onKeyPress(.escape) { clearSelection() }` is the *fixed* form; reporting it would mean the advice can never be satisfied, and a rule that cannot be satisfied gets switched off. A body that is exactly one `FunctionCallExprSyntax` — optionally `return`ed — is already a named seam, and an empty body has nothing to extract.
+
+A single **assignment** is not a call and does report. That asymmetry with `{ clear() }` is deliberate rather than an oversight: `{ selectedId = nil }` has no name either, and naming it is exactly the fix.
+
+### Refutations
+
+- **Single-call bodies** — the fixed form.
+- **Empty bodies** — nothing to extract.
+- **Read-only closures** — no captured write. That is the pure sibling's territory when pure, and nobody's when it merely reads.
+- **Local-only writes** — writes to a `var` declared inside the closure never escape, and neither do writes to a closure parameter, including an `inout` accumulator in a nested `reduce(into:)`.
+- **Test files** — the same skip the other testability visitors apply.
+- **`Button` bodies that are a single no-argument call** — [Button Closure Wrapping](button-closure-wrapping.md) owns that exact shape, and condition 3 already excludes it here, so the two cannot double-report.
+- **`onAppear` / `onDisappear`** — see below.
+
+### Interaction with other rules
+
+**[Impure Call in View Body](impure-call-in-view-body.md)** is why `onAppear` and `onDisappear` are absent from the allowlist. That rule's suggestion is *"move it out of `body` — an action / `onAppear` for effects"*, so listing `onAppear` here would hand a reader straight from that rule's fix into this rule's finding. Two rules passing someone back and forth is how a whole category gets disabled. The lifecycle modifiers are also usually one-liners, which condition 3 mostly refutes anyway, so the exclusion costs little.
+
+**[Could Be Private Member](could-be-private-member.md)** pulls the other way: the extracted method is called from one place in production, so it becomes a candidate for `private`. Empirically it does not misfire — a run against SwiftUMLStudio after the extraction above reported `could-be-private-member` 39 times project-wide and on none of the four extracted handlers, because the cross-file visitor counts the new test-file references as usages. The protection comes from usage counting rather than from that rule's property-test exemption, which is gated on a *pure* shape these handlers do not have.
+
+**[Button Closure Wrapping](button-closure-wrapping.md)** covers the complementary Button shape, as described in the refutations.
+
+### Known limitations
+
+The bound-name set backing condition 2 is **flat — scopes are not tracked**. A genuine captured write to `total` goes unrecorded if some unrelated nested closure also binds a `total`. That errs toward *not* reporting, which is the right direction for a rule making a positive claim, but it is a real hole.
+
+### Severity
+
+`Info`. This reports a refactor, not a defect — the code works, it is simply unobservable. Unlike its pure sibling it is **not** part of the collapsed candidate inventory, because that inventory means *property-test seeds* and this rule is definitionally not one; findings are listed in text output by default.

--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier+Category.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier+Category.swift
@@ -131,7 +131,7 @@ extension RuleIdentifier {
         case .globalMutableState, .nonInjectedNondeterminism, .pureFunctionCandidate,
              .pureClosureCandidate, .extractablePureKernel, .missingEquatableOnStateType,
              .impureCallInViewBody, .viewHostingBeforeInspection,
-             .observableEnvironmentViewMissingInspectionHook:
+             .observableEnvironmentViewMissingInspectionHook, .unreachableEffectClosure:
             return .testability
 
             // Other/System Rules

--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
@@ -238,6 +238,10 @@ public enum RuleIdentifier: String, CaseIterable, Codable, Sendable {
     /// so it cannot be inspected without trapping.
     case observableEnvironmentViewMissingInspectionHook = "Observable Environment View Missing Inspection Hook"
 
+    /// A closure registered as a callback that writes to what it captured — the
+    /// impure twin of `pureClosureCandidate`, which refutes exactly this shape.
+    case unreachableEffectClosure = "Unreachable Effect Closure"
+
     /// A value rebuilt field-by-field from one you already have, where the initialiser has
     /// defaulted parameters — so a forgotten field takes its default SILENTLY.
     case lossyStructRebuild = "Lossy Struct Rebuild"

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/Testability.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/Testability.swift
@@ -104,7 +104,8 @@ class Testability: BasePatternRegistrar {
         // Single-purpose-visitor rules get their own leaf registrars.
         registry.register(registrars: [
             MissingEquatableOnStateType(),
-            ImpureCallInViewBody()
+            ImpureCallInViewBody(),
+            UnreachableEffectClosure()
         ])
     }
 }

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/UnreachableEffectClosure.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/UnreachableEffectClosure.swift
@@ -1,0 +1,28 @@
+import Foundation
+import SwiftProjectLintModels
+import SwiftProjectLintRegistry
+import SwiftProjectLintVisitors
+
+/// Registrar for the Unreachable Effect Closure rule.
+///
+/// The impure twin of `pureClosureCandidate`. That rule refutes a closure that writes to what it
+/// captured — correctly, for a property-test seed — which leaves the effectful case reported by
+/// nobody, even though the unreachability argument applies to it just as well.
+struct UnreachableEffectClosure: PatternRegistrarProtocol {
+
+    var pattern: SyntaxPattern {
+        SyntaxPattern(
+            name: .unreachableEffectClosure,
+            visitor: UnreachableEffectClosureVisitor.self,
+            severity: .info,
+            category: .testability,
+            messageTemplate: "An effectful closure registered as a callback — no test can reach "
+                + "its effect",
+            suggestion: "Lift the body into a named method; the effect becomes assertable through "
+                + "the state it writes.",
+            description: "Surfaces closures registered on a SwiftUI callback — a view modifier or a "
+                + "Button action — that write to captured state. No test can fire the callback, so "
+                + "the effect has no seam to be observed through; naming it gives the effect one."
+        )
+    }
+}

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/UnreachableEffectClosureVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/UnreachableEffectClosureVisitor.swift
@@ -1,0 +1,224 @@
+import Foundation
+import SwiftProjectLintModels
+import SwiftProjectLintVisitors
+import SwiftSyntax
+
+/// The effect nobody can assert on.
+///
+/// `pureClosureCandidate` opens with the right argument — *an inline closure cannot be tested; there
+/// is no name to call and no seam to reach it through* — and then narrows to **pure** closures,
+/// refuting anything that writes to what it captured. For a property-test seed that refutal is
+/// correct: you cannot generate inputs for a closure whose job is a side effect.
+///
+/// But the unreachability claim never depended on purity. It is scoped to the wrong conclusion: it
+/// should refuse *property-test candidacy*, not refuse *extraction*. This rule is the other half —
+/// a closure that **writes to captured state**, is **registered as a callback** rather than called
+/// inline, and therefore has no seam through which any test can observe its effect. For effectful
+/// closures the argument is stronger, not weaker: a silent regression in a side effect on shared
+/// state is exactly what a test exists to catch.
+///
+///     .onKeyPress(.escape) {
+///         viewport.selectedNodeId = nil
+///         return .handled
+///     }
+///
+/// Nothing can reach that. `ImageRenderer` drives a real draw pass but never fires key presses, and
+/// ViewInspector cannot traverse a view whose body is a `GeometryReader`. Give the body a name and
+/// "escape clears the selection" becomes a sentence a test can state.
+///
+/// **The suggestion is deliberately not `pureClosureCandidate`'s.** That rule says *its captures
+/// become parameters*, which is wrong here — the mutation target stays captured. What changes is
+/// that the *effect* acquires a name a test can invoke.
+///
+/// `info` severity. Reports a refactor, not a defect: the code works, it is simply unobservable.
+final class UnreachableEffectClosureVisitor: BasePatternVisitor {
+
+    private var fileIsTestOrFixture = false
+    private let purityInferrer = PurityInferrer()
+
+    required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
+        super.init(pattern: pattern, viewMode: viewMode)
+    }
+
+    override func setFilePath(_ filePath: String) {
+        super.setFilePath(filePath)
+        fileIsTestOrFixture = isTestOrFixtureFile()
+    }
+
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        guard !fileIsTestOrFixture,
+              let surface = CallbackSurface(call: node),
+              let closure = surface.callbackClosure(in: node),
+              isWorthExtracting(closure),
+              purityInferrer.mutatesCapturedState(closure) else {
+            return .visitChildren
+        }
+
+        addIssue(
+            severity: .info,
+            message: "The closure registered on `\(surface.name)` writes to captured state — "
+                + "no test can reach its effect.",
+            filePath: getFilePath(for: Syntax(closure)),
+            lineNumber: getLineNumber(for: Syntax(closure)),
+            suggestion: "Lift the body into a named method; the effect becomes assertable through "
+                + "the state it writes.",
+            ruleName: .unreachableEffectClosure,
+            symbol: enclosingDeclarationName(of: node) ?? surface.name
+        )
+        return .visitChildren
+    }
+
+    /// Condition 3 — the body is more than a single call, so there is something to name.
+    ///
+    /// **This is what makes the rule converge**, and it is not a nicety. `.onKeyPress(.escape) {
+    /// clearSelection() }` is the *fixed* form: reporting it would mean the rule fires forever on
+    /// code that has already taken its advice, and a rule that cannot be satisfied gets switched
+    /// off. A body that is exactly one `FunctionCallExprSyntax` — optionally `return`ed — is already
+    /// a named seam, and an empty body has nothing to extract.
+    ///
+    /// A single *assignment* is not a call and does report. That is deliberate: `{ selectedId = nil
+    /// }` has no name either, and naming it is exactly the fix. The asymmetry with `{ clear() }` is
+    /// the point rather than an oversight — one has a seam, the other does not.
+    private func isWorthExtracting(_ closure: ClosureExprSyntax) -> Bool {
+        let statements = closure.statements
+        guard let only = statements.first, statements.count == 1 else {
+            return !statements.isEmpty
+        }
+        return !isSingleCall(only)
+    }
+
+    /// A statement that is exactly one call expression, with or without `return`.
+    private func isSingleCall(_ statement: CodeBlockItemSyntax) -> Bool {
+        let expression: ExprSyntax?
+        switch statement.item {
+        case .expr(let expr):
+            expression = expr
+
+        case .stmt(let stmt):
+            expression = stmt.as(ReturnStmtSyntax.self)?.expression
+
+        case .decl:
+            expression = nil
+        }
+        return expression?.is(FunctionCallExprSyntax.self) ?? false
+    }
+
+    /// The declaration the closure is registered inside — the view's `body`, usually.
+    ///
+    /// A location rather than a subject, on the same terms `pureClosureCandidate` uses: the finding
+    /// *is* a closure, so by definition it has no name of its own. `onTapGesture` names the
+    /// operation, not the code, and every tap handler in a project would share it.
+    private func enclosingDeclarationName(of node: some SyntaxProtocol) -> String? {
+        var parent = node.parent
+        while let current = parent {
+            if let function = current.as(FunctionDeclSyntax.self) {
+                return function.name.text
+            }
+            if let variable = current.as(VariableDeclSyntax.self),
+               variable.parent?.is(MemberBlockItemSyntax.self) ?? false {
+                return variable.bindings
+                    .lazy
+                    .compactMap { $0.pattern.as(IdentifierPatternSyntax.self)?.identifier.text }
+                    .first
+            }
+            parent = current.parent
+        }
+        return nil
+    }
+}
+
+/// Where a callback closure is registered — condition 1, as two shapes rather than one.
+///
+/// Deliberately an allowlist rather than "any trailing closure on a member access in a view body".
+/// That inference would sweep in `Toggle`, `ForEach` and every custom `@ViewBuilder`, none of which
+/// register a callback. **Prefer under-reporting**: an unlisted modifier is a missed finding, while
+/// a wrong inference is a finding the reader has to argue with. The cost is that the list drifts
+/// behind SwiftUI, which is the maintenance this rule signs up for.
+enum CallbackSurface {
+
+    /// A view modifier — `.onTapGesture { … }`. A `MemberAccessExprSyntax` call.
+    case modifier(String)
+
+    /// A `Button`'s action. A `DeclReferenceExprSyntax` call, so the modifier match cannot see it,
+    /// and it needs its own arm.
+    ///
+    /// In scope despite `buttonClosureWrapping` also looking at `Button`: that rule fires only on a
+    /// body that is a *single no-argument call*, which is exactly the shape `isWorthExtracting`
+    /// already excludes. The two cannot collide. Leaving `Button` out would have waived every
+    /// multi-statement action — `Button { count += 1; save() }` — with nothing else reporting it.
+    case buttonAction
+
+    /// The SwiftUI callback surface, as an explicit list.
+    ///
+    /// `onAppear` / `onDisappear` are **deliberately absent**. `impureCallInViewBody`'s own
+    /// suggestion is *"move it out of `body` — an action / `onAppear` for effects"*, so listing
+    /// `onAppear` here would hand a reader straight from that rule's fix into this rule's finding.
+    /// Two rules passing someone back and forth is how a whole category gets disabled. They are also
+    /// usually one-liners, which condition 3 mostly refutes anyway, so the exclusion costs little.
+    private static let modifiers: Set<String> = [
+        "onTapGesture", "onLongPressGesture", "onKeyPress", "onContinuousHover", "onHover",
+        "onChange", "onSubmit", "onDrag", "onDrop",
+        // Gesture callbacks.
+        "onEnded", "onChanged", "updating"
+    ]
+
+    init?(call: FunctionCallExprSyntax) {
+        if let member = call.calledExpression.as(MemberAccessExprSyntax.self),
+           Self.modifiers.contains(member.declName.baseName.text) {
+            self = .modifier(member.declName.baseName.text)
+            return
+        }
+        if let reference = call.calledExpression.as(DeclReferenceExprSyntax.self),
+           reference.baseName.text == "Button" {
+            self = .buttonAction
+            return
+        }
+        return nil
+    }
+
+    var name: String {
+        switch self {
+        case .modifier(let name):
+            return name
+
+        case .buttonAction:
+            return "Button"
+        }
+    }
+
+    /// The closure that actually runs on the callback.
+    ///
+    /// For a modifier that is the trailing closure, or the first closure argument when it is written
+    /// in parenthesised form.
+    ///
+    /// `Button` needs more care, because which closure is the *action* depends on the spelling. In
+    /// `Button(action: { … }) { Text("Go") }` the trailing closure is the **label** — a
+    /// `@ViewBuilder`, not a callback — and reporting it would be a false finding. So an explicit
+    /// `action:` argument wins whenever it is present; only otherwise is the first trailing closure
+    /// the action, which covers `Button("Title") { … }` and `Button { … } label: { … }`.
+    func callbackClosure(in call: FunctionCallExprSyntax) -> ClosureExprSyntax? {
+        switch self {
+        case .modifier:
+            return call.trailingClosure ?? Self.firstClosureArgument(of: call)
+
+        case .buttonAction:
+            return Self.argument(labelled: "action", of: call) ?? call.trailingClosure
+        }
+    }
+
+    private static func firstClosureArgument(of call: FunctionCallExprSyntax) -> ClosureExprSyntax? {
+        call.arguments.lazy
+            .compactMap { $0.expression.as(ClosureExprSyntax.self) }
+            .first
+    }
+
+    private static func argument(
+        labelled label: String,
+        of call: FunctionCallExprSyntax
+    ) -> ClosureExprSyntax? {
+        call.arguments.lazy
+            .filter { $0.label?.text == label }
+            .compactMap { $0.expression.as(ClosureExprSyntax.self) }
+            .first
+    }
+}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Many of these rules exist just so I can explore the effects. Some rules are bad 
 
 # Swift Project Linter
 
-A static analysis tool for SwiftUI projects that detects architectural issues, performance problems, and code quality concerns. Parses Swift source files using SwiftSyntax AST visitors to identify anti-patterns across 200 rules in 13 categories.
+A static analysis tool for SwiftUI projects that detects architectural issues, performance problems, and code quality concerns. Parses Swift source files using SwiftSyntax AST visitors to identify anti-patterns across 201 rules in 13 categories.
 
 The origin of this project began with a limitation of SwiftLint: it processes a single file at a time and cannot identify cross-file issues.
 
@@ -18,7 +18,7 @@ Motivating example: I was watching the "Quality Coding" channel on YouTube. Jon 
 
 - **SwiftSyntax AST Analysis**: Precise, AST-based pattern detection — no regex
 - **Cross-File Analysis**: Detects issues spanning multiple files (duplicate state, view hierarchies)
-- **200 Lint Rules** across 13 categories
+- **201 Lint Rules** across 13 categories
 - **Three delivery targets**: macOS app GUI, CLI for CI/CD, and a reusable Core library
 - **YAML configuration**: `.swiftprojectlint.yml` for per-project rule customization
 - **Inline suppression**: `// swiftprojectlint:disable` comments for per-line control
@@ -49,7 +49,7 @@ swift run CLI /path/to/project --categories stateManagement,performance --thresh
 
 ## Rules
 
-200 rules across 13 categories. See [Docs/rules/RULES.md](Docs/rules/RULES.md) for the full reference.
+201 rules across 13 categories. See [Docs/rules/RULES.md](Docs/rules/RULES.md) for the full reference.
 
 | Category | Rules |
 |----------|-------|
@@ -65,7 +65,7 @@ swift run CLI /path/to/project --categories stateManagement,performance --thresh
 | UI Patterns | 7 |
 | Modernization | 25 |
 | Idempotency | 7 |
-| Testability | 9 |
+| Testability | 10 |
 
 Rules marked **opt-in** are disabled by default and must be explicitly listed under `enabled_only` in `.swiftprojectlint.yml`.
 

--- a/Tests/CoreTests/Testability/UnreachableEffectClosureVisitorTests.swift
+++ b/Tests/CoreTests/Testability/UnreachableEffectClosureVisitorTests.swift
@@ -1,0 +1,286 @@
+@testable import Core
+import Foundation
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+/// Drives the visitor over `source` and returns just this rule's findings.
+///
+/// At file scope for the same reason `PureClosureCandidateVisitorTests` does it: the suite's only
+/// helper, kept out of the type so `type_body_length` has room as tests accumulate.
+private func analyze(_ source: String, filePath: String = "ContentView.swift") -> [LintIssue] {
+    let visitor = UnreachableEffectClosureVisitor(patternCategory: .testability)
+    let syntax = Parser.parse(source: source)
+    visitor.setSourceLocationConverter(
+        SourceLocationConverter(fileName: filePath, tree: syntax)
+    )
+    visitor.setFilePath(filePath)
+    visitor.walk(syntax)
+    return visitor.detectedIssues.filter { $0.ruleName == .unreachableEffectClosure }
+}
+
+/// The effect nobody can assert on.
+///
+/// `pureClosureCandidate` argues from **reachability** — an inline closure has no name to call and
+/// no seam to reach it through — and then narrows to pure closures, refuting anything that writes to
+/// what it captured. Right for a property-test seed, wrong as a conclusion about extraction: the
+/// unreachability claim never depended on purity. This rule covers what falls through.
+///
+/// The measured case is SwiftUMLStudio's `NativeDiagramView`, where hover and key-press handlers
+/// wrote to a captured `viewport` and sat at 0% coverage — `ImageRenderer` never fires gestures, and
+/// ViewInspector cannot traverse a body that is a `GeometryReader`.
+@Suite("Effectful callback closures are unreachable")
+struct UnreachableEffectClosureVisitorTests {
+
+    // MARK: - The motivating case
+
+    @Test("a key-press handler writing captured state is reported")
+    func keyPressWritingCaptureIsReported() {
+        let issues = analyze("""
+        struct DiagramView: View {
+            var body: some View {
+                canvas.onKeyPress(.escape) {
+                    viewport.selectedNodeId = nil
+                    return .handled
+                }
+            }
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("onKeyPress") == true)
+        #expect(issues.first?.severity == .info)
+    }
+
+    @Test("a hover handler writing captured state is reported")
+    func hoverWritingCaptureIsReported() {
+        let issues = analyze("""
+        struct DiagramView: View {
+            var body: some View {
+                canvas.onContinuousHover { phase in
+                    switch phase {
+                    case .active(let location):
+                        viewport.hoveredNodeId = hitNode(at: location)?.id
+                    case .ended:
+                        viewport.hoveredNodeId = nil
+                    }
+                }
+            }
+        }
+        """)
+        #expect(issues.count == 1)
+    }
+
+    @Test("the finding names the enclosing declaration, since a closure has no name of its own")
+    func findingNamesTheEnclosingDeclaration() {
+        let issues = analyze("""
+        struct DiagramView: View {
+            var body: some View {
+                canvas.onTapGesture {
+                    selectedId = nil
+                    lastTapCount += 1
+                }
+            }
+        }
+        """)
+        #expect(issues.first?.symbol == "body")
+    }
+
+    @Test("the suggestion is not the pure sibling's — captures do not become parameters here")
+    func suggestionDiffersFromThePureSibling() {
+        let issues = analyze("""
+        view.onTapGesture {
+            selectedId = nil
+            count += 1
+        }
+        """)
+        let suggestion = issues.first?.suggestion ?? ""
+        #expect(suggestion.contains("named method"))
+        #expect(suggestion.contains("becomes a parameter") == false)
+    }
+
+    // MARK: - Convergence (condition 3)
+
+    @Test("the fixed form is not reported — otherwise the rule fires forever")
+    func singleCallBodyIsNotReported() {
+        // `.onKeyPress(.escape) { clearSelection() }` is what acting on this rule produces. Report
+        // it and the advice can never be satisfied, which is how a rule gets switched off.
+        #expect(analyze("view.onKeyPress(.escape) { clearSelection() }").isEmpty)
+    }
+
+    @Test("a returned single call is the fixed form too")
+    func returnedSingleCallIsNotReported() {
+        #expect(analyze("view.onKeyPress(.escape) { return clearSelection() }").isEmpty)
+    }
+
+    @Test("an empty body has nothing to extract")
+    func emptyBodyIsNotReported() {
+        #expect(analyze("view.onTapGesture { }").isEmpty)
+    }
+
+    @Test("a single assignment IS reported — it has no name either")
+    func singleAssignmentIsReported() {
+        // The deliberate asymmetry with `{ clear() }`: one has a seam, the other does not. Naming
+        // it is exactly the fix this rule asks for.
+        #expect(analyze("view.onTapGesture { selectedId = nil }").count == 1)
+    }
+
+    // MARK: - Refutations
+
+    @Test("a read-only closure is not this rule's business")
+    func readOnlyClosureIsNotReported() {
+        #expect(analyze("""
+        view.onTapGesture {
+            logger.debug("tapped \\(selectedId)")
+            report(selectedId)
+        }
+        """).isEmpty)
+    }
+
+    @Test("writes to the closure's own locals never escape")
+    func localOnlyWritesAreNotReported() {
+        #expect(analyze("""
+        view.onTapGesture {
+            var count = 0
+            count += 1
+            print(count)
+        }
+        """).isEmpty)
+    }
+
+    @Test("a nested reduce(into:) accumulator is a local, not a capture")
+    func nestedAccumulatorIsNotReported() {
+        // The case the SEI pin this rule landed on exists to get right: `total` is the inner
+        // closure's own parameter. Before that fix this reported, contradicting the rule's own
+        // refutation list.
+        #expect(analyze("""
+        view.onTapGesture {
+            let sum = values.reduce(into: 0) { total, value in total += value }
+            print(sum)
+        }
+        """).isEmpty)
+    }
+
+    @Test("test files are skipped")
+    func testFilesAreSkipped() {
+        #expect(analyze("""
+        view.onTapGesture {
+            selectedId = nil
+            count += 1
+        }
+        """, filePath: "DiagramViewTests.swift").isEmpty)
+    }
+
+    // MARK: - The allowlist (condition 1)
+
+    @Test("onAppear and onDisappear are deliberately absent")
+    func lifecycleModifiersAreNotReported() {
+        // `impureCallInViewBody` tells a reader to move effects INTO `onAppear`. Reporting it here
+        // would hand them straight back, and two rules passing someone back and forth is how a
+        // category gets disabled.
+        for modifier in ["onAppear", "onDisappear"] {
+            #expect(analyze("""
+            view.\(modifier) {
+                isLoaded = true
+                count += 1
+            }
+            """).isEmpty)
+        }
+    }
+
+    @Test("an unlisted modifier is a missed finding, not an inferred one")
+    func unlistedModifierIsNotReported() {
+        // Prefer under-reporting. Inferring "any trailing closure on a member access" would sweep
+        // in every custom view builder.
+        #expect(analyze("""
+        view.onReceive(timer) {
+            tick += 1
+            lastTick = Date()
+        }
+        """).isEmpty)
+    }
+
+    @Test("a ViewBuilder closure is not a callback")
+    func viewBuilderClosureIsNotReported() {
+        #expect(analyze("""
+        ForEach(rows) { row in
+            rendered = row
+            total += 1
+        }
+        """).isEmpty)
+    }
+
+    @Test("gesture callbacks count")
+    func gestureCallbacksAreReported() {
+        #expect(analyze("""
+        DragGesture().onChanged { value in
+            offset = value.translation
+            isDragging = true
+        }
+        """).count == 1)
+    }
+
+    // MARK: - Button, the second surface
+
+    @Test("a multi-statement Button action is reported")
+    func multiStatementButtonActionIsReported() {
+        // The widening past the original proposal. `buttonClosureWrapping` owns only the
+        // single-call form, so without this arm nothing reports the common case.
+        let issues = analyze("""
+        Button("Save") {
+            count += 1
+            save()
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Button") == true)
+    }
+
+    @Test("a single-call Button action belongs to buttonClosureWrapping")
+    func singleCallButtonActionIsNotReported() {
+        // The two rules cannot collide: that one fires only on this shape, which condition 3
+        // already excludes here.
+        #expect(analyze("""
+        Button("Save") { save() }
+        """).isEmpty)
+    }
+
+    @Test("the label closure is not mistaken for the action")
+    func buttonLabelIsNotMistakenForTheAction() {
+        // `Button(action:) { label }` puts a @ViewBuilder in the trailing position. Reading the
+        // trailing closure blindly would report the label, which is not a callback at all.
+        let issues = analyze("""
+        Button(action: { save() }) {
+            Text(title)
+            Image(systemName: icon)
+        }
+        """)
+        #expect(issues.isEmpty)
+    }
+
+    @Test("the action is found through an explicit action: label")
+    func explicitActionArgumentIsReported() {
+        let issues = analyze("""
+        Button(action: {
+            count += 1
+            save()
+        }) {
+            Text(title)
+        }
+        """)
+        #expect(issues.count == 1)
+    }
+
+    @Test("the trailing-action form with a label: closure is reported")
+    func trailingActionWithLabelClosureIsReported() {
+        let issues = analyze("""
+        Button {
+            count += 1
+            save()
+        } label: {
+            Text(title)
+        }
+        """)
+        #expect(issues.count == 1)
+    }
+}


### PR DESCRIPTION
Implements the rule designed in `Docs/design/unreachable-effect-closure-rule-design.md` (#87, #88),
on the SEI predicate published in #90. 21 new tests; full suite green at 3243.

## The rule

`pure-closure-candidate` argues from **reachability** — an inline closure has no name to call and no
seam to reach it through — then narrows to *pure* closures and refutes anything that writes to what
it captured. Right for a property-test seed, wrong as a conclusion about extraction. This reports
what fell through: a closure that writes to captured state, is registered as a callback, and so has
no seam through which any test can observe its effect.

- **Condition 1** — two surfaces by explicit allowlist: view modifiers, and `Button` actions.
- **Condition 2** — `PurityInferrer.mutatesCapturedState(_:)`, the same verdict the pure sibling uses
  to refute. The two cannot disagree about what a captured write is.
- **Condition 3** — more than a single call. This is what makes it converge; reporting the fixed form
  would mean the advice can never be satisfied.

## Road test: 35 findings, no false positives

| corpus | total | Button | modifiers |
|---|---|---|---|
| `Sources/App` (this repo) | 7 | 7 | 0 |
| SwiftLintRuleStudio | 28 | 24 | 2 `onHover`, 2 `onChange` |

Every one inspected is a true positive. The best of them is
`RuleBrowserView.swift:61` — *"clear the selection when the selected rule falls out of the filter"* —
a real conditional contract with no seam, which is exactly the rule's thesis.

**This answers the design doc's open question 4.** Button is 86% of volume, so the scope widening
agreed in #88 carries almost the whole rule; a modifiers-only v1 would have found 2 things in a real
GUI app. The modifier arm does fire in the wild, just rarely.

Volume is nowhere near `pure-closure-candidate`'s 208, so the doc's recommendation stands: this does
**not** join `CandidateInventory.inventoryRules`, and findings list by default at `.info`.

## What a reviewer should scrutinise

- **The single-assignment asymmetry.** `{ selectedId = nil }` reports, `{ clear() }` does not. It
  follows from condition 3 as designed — one has a seam, the other doesn't — and it fired in practice
  (`Button("Select All") { enabledRuleNames = allRuleNames }`). Defensible, but it is the most
  arguable finding shape and the likeliest source of "this is noise" pushback.
- **Button action resolution.** `Button(action: { … }) { Text("Go") }` puts a `@ViewBuilder` in the
  trailing position; reading the trailing closure blindly would report the label. An explicit
  `action:` argument wins when present. Tested from both directions.
- **The flat bound-name set**, inherited from SEI: scopes aren't tracked, so a captured write to
  `total` goes unrecorded if an unrelated nested closure also binds a `total`. Errs toward silence.
  Documented under Known limitations.
- **One commit rather than several.** The repo's guards make the pieces atomic — an unregistered rule
  fails the doc-resolution and README-count tests, so no smaller unit is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUZfgeKNsoL9GgCVVnuB8n