### PR TITLE
Let the caller say whether this is an app or a library

### DIFF
--- a/Docs/user/reference.md
+++ b/Docs/user/reference.md
@@ -24,6 +24,7 @@ swiftprojectlint <project-path> [options]
 | `--threshold` | `error`, `warning`, `info` | `warning` | Minimum severity that causes a non-zero exit code. |
 | `--categories` | See below | all | One category name. **Repeat the flag or comma-separate** for several: `--categories a,b` or `--categories a --categories b`. Restricts analysis to those categories. |
 | `--config` | file path | `.swiftprojectlint.yml` in project root | Path to a configuration file. |
+| `--target-type` | `auto`, `app`, `library` | `auto` | Whether the analyzed code is an app target or a library (see [Target Type](#target-type)). `auto` treats a directory containing `Package.swift` as a library and everything else as an app. |
 | `--include-nested-packages` | — | off | Analyze nested first-party Swift packages instead of skipping them (see [Nested Packages](#nested-packages)). Overrides `include_nested_packages` in the config when present. |
 | `--version` | — | — | Print the version number and exit. |
 | `--help` | — | — | Print usage information and exit. |
@@ -151,6 +152,34 @@ rules:
 | `Tests/` | Substring match — excludes any path containing `Tests/` |
 | `*.generated.swift` | Glob match against the full relative path |
 | `**/*.generated.swift` | Strip `**/`, then glob match against the filename only |
+
+### Target Type
+
+A few rules assume the single-target app model. `public-in-app-target` is the
+clearest: in an app, a `public` declaration is over-exposure, because nothing
+outside the target can consume it; in a library, `public` **is** the API. The same
+declaration is a finding in one and the point of the code in the other.
+
+By default (`--target-type auto`) the tool looks for a `Package.swift` in the
+directory you point it at. That answers correctly for a Swift package linted at its
+root, and says "app" for everything else — including two cases where it is wrong:
+
+- a **framework or library target in an Xcode project**, which has no manifest at all
+- a **package linted from a subdirectory**, where the manifest sits further up
+
+In both, every `public` in a deliberately public API is flagged. Pass
+`--target-type library` to state the answer instead:
+
+```bash
+swift run CLI /path/to/MyFramework --target-type library
+```
+
+`--target-type app` forces the opposite, keeping app-only rules on even when a
+`Package.swift` is present — useful for an executable package where `public` really
+is unnecessary.
+
+The flag only overrides this app-versus-library judgement. It does not change which
+files are discovered, and it is independent of nested-package handling below.
 
 ### Nested Packages
 

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
@@ -66,17 +66,37 @@ extension ProjectLinter {
         }
     }
 
-    /// Adjusts configuration for Swift Packages: disables `publicInAppTarget`,
+    /// Adjusts configuration for libraries: disables `publicInAppTarget`,
     /// excludes executable source paths from the `printStatement` rule, and suppresses
     /// `unusedProtocolAbstraction` when first-party nested packages are out of scope.
+    ///
+    /// - Parameters:
+    ///   - path: The project root being analyzed.
+    ///   - configuration: The configuration to adjust.
+    ///   - targetType: Whether to treat the project as a library, an app, or to detect
+    ///     it from the presence of a `Package.swift`. See ``TargetType``.
     static func resolveConfiguration(
         for path: String,
-        base configuration: LintConfiguration
+        base configuration: LintConfiguration,
+        targetType: TargetType = .auto
     ) -> LintConfiguration {
-        let isSwiftPackage = FileManager.default.fileExists(
-            atPath: (path as NSString).appendingPathComponent("Package.swift")
-        )
-        guard isSwiftPackage else { return configuration }
+        // `.auto` keeps the historical rule — a `Package.swift` beside the analyzed
+        // path means library — so an existing run's behaviour is unchanged unless the
+        // caller asks for something else.
+        let isLibrary: Bool
+        switch targetType {
+        case .library:
+            isLibrary = true
+
+        case .app:
+            isLibrary = false
+
+        case .auto:
+            isLibrary = FileManager.default.fileExists(
+                atPath: (path as NSString).appendingPathComponent("Package.swift")
+            )
+        }
+        guard isLibrary else { return configuration }
 
         var disabledRules = configuration.disabledRules
         disabledRules.insert(.publicInAppTarget)

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
@@ -53,6 +53,11 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
     ///   - detector: Optional pre-configured detector. If nil, a default detector is created.
     ///   - configuration: YAML-based configuration for rule/path control.
     /// - Returns: An array of `LintIssue` objects describing all detected issues.
+    ///
+    /// This is the `ProjectAnalyzerProtocol` requirement, which cannot carry a
+    /// defaulted `targetType` — Swift does not let a default argument satisfy a
+    /// protocol requirement. It forwards to the overload below with `.auto`, so a
+    /// caller that does not care about target type is unaffected.
     public func analyzeProject(
         at path: String,
         categories: [PatternCategory]? = nil,
@@ -60,8 +65,40 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         detector: (any SourcePatternDetectorProtocol)? = nil,
         configuration: LintConfiguration = .default
     ) async -> [LintIssue] {
+        await analyzeProject(
+            at: path,
+            targetType: .auto,
+            categories: categories,
+            ruleIdentifiers: ruleIdentifiers,
+            detector: detector,
+            configuration: configuration
+        )
+    }
+
+    /// Analyzes a project, stating whether it is an app target or a library.
+    ///
+    /// - Parameters:
+    ///   - path: The root directory path of the SwiftUI project to analyze.
+    ///   - targetType: Whether the project is an app, a library, or should be detected
+    ///     from its structure. See ``TargetType``. It carries no default and sits ahead
+    ///     of the optional parameters for two reasons: a default here would make this
+    ///     overload ambiguous with the protocol requirement above, and a non-defaulted
+    ///     parameter trailing the defaulted ones trips `function_default_parameter_at_end`.
+    ///   - categories: Optional array of pattern categories to analyze. If nil, analyzes all categories.
+    ///   - ruleIdentifiers: Optional array of specific rule identifiers to analyze. If provided, overrides categories.
+    ///   - detector: Optional pre-configured detector. If nil, a default detector is created.
+    ///   - configuration: YAML-based configuration for rule/path control.
+    /// - Returns: An array of `LintIssue` objects describing all detected issues.
+    public func analyzeProject(
+        at path: String,
+        targetType: TargetType,
+        categories: [PatternCategory]? = nil,
+        ruleIdentifiers: [RuleIdentifier]? = nil,
+        detector: (any SourcePatternDetectorProtocol)? = nil,
+        configuration: LintConfiguration = .default
+    ) async -> [LintIssue] {
         let effectiveConfiguration = Self.resolveConfiguration(
-            for: path, base: configuration
+            for: path, base: configuration, targetType: targetType
         )
 
         let (filePaths, evidenceOnlyFilePaths) = await discoverFiles(

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/TargetType.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/TargetType.swift
@@ -1,0 +1,28 @@
+/// Whether the analyzed code is an app target, a library, or should be detected
+/// from the project structure.
+///
+/// A handful of rules assume the single-target app model — `publicInAppTarget` is
+/// the clearest case: in an app, a `public` declaration is over-exposure, because
+/// nothing outside the target can consume it; in a library, `public` *is* the API.
+/// The same declaration is a finding in one and the point of the code in the other.
+///
+/// Detection alone cannot always settle which applies. `auto` looks for a
+/// `Package.swift`, which answers correctly for a Swift package linted at its root
+/// and says "app" for everything else — including a framework target in an Xcode
+/// project, and including a package linted from a subdirectory. Those are libraries
+/// that do not look like one from the path handed to the linter, and no amount of
+/// sniffing settles it from inside the analyzed directory. This enum exists so the
+/// caller can state the answer instead.
+public enum TargetType: Sendable {
+    /// Detect from project structure: a directory containing `Package.swift` is a
+    /// library, anything else is an app target.
+    case auto
+
+    /// Treat as an app target, enforcing rules like `publicInAppTarget` even when a
+    /// `Package.swift` is present.
+    case app
+
+    /// Treat as a library, suppressing rules that assume a single-target app
+    /// regardless of whether a `Package.swift` was found.
+    case library
+}

--- a/Sources/CLI/CLITargetType.swift
+++ b/Sources/CLI/CLITargetType.swift
@@ -1,0 +1,21 @@
+import ArgumentParser
+import Core
+
+/// The target type hint passed via `--target-type`.
+///
+/// A CLI-side mirror of ``TargetType`` rather than a conformance on it: making the
+/// engine's enum `ExpressibleByArgument` would put an ArgumentParser dependency in
+/// the engine to serve one flag.
+enum CLITargetType: String, ExpressibleByArgument, CaseIterable {
+    case auto
+    case app
+    case library
+
+    var coreTargetType: TargetType {
+        switch self {
+        case .auto: .auto
+        case .app: .app
+        case .library: .library
+        }
+    }
+}

--- a/Sources/CLI/SwiftProjectLintCLI.swift
+++ b/Sources/CLI/SwiftProjectLintCLI.swift
@@ -25,6 +25,16 @@ struct SwiftProjectLintCLI: AsyncParsableCommand {
     @Option(name: .long, help: "Minimum severity to trigger a non-zero exit: error, warning, or info.")
     var threshold: SeverityThreshold = .warning
 
+    @Option(
+        name: .long,
+        help: """
+        Target type: auto (default), app, or library. Use 'library' to suppress app-only \
+        rules such as public-in-app-target for a framework target or a package linted \
+        from a subdirectory, where auto-detection reports 'app'.
+        """
+    )
+    var targetType: CLITargetType = .auto
+
     /// Repeat the flag, or comma-separate: `--categories a,b` / `--categories a --categories b`.
     ///
     /// **`.singleValue` rather than `.upToNextOption`, and the difference is a real defect.**
@@ -101,6 +111,7 @@ struct SwiftProjectLintCLI: AsyncParsableCommand {
 
         let issues = await linter.analyzeProject(
             at: absolutePath,
+            targetType: targetType.coreTargetType,
             categories: selectedCategories,
             detector: system.detector,
             configuration: configuration

--- a/Tests/CoreTests/TargetTypeTests.swift
+++ b/Tests/CoreTests/TargetTypeTests.swift
@@ -1,0 +1,114 @@
+@testable import Core
+import Foundation
+import SwiftProjectLintModels
+import Testing
+
+/// `--target-type` lets the caller state whether the analyzed code is an app target or a
+/// library, overriding the `Package.swift` sniff.
+///
+/// Every case runs the full `analyzeProject` path against a real directory on disk and
+/// asserts on `publicInAppTarget`, the clearest rule that differs between the two: in an
+/// app a `public` declaration is over-exposure, in a library it is the API.
+///
+/// The suite is a matrix — both layouts against all three target types — because the
+/// interesting claims are the *disagreements*. Testing `.library` on a package and `.app`
+/// on a plain directory would pass even if the flag were ignored entirely, since those
+/// are the values auto-detection already picks.
+struct TargetTypeTests {
+
+    private func makeProject(withManifest: Bool) -> String {
+        let base = FileManager.default.temporaryDirectory.path
+        let root = (base as NSString)
+            .appendingPathComponent("TargetTypeProject-\(UUID().uuidString)")
+        let sources = (root as NSString).appendingPathComponent("Sources")
+        try? FileManager.default.createDirectory(
+            atPath: sources, withIntermediateDirectories: true
+        )
+
+        if withManifest {
+            try? "// swift-tools-version:6.0\n".write(
+                toFile: (root as NSString).appendingPathComponent("Package.swift"),
+                atomically: true, encoding: .utf8
+            )
+        }
+
+        try? "public struct Widget {\n    public func render() {}\n}\n".write(
+            toFile: (sources as NSString).appendingPathComponent("Widget.swift"),
+            atomically: true, encoding: .utf8
+        )
+        return root
+    }
+
+    private func publicInAppTargetIssues(
+        at root: String,
+        targetType: TargetType
+    ) async -> [LintIssue] {
+        let linter = ProjectLinter()
+        let system = PatternRegistryFactory.createConfiguredSystem()
+        let issues = await linter.analyzeProject(
+            at: root,
+            targetType: targetType,
+            detector: system.detector
+        )
+        return issues.filter { $0.ruleName == .publicInAppTarget }
+    }
+
+    // MARK: - The flag overrides detection
+
+    /// The motivating case: a framework target in an Xcode project has no `Package.swift`,
+    /// so auto-detection calls it an app and every `public` in its API is flagged.
+    @Test("library on a directory with no manifest suppresses publicInAppTarget")
+    func libraryOverridesMissingManifest() async {
+        let root = makeProject(withManifest: false)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        #expect(await publicInAppTargetIssues(at: root, targetType: .library).isEmpty)
+    }
+
+    /// The opposite override: an app that happens to carry a `Package.swift` should still
+    /// be held to app rules when the caller says so.
+    @Test("app on a directory with a manifest keeps publicInAppTarget enabled")
+    func appOverridesPresentManifest() async {
+        let root = makeProject(withManifest: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        #expect(await publicInAppTargetIssues(at: root, targetType: .app).isEmpty == false)
+    }
+
+    // MARK: - auto is unchanged
+
+    /// Control for `libraryOverridesMissingManifest`: without the flag the same tree is
+    /// flagged, so the suppression above is the flag's doing and not an inert rule.
+    @Test("auto on a directory with no manifest still flags publicInAppTarget")
+    func autoTreatsPlainDirectoryAsApp() async {
+        let root = makeProject(withManifest: false)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        #expect(await publicInAppTargetIssues(at: root, targetType: .auto).isEmpty == false)
+    }
+
+    /// Control for `appOverridesPresentManifest`: the same tree is silent under `.auto`,
+    /// so the issues that appear above come from the override rather than from the rule
+    /// having been on all along.
+    @Test("auto on a directory with a manifest suppresses publicInAppTarget")
+    func autoTreatsManifestDirectoryAsLibrary() async {
+        let root = makeProject(withManifest: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        #expect(await publicInAppTargetIssues(at: root, targetType: .auto).isEmpty)
+    }
+
+    /// The protocol requirement takes no target type and must keep behaving as `.auto`,
+    /// since `ContentViewModel` and every existing caller reach the linter through it.
+    @Test("the no-target-type entry point behaves as auto")
+    func defaultEntryPointMatchesAuto() async {
+        let root = makeProject(withManifest: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let linter = ProjectLinter()
+        let system = PatternRegistryFactory.createConfiguredSystem()
+        let issues = await linter.analyzeProject(at: root, detector: system.detector)
+
+        #expect(issues.contains { $0.ruleName == .publicInAppTarget } == false)
+    }
+}


### PR DESCRIPTION
Recovers the `--target-type` flag from `stash@{1}`, which predates the package split and can no longer be restored by `git stash pop`.

## Why

A few rules assume the single-target app model. `public-in-app-target` is the clearest: in an app a `public` declaration is over-exposure, because nothing outside the target can consume it; in a library `public` **is** the API.

The existing sniff looks for a `Package.swift` beside the analyzed path. That answers correctly for a package linted at its root and says "app" for everything else — including two cases where it's wrong:

- a **framework target in an Xcode project**, which has no manifest at all
- a **package linted from a subdirectory**, where the manifest sits further up

In both, every `public` in a deliberately public API is flagged.

## What

`--target-type auto|app|library`, defaulting to `auto`.

Measured through the built binary:

| layout | `auto` | override |
|---|---|---|
| no manifest | 2 findings | `--target-type library` → **0** |
| `Package.swift` present | 0 findings | `--target-type app` → **2** |

## Two decisions

**`auto` is byte-identical to today's behaviour.** The stashed original also changed auto-detection to walk *up* the tree for a manifest, which silently reclassifies every run that lints a subdirectory. That's a separate judgement from adding the flag — and the flag makes it unnecessary — so it isn't here.

**The protocol requirement is unchanged.** Threading the parameter broke `ProjectAnalyzerProtocol` conformance, since Swift won't let a default argument satisfy a requirement. The five-argument requirement stays and forwards with `.auto`, leaving `ContentViewModel`, its mock, and every existing caller untouched. `targetType` sits ahead of the optional parameters: a default would make the overload ambiguous with the requirement, and a trailing non-defaulted parameter trips `function_default_parameter_at_end`.

## On the tests

A matrix of both layouts against all three target types. The disagreements are the point — `.library` on a package and `.app` on a plain directory would pass even if the flag were ignored, since those are what auto-detection already picks. The two `.auto` cases assert the *opposite* outcome on the same tree, so each override is shown to be doing the work.

## Verification

- Full suite green: **3262 tests, 396 suites**, after `swift package clean`
- SwiftLint `--strict`: **13 violations before and after**, none in the changed files (an earlier revision added 4; they're fixed)
- CLI verified against the built binary: flag registers in `--help`, rejects invalid values, and produces the matrix above

## Not included

The `excludedFilenames` config option and the cross-file inline-suppression fix stashed alongside this remain unported. `stash@{1}` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjbVm7qSbE3WKVfDMXNGdx