### PR TITLE
Say so in the counts when a nested package was never analysed

### DIFF
--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/FileAnalysis/FileAnalysisUtils.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/FileAnalysis/FileAnalysisUtils.swift
@@ -87,6 +87,46 @@ public struct FileAnalysisUtils {
     /// exclude. The root's own `Package.swift` does not count. Returns on the first
     /// match and prunes build/checkout directories, so it never treats a third-party
     /// dependency checkout (e.g. under `.build`) as a first-party package.
+    /// The directory names of the first-party nested packages a default run excludes,
+    /// sorted, or `[]` when there are none.
+    ///
+    /// Same walk and same skip list as ``containsNestedPackage(in:)``, which stays as
+    /// the fast predicate: it returns on the first match, and every caller that only
+    /// needs to know *whether* to warn should keep using it. This one pays the full
+    /// enumeration to say WHICH packages, and is worth that only where the names are
+    /// going into a message — a reader who is told "excludes 1 nested package" still
+    /// has to go find out which, and on a repo with several the count alone does not
+    /// say whether the one they care about was in scope.
+    public static func nestedPackageNames(in path: String) -> [String] {
+        let fileManager = FileManager.default
+        let rootURL = URL(fileURLWithPath: path, isDirectory: true)
+        guard let enumerator = fileManager.enumerator(
+            at: rootURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: .skipsHiddenFiles
+        ) else {
+            return []
+        }
+
+        var names: Set<String> = []
+        for case let itemURL as URL in enumerator {
+            let isDirectory = (try? itemURL.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+            guard isDirectory else { continue }
+
+            if skippedDirectories.contains(itemURL.lastPathComponent) {
+                enumerator.skipDescendants()
+                continue
+            }
+            if fileManager.fileExists(atPath: itemURL.appendingPathComponent("Package.swift").path) {
+                names.insert(itemURL.lastPathComponent)
+                // A package's own subdirectories are inside it, not beside it; descending
+                // would report its vendored or example packages as separate skips.
+                enumerator.skipDescendants()
+            }
+        }
+        return names.sorted()
+    }
+
     public static func containsNestedPackage(in path: String) -> Bool {
         let fileManager = FileManager.default
         let rootURL = URL(fileURLWithPath: path, isDirectory: true)

--- a/Sources/CLI/SwiftProjectLintCLI.swift
+++ b/Sources/CLI/SwiftProjectLintCLI.swift
@@ -106,13 +106,30 @@ struct SwiftProjectLintCLI: AsyncParsableCommand {
             configuration: configuration
         )
 
-        print(Self.render(issues, format: format, selectedCategories: selectedCategories))
+        // Named once and used twice: the summary caveat on stdout and the fuller notice on
+        // stderr describe the same skip, so deriving them from one value keeps them from
+        // drifting into disagreeing about whether anything was excluded.
+        let skippedPackages = configuration.includeNestedPackages == false
+            ? FileAnalysisUtils.nestedPackageNames(in: absolutePath)
+            : []
+
+        print(Self.render(
+            issues,
+            format: format,
+            selectedCategories: selectedCategories,
+            skippedNestedPackages: skippedPackages
+        ))
 
         // Surface skipped scope: a clean-looking result is misleading if whole
         // first-party packages were never analyzed. Written to stderr so it never
         // contaminates machine-readable stdout (e.g. `--format json`).
-        if configuration.includeNestedPackages == false,
-           FileAnalysisUtils.containsNestedPackage(in: absolutePath) {
+        //
+        // The summary line now carries a short form of this on stdout as well, and both are
+        // wanted. Measured (#95): on a 730-line run this notice lands at line 698, after the
+        // count it qualifies, and `> file` keeps the count while dropping the caveat — so
+        // stderr alone reaches nobody reading the number. This one stays because it says
+        // more: that cross-file rules cannot span the boundary at all.
+        if !skippedPackages.isEmpty {
             Self.printToStandardError(Self.nestedPackagesSkippedNotice)
         }
 
@@ -154,17 +171,32 @@ struct SwiftProjectLintCLI: AsyncParsableCommand {
     ///
     /// Naming `testability` in `--categories` is the opt-in. Asking for the category is asking for
     /// its contents, so the listing comes back in full with no extra flag to discover.
+    /// `skippedNestedPackages` reaches only the text path, and that asymmetry is the same
+    /// rule the collapsing is: a JSON or CSV consumer must not have prose spliced into its
+    /// output, and `pbt-seeds` is parsed by `swift-infer`. A machine-readable channel wanting
+    /// this fact wants it as a FIELD, which is a separate change and belongs in the schema.
     static func render(
         _ issues: [LintIssue],
         format: OutputFormat,
-        selectedCategories: [PatternCategory]?
+        selectedCategories: [PatternCategory]?,
+        skippedNestedPackages: [String] = []
     ) -> String {
-        let requestedTestability = selectedCategories?.contains(.testability) ?? false
-        guard format == .text, !requestedTestability else {
+        guard format == .text else {
             return format.formatter.format(issues: issues)
         }
+        // `--categories testability` skips the collapsing but NOT the caveat. It is the
+        // request that asks to see the candidate inventory in full, which makes it the
+        // reading most distorted by a package having been left out — the earlier shape of
+        // this guard sent it through the bare `format.formatter` and dropped the caveat on
+        // exactly that path.
+        guard !(selectedCategories?.contains(.testability) ?? false) else {
+            return TextFormatter(skippedNestedPackages: skippedNestedPackages)
+                .format(issues: issues)
+        }
         let split = CandidateInventory.split(issues, collapsing: true)
-        return TextFormatter(withheld: split.withheld).format(issues: split.listed)
+        return TextFormatter(
+            withheld: split.withheld, skippedNestedPackages: skippedNestedPackages
+        ).format(issues: split.listed)
     }
 
     private static func printToStandardError(_ message: String) {

--- a/Sources/Core/Export/TextFormatter.swift
+++ b/Sources/Core/Export/TextFormatter.swift
@@ -11,8 +11,39 @@ public struct TextFormatter: IssueFormatterProtocol {
     /// designing against. The count covers everything; only the enumeration is shortened.
     private let withheld: [LintIssue]
 
-    public init(withheld: [LintIssue] = []) {
+    /// Nested first-party packages this run did NOT analyse, by directory name.
+    ///
+    /// The same reasoning as `withheld` one level up. `withheld` keeps the summary honest
+    /// about issues we counted but did not print; this keeps it honest about files we never
+    /// read at all — a strictly worse silence, because no flag on the enumeration brings
+    /// them back, only re-running with `--include-nested-packages`.
+    ///
+    /// Measured on SwiftFormatRuleStudio (issue #95): a default run reported
+    /// `Found 405 issues` and `44 of these are property-test candidates` over the app
+    /// target alone, while the nested `SwiftFormatRuleStudioCore` — the library, and where
+    /// every interesting subject lived — contributed **nothing**. With the flag the
+    /// candidate count is 131. The stderr notice said so and lost the placement fight:
+    /// line 698 of 730, after 405 issues had scrolled past, on a stream that `> file`
+    /// leaves behind.
+    private let skippedNestedPackages: [String]
+
+    public init(withheld: [LintIssue] = [], skippedNestedPackages: [String] = []) {
         self.withheld = withheld
+        self.skippedNestedPackages = skippedNestedPackages
+    }
+
+    /// The scope caveat appended to any count this formatter prints, or `""` when the run
+    /// covered everything.
+    ///
+    /// Deliberately on EVERY count rather than once at the end: the two numbers get quoted
+    /// separately — an issue total into a CI summary, the candidate total into a decision
+    /// about what to property-test — and a caveat that travels with only one of them is a
+    /// caveat the other reader never sees.
+    private var scopeCaveat: String {
+        guard !skippedNestedPackages.isEmpty else { return "" }
+        let names = skippedNestedPackages.joined(separator: ", ")
+        let noun = skippedNestedPackages.count == 1 ? "package" : "packages"
+        return " — excludes nested \(noun) \(names); re-run with --include-nested-packages"
     }
 
     /// Formats a list of lint issues as text lines.
@@ -56,7 +87,7 @@ public struct TextFormatter: IssueFormatterProtocol {
         return [
             "",
             "\(withheld.count) of these are property-test candidates, not listed above "
-                + "(\(breakdown)).",
+                + "(\(breakdown))\(scopeCaveat).",
             "  They are an inventory of what COULD be property-tested — a pure function is not a "
                 + "defect, and there is nothing to fix per line.",
             "  See them:  --categories testability",
@@ -84,10 +115,13 @@ public struct TextFormatter: IssueFormatterProtocol {
 
         let total = issues.count
         if total == 0 {
-            return "No issues found."
+            // The caveat matters MOST here. "No issues found." over a repo whose library was
+            // never opened is the confident zero this project designs against, and it is the
+            // one line a reader is least likely to go looking behind.
+            return "No issues found.\(scopeCaveat)"
         }
 
         let detail = parts.joined(separator: ", ")
-        return "Found \(total) \(total == 1 ? "issue" : "issues") (\(detail))"
+        return "Found \(total) \(total == 1 ? "issue" : "issues") (\(detail))\(scopeCaveat)"
     }
 }

--- a/Tests/CLITests/CandidateInventoryTests.swift
+++ b/Tests/CLITests/CandidateInventoryTests.swift
@@ -123,6 +123,46 @@ struct CandidateInventoryTests {
         #expect(output.contains("not listed above"))
     }
 
+    // MARK: - Skipped scope reaches every text reading (#95)
+
+    @Test("the collapsed text summary carries the skipped-scope caveat")
+    func collapsedTextCarriesCaveat() {
+        let output = SwiftProjectLintCLI.render(
+            corpus(), format: .text, selectedCategories: nil,
+            skippedNestedPackages: ["MyLibCore"]
+        )
+        #expect(output.contains("excludes nested package MyLibCore"))
+    }
+
+    /// The seam this nearly shipped without. `--categories testability` skips the
+    /// collapsing, and an earlier shape of the guard sent it through the bare
+    /// `format.formatter` — dropping the caveat on precisely the request that asks to see
+    /// the candidate inventory in full, which is the reading a missing package distorts
+    /// most.
+    @Test("asking for testability still carries the caveat")
+    func testabilityListingCarriesCaveat() {
+        let output = SwiftProjectLintCLI.render(
+            corpus(), format: .text, selectedCategories: [.testability],
+            skippedNestedPackages: ["MyLibCore"]
+        )
+        #expect(output.contains("not listed above") == false)
+        #expect(output.contains("excludes nested package MyLibCore"))
+    }
+
+    @Test("machine-readable output is never contaminated with the caveat")
+    func machineReadableStaysClean() {
+        // The constraint the stderr channel existed to respect in the first place: a JSON
+        // consumer parses this. Prose in it is a break, not a courtesy — a machine-readable
+        // channel wanting this fact wants it as a field.
+        for format in [OutputFormat.json, .csv, .pbtSeeds] {
+            let output = SwiftProjectLintCLI.render(
+                corpus(), format: format, selectedCategories: nil,
+                skippedNestedPackages: ["MyLibCore"]
+            )
+            #expect(output.contains("excludes nested package") == false)
+        }
+    }
+
     /// The constraint this whole design exists to respect: the machine-readable formats must stay
     /// complete, because `pbt-seeds` IS the pipeline and a JSON consumer filters for itself.
     @Test("machine-readable formats are never collapsed", arguments: [OutputFormat.json, .csv, .pbtSeeds])

--- a/Tests/CLITests/SkippedScopeCaveatTests.swift
+++ b/Tests/CLITests/SkippedScopeCaveatTests.swift
@@ -1,0 +1,96 @@
+import Core
+import Testing
+
+/// The counts a reader quotes must say when they cover only part of the repo (#95).
+///
+/// A default run over `SwiftFormatRuleStudio` reported `Found 405 issues` and
+/// `44 of these are property-test candidates` while never opening the nested
+/// `SwiftFormatRuleStudioCore` — where the library, and every subject worth
+/// property-testing, lived. With the nested package in scope the same run reports 984
+/// issues and 131 candidates. The stderr notice said so and lost the placement fight:
+/// line 698 of 730, on a stream `> file` discards.
+///
+/// **The arms that matter are the negative ones.** A caveat that is always present is
+/// noise a reader learns to skip, and one that never fires is the defect restored
+/// silently — so every case below has its no-skip twin asserting the string is absent.
+struct SkippedScopeCaveatTests {
+
+    private func issue(_ severity: IssueSeverity = .warning) -> LintIssue {
+        LintIssue(
+            severity: severity, message: "m", filePath: "A.swift",
+            lineNumber: 1, suggestion: nil, ruleName: .fatView
+        )
+    }
+
+    private let caveat = "excludes nested package"
+
+    // MARK: - The issue count
+
+    @Test("the summary names the skipped package")
+    func summaryCarriesTheCaveat() {
+        let summary = TextFormatter(skippedNestedPackages: ["MyLibCore"])
+            .summaryLine(for: [issue()])
+        #expect(summary.contains("Found 1 issue (1 warning)"))
+        #expect(summary.contains("excludes nested package MyLibCore"))
+        #expect(summary.contains("--include-nested-packages"))
+    }
+
+    @Test("a run that skipped nothing says nothing")
+    func summaryIsUnchangedWithoutSkips() {
+        let summary = TextFormatter().summaryLine(for: [issue()])
+        #expect(summary == "Found 1 issue (1 warning)")
+    }
+
+    @Test("several packages are all named, sorted")
+    func summaryNamesEveryPackage() {
+        let summary = TextFormatter(skippedNestedPackages: ["Alpha", "Beta"])
+            .summaryLine(for: [issue()])
+        #expect(summary.contains("excludes nested packages Alpha, Beta"))
+    }
+
+    // MARK: - The zero case, where it matters most
+
+    @Test("`No issues found.` is qualified too")
+    func emptyResultCarriesTheCaveat() {
+        // The confident zero this project designs against: a clean bill of health over a
+        // repo whose library was never opened, and the line a reader is least likely to
+        // go looking behind.
+        let output = TextFormatter(skippedNestedPackages: ["MyLibCore"]).format(issues: [])
+        #expect(output.contains("No issues found."))
+        #expect(output.contains(caveat))
+    }
+
+    @Test("a genuinely clean run still reads clean")
+    func emptyResultUnchangedWithoutSkips() {
+        let output = TextFormatter().format(issues: [])
+        #expect(output.contains("No issues found."))
+        #expect(!output.contains(caveat))
+    }
+
+    // MARK: - The candidate inventory
+
+    @Test("the property-test candidate count is qualified")
+    func inventoryNoticeCarriesTheCaveat() {
+        // Quoted separately from the issue total — into a decision about what to
+        // property-test — so a caveat on only the other number never reaches this reader.
+        let candidate = LintIssue(
+            severity: .info, message: "pure", filePath: "B.swift",
+            lineNumber: 2, suggestion: nil, ruleName: .pureFunctionCandidate
+        )
+        let output = TextFormatter(withheld: [candidate], skippedNestedPackages: ["MyLibCore"])
+            .format(issues: [issue()])
+        #expect(output.contains("1 of these are property-test candidates"))
+        #expect(output.contains(caveat))
+    }
+
+    @Test("the inventory notice is unchanged without skips")
+    func inventoryNoticeUnchangedWithoutSkips() {
+        let candidate = LintIssue(
+            severity: .info, message: "pure", filePath: "B.swift",
+            lineNumber: 2, suggestion: nil, ruleName: .pureFunctionCandidate
+        )
+        let output = TextFormatter(withheld: [candidate]).format(issues: [issue()])
+        #expect(output.contains("1 of these are property-test candidates"))
+        #expect(!output.contains(caveat))
+    }
+}

--- a/Tests/CoreTests/FileAnalysis/FileAnalysisUtilsFindSwiftFilesTests.swift
+++ b/Tests/CoreTests/FileAnalysis/FileAnalysisUtilsFindSwiftFilesTests.swift
@@ -206,4 +206,58 @@ struct FileAnalysisUtilsFindSwiftFilesTests {
             #expect(firstFile.hasSuffix("Main.swift"))
         }
     }
+
+    // MARK: - nestedPackageNames (#95)
+
+    /// Names every skipped package, so the summary caveat can say WHICH — a reader told
+    /// "excludes 1 nested package" still has to go find out whether it was theirs.
+    @Test func nestedPackageNamesListsThemSorted() throws {
+        try withTempDir { root in
+            try touch(root.appendingPathComponent("Package.swift"), content: "// root")
+            for name in ["Zeta", "Alpha"] {
+                let child = root.appendingPathComponent("Packages/\(name)")
+                try touch(child.appendingPathComponent("Package.swift"), content: "// \(name)")
+            }
+
+            #expect(FileAnalysisUtils.nestedPackageNames(in: root.path) == ["Alpha", "Zeta"])
+        }
+    }
+
+    /// Agrees with the fast predicate on the negative case. The root's own manifest is not
+    /// a nested package, and a listing that returned it would put a caveat on every flat
+    /// project — noise a reader learns to skip, which costs the caveat its meaning where it
+    /// is true.
+    @Test func nestedPackageNamesIgnoresRootManifest() throws {
+        try withTempDir { root in
+            try touch(root.appendingPathComponent("Package.swift"), content: "// root")
+            try touch(root.appendingPathComponent("Sources/App/Main.swift"))
+
+            #expect(FileAnalysisUtils.nestedPackageNames(in: root.path).isEmpty)
+            #expect(FileAnalysisUtils.containsNestedPackage(in: root.path) == false)
+        }
+    }
+
+    /// A third-party checkout is not a first-party package. Same pruning as the predicate.
+    @Test func nestedPackageNamesExcludesBuildArtifacts() throws {
+        try withTempDir { root in
+            let dep = root.appendingPathComponent(".build/checkouts/Yams")
+            try touch(dep.appendingPathComponent("Package.swift"), content: "// manifest")
+
+            #expect(FileAnalysisUtils.nestedPackageNames(in: root.path).isEmpty)
+        }
+    }
+
+    /// A nested package's OWN nested packages are inside it, not beside it. Descending
+    /// would report a vendored or example package as a separately-skipped one, which
+    /// overstates what the default run left out.
+    @Test func nestedPackageNamesDoesNotDescendIntoAPackage() throws {
+        try withTempDir { root in
+            let child = root.appendingPathComponent("Packages/Child")
+            try touch(child.appendingPathComponent("Package.swift"), content: "// child")
+            let grandchild = child.appendingPathComponent("Examples/Demo")
+            try touch(grandchild.appendingPathComponent("Package.swift"), content: "// demo")
+
+            #expect(FileAnalysisUtils.nestedPackageNames(in: root.path) == ["Child"])
+        }
+    }
 }


### PR DESCRIPTION
Addresses #95 (items 1 and 2).

## The argument is already in the file

`TextFormatter` holds withheld candidates rather than letting the CLI pass fewer issues, and says why:

> …so the **summary stays honest**. If the CLI simply passed fewer issues, "Found 212 issues" would be a silent undercount of a run that found 876, which is the same species of lie as the confident zero this project keeps designing against.

A skipped nested package is that lie one level up, and worse — no flag on the enumeration brings those findings back, only re-running the tool.

## Before

```
Found 405 issues (64 warnings, 341 info)
44 of these are property-test candidates, not listed above (…)
```

Both over the app target alone. `SwiftFormatRuleStudioCore` — the library, and where every subject worth property-testing lived — contributed nothing, and neither line says so.

## After

```
Found 405 issues (64 warnings, 341 info) — excludes nested package SwiftFormatRuleStudioCore; re-run with --include-nested-packages
44 of these are property-test candidates, not listed above (…) — excludes nested package SwiftFormatRuleStudioCore; re-run with --include-nested-packages.
```

With `--include-nested-packages`: **984 issues, 131 candidates**, and no caveat. The default was understating by 579 issues and 87 candidates.

## Choices worth reviewing

**Names, not a count.** A reader told "excludes 1 nested package" still has to go find out whether it was theirs. New `FileAnalysisUtils.nestedPackageNames(in:)`; `containsNestedPackage` stays as the fast first-match predicate, and the full walk is paid only where names go into a message.

**`No issues found.` is qualified too** — the case that matters most. A clean bill of health over a repo whose library was never opened *is* the confident zero, and it's the line a reader is least likely to look behind.

**The stderr notice stays.** It says more than the caveat: that cross-file rules cannot span the boundary at all. Both are wanted; stderr alone reaches nobody reading the number.

**Machine-readable output untouched.** JSON, CSV and pbt-seeds get no prose spliced in — pinned by a test. #95's item 3 (a `skippedPackages` field in the seed manifest) is the right way for a consumer to get this, and is a schema change I have not made here.

## The seam this nearly shipped without

`--categories testability` skips the collapsing, and the first shape of my guard sent it through the bare `format.formatter` — dropping the caveat on precisely the request that asks to see the candidate inventory *in full*, which is the reading a missing package distorts most. Restructured and pinned.

## Testing

Every caveat assertion has a **no-skip twin**. A caveat that is always present is noise a reader learns to skip; one that never fires is the defect restored silently. Only the pair tells them apart.

- 3,257 tests / 395 suites green on a clean build (`swift package clean` first, per the doc-loader meta-test flake on incremental builds)
- `swiftlint --strict` unchanged at its pre-existing 13 violations, **none** in files this touches — verified by stashing and re-running

## Not addressed

#95's item 4 — whether the *default* should flip — is a real question this deliberately leaves open. And the unrunnable `swift-infer discover --seeds .pbt/seeds.json` hint in the same output block is untouched; it wants `--target`/`--sources` appended and is a separate one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzbS3ixXbX6RgStfjbfWWY