### PR TITLE
Pin ViewInspector to the merged macOS 27 fix and lift the quarantine

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,14 @@ let package = Package(
         .package(path: "Packages/SwiftProjectLintConfig"),
         .package(path: "Packages/SwiftProjectLintEngine"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", exact: "602.0.0"),
-        .package(url: "https://github.com/nalexn/ViewInspector.git", from: "0.9.5"),
+        // Pinned to the exact commit that fixes ViewInspector on macOS 27
+        // (nalexn/ViewInspector#421, merged 2026-08-09). There is no 0.10.4 tag
+        // yet — 0.10.4 is the default branch — so a revision pin is the only way
+        // to get the fix reproducibly. Swap for `from:` once the tag lands.
+        .package(
+            url: "https://github.com/nalexn/ViewInspector.git",
+            revision: "6be008f348a757e7c0c6901c2dde983e5bba069f"
+        ),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
         .package(url: "https://github.com/x-sheep/swift-property-based.git", from: "1.0.0"),

--- a/Tests/AppTests/ContentViewActionsTests.swift
+++ b/Tests/AppTests/ContentViewActionsTests.swift
@@ -128,25 +128,7 @@ struct ContentViewActionsTests {
         #expect(buttons.count == 2)
     }
 
-    // ViewInspector 0.10.3 (the latest release) cannot read accessibility
-    // modifiers on macOS 27 beta (build 26A5388g). Its `accessibilityIdentifier()`
-    // takes the `#available(macOS 26.0, *)` branch, which reads
-    // `modifier|storage|value|properties|identifier|some|rawValue` off an
-    // `AccessibilityAttachmentModifier`; this SwiftUI lays that out differently,
-    // so every lookup throws `modifierNotFound`. Expected upstream lag against a
-    // beta OS — 0.10.3 predates it.
-    //
-    // Not specific to the modifier chain here: a bare
-    // `Button("Hi") {}.accessibilityIdentifier("x")` fails identically, as do
-    // `find(viewWithAccessibilityIdentifier:)` and `accessibilityLabel()`.
-    //
-    // The identifiers themselves are correct and present in
-    // `ContentViewActions.swift` (lines 25, 31, 38); only the test-time
-    // introspection is broken. Re-enable when ViewInspector ships support for
-    // this SwiftUI version. Runtime coverage for these identifiers lives in the
-    // XCUITest target (`Tests/UITests`), which reads the real accessibility tree.
-    @Test("accessibility identifiers are set correctly without directory",
-          .disabled("ViewInspector 0.10.3 cannot read accessibility modifiers on macOS 27 beta"))
+    @Test("accessibility identifiers are set correctly without directory")
     func accessibilityIdentifiersWithoutDirectory() throws {
         let view = ContentViewActions(
             selectedDirectory: "",
@@ -161,9 +143,7 @@ struct ContentViewActionsTests {
         #expect(identifiers.contains("mainActionButton"))
     }
 
-    // Disabled for the same reason as the test above.
-    @Test("accessibility identifiers are set correctly with directory",
-          .disabled("ViewInspector 0.10.3 cannot read accessibility modifiers on macOS 27 beta"))
+    @Test("accessibility identifiers are set correctly with directory")
     func accessibilityIdentifiersWithDirectory() throws {
         let view = ContentViewActions(
             selectedDirectory: "/some/path",


### PR DESCRIPTION
## What

Repoints ViewInspector from `from: "0.9.5"` (resolving to 0.10.3) to the exact revision `6be008f`, and re-enables the two quarantined accessibility tests in `ContentViewActionsTests`.

## Why

macOS 27 replaced `AccessibilityProperties`' named members with a generic `storage` array, so `accessibilityIdentifier()` and `accessibilityLabel()` threw `modifierNotFound` regardless of the view. Fixed upstream in [nalexn/ViewInspector#421](https://github.com/nalexn/ViewInspector/pull/421), **merged 2026-08-09**.

## Revision pin, not a version bump

There is **no `0.10.4` tag yet** — `0.10.4` is the repo's default branch, and `0.10.3` (September 2025) is still the newest release. A revision pin is the only way to get the fix reproducibly. Pinned to the commit rather than the branch so resolution doesn't drift with upstream's pre-release work; swap back to `from:` once the tag lands.

## No GeometryProxy preflight here — deliberately

The same upstream PR fixes a second, nastier break: a `GeometryProxy` `unsafeBitCast` that *traps* (killing the test process, not failing a test) on any traversal reaching a `GeometryReader`. Sibling repos get a preflight test for it.

**This repo isn't exposed.** The only `GeometryReader` mentions here are the `GeometryReaderOveruse` lint rule's own pattern strings — a linter describing SwiftUI, not using it. A preflight would guard nothing, so none is added.

## Verification

macOS 27.0 (26A5388g) — the full `AppTests` target passes: **184 tests in 24 suites**, including both re-enabled tests. `AppTests` is the only target that links ViewInspector, so that's the change's entire blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018X34yNf4b4wKZSctvdsCLd