### PR TITLE
Stop the could-be-private rules flagging reachable declarations

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/CouldBePrivateMemberVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/CouldBePrivateMemberVisitor.swift
@@ -209,6 +209,24 @@ final class CouldBePrivateMemberVisitor: CrossFileVisitorBase, CrossFilePatternV
         functionNestingDepth -= 1
     }
 
+    /// An *implicit* getter — `var body: String { … }` with no `get` keyword — is spelled
+    /// as an `AccessorBlockSyntax` whose accessors are a bare `.getter` statement list,
+    /// with no `AccessorDeclSyntax` anywhere inside. The accessor override above therefore
+    /// never fires, `functionNestingDepth` stays at 0 through the body, and every local
+    /// `let` in it is collected as though it were a stored property of the enclosing type.
+    ///
+    /// Only the `.getter` case is counted: an explicit `get { }` / `set { }` block does
+    /// contain `AccessorDeclSyntax` children, so incrementing here as well would
+    /// double-count it.
+    override func visit(_ node: AccessorBlockSyntax) -> SyntaxVisitorContinueKind {
+        if case .getter = node.accessors { functionNestingDepth += 1 }
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: AccessorBlockSyntax) {
+        if case .getter = node.accessors { functionNestingDepth -= 1 }
+    }
+
     override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
         // Skip if outside a type, or inside a function body (local variables)
         guard typeNestingDepth > 0, functionNestingDepth == 0 else { return .visitChildren }
@@ -231,12 +249,13 @@ final class CouldBePrivateMemberVisitor: CrossFileVisitorBase, CrossFilePatternV
     // MARK: - Collect References
 
     override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
-        identifierUsages[node.baseName.text, default: []].insert(currentFilePath)
+        identifierUsages[Self.stripBackticks(node.baseName.text), default: []]
+            .insert(currentFilePath)
         return .visitChildren
     }
 
     override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
-        let memberName = node.declName.baseName.text
+        let memberName = Self.stripBackticks(node.declName.baseName.text)
         identifierUsages[memberName, default: []].insert(currentFilePath)
         return .visitChildren
     }
@@ -292,11 +311,27 @@ final class CouldBePrivateMemberVisitor: CrossFileVisitorBase, CrossFilePatternV
 
         declarations.append(MemberDeclaration(
             typeName: currentTypeName,
-            memberName: name,
+            memberName: Self.stripBackticks(name),
             memberKind: kind,
             file: currentFilePath,
             node: node
         ))
+    }
+
+    /// Strips the backtick escaping from a keyword used as an identifier.
+    ///
+    /// SwiftSyntax reports the declaration `func \`default\`()` with a `.text` of
+    /// `` `default` ``, backticks included, but the call site `config.default()` needs no
+    /// escaping and reports `default`. The two spellings are the same member, so without
+    /// normalising both sides the usage map never matches and every backticked member
+    /// looks unreferenced.
+    ///
+    /// Applied at all three sites — the declaration and both reference collectors — since
+    /// normalising only one side would leave the mismatch exactly as it was.
+    private static func stripBackticks(_ text: String) -> String {
+        text.hasPrefix("`") && text.hasSuffix("`") && text.count >= 2
+            ? String(text.dropFirst().dropLast())
+            : text
     }
 
     /// Members carrying explicit access control, `override`, or `@objc`

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/CouldBePrivateVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/CouldBePrivateVisitor.swift
@@ -26,9 +26,31 @@ final class CouldBePrivateVisitor: CrossFileVisitorBase, CrossFilePatternVisitor
     /// Maps type name → set of protocol names it conforms to.
     private var typeConformances: [String: Set<String>] = [:]
 
+    /// Type names appearing in the type annotation of a non-private member, keyed by the
+    /// file that member is declared in: file → Set<typeName>.
+    ///
+    /// These are part of that file's accessible surface even when no other file ever
+    /// writes the name. A caller reaching `cache.entries["k"]` receives a value of the
+    /// element type through inference; making that type `private` stops the code
+    /// compiling although nothing outside the file names it.
+    private var accessibleInterfaceTypes: [String: Set<String>] = [:]
+
+    /// Depth inside type bodies, so member declarations can be told from top-level ones
+    /// when collecting interface types. Incremented unconditionally on entering a type
+    /// declaration and decremented in `visitPost`: the entry points below `guard` past
+    /// their body for `@main` and `App` types, and `visitPost` still runs for those, so
+    /// counting only after the guard would leave the depth permanently skewed.
+    private var typeNestingDepth: Int = 0
+
+    override func setFilePath(_ filePath: String) {
+        super.setFilePath(filePath)
+        typeNestingDepth = 0
+    }
+
     // MARK: - Collect Declarations (top-level, internal access only)
 
     override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        typeNestingDepth += 1
         // Skip App entry points and @main types — they can't be private
         guard !isSwiftUIApp(node), !hasMainAttribute(node.attributes) else { return .visitChildren }
         collectDeclarationIfEligible(node.name.text, modifiers: node.modifiers, node: Syntax(node))
@@ -36,26 +58,64 @@ final class CouldBePrivateVisitor: CrossFileVisitorBase, CrossFilePatternVisitor
         return .visitChildren
     }
 
+    override func visitPost(_ _: StructDeclSyntax) { typeNestingDepth -= 1 }
+
     override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+        typeNestingDepth += 1
         collectDeclarationIfEligible(node.name.text, modifiers: node.modifiers, node: Syntax(node))
         trackProtocolConformance(node.name.text, inheritance: node.inheritanceClause)
         return .visitChildren
     }
+
+    override func visitPost(_ _: ClassDeclSyntax) { typeNestingDepth -= 1 }
 
     override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+        typeNestingDepth += 1
         collectDeclarationIfEligible(node.name.text, modifiers: node.modifiers, node: Syntax(node))
         trackProtocolConformance(node.name.text, inheritance: node.inheritanceClause)
         return .visitChildren
     }
+
+    override func visitPost(_ _: EnumDeclSyntax) { typeNestingDepth -= 1 }
 
     override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+        typeNestingDepth += 1
         collectDeclarationIfEligible(node.name.text, modifiers: node.modifiers, node: Syntax(node))
         trackProtocolConformance(node.name.text, inheritance: node.inheritanceClause)
         return .visitChildren
     }
 
+    override func visitPost(_ _: ActorDeclSyntax) { typeNestingDepth -= 1 }
+
     override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+        typeNestingDepth += 1
         projectProtocolNames.insert(node.name.text)
+        return .visitChildren
+    }
+
+    override func visitPost(_ _: ProtocolDeclSyntax) { typeNestingDepth -= 1 }
+
+    // MARK: - Collect the file's accessible interface types
+
+    override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard typeNestingDepth > 0, !isPrivate(node.modifiers) else { return .visitChildren }
+        if let annotation = node.bindings.first?.typeAnnotation?.type {
+            collectTypeNames(
+                from: annotation,
+                into: &accessibleInterfaceTypes[currentFilePath, default: []]
+            )
+        }
+        return .visitChildren
+    }
+
+    override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard typeNestingDepth > 0, !isPrivate(node.modifiers) else { return .visitChildren }
+        if let returnType = node.signature.returnClause?.type {
+            collectTypeNames(
+                from: returnType,
+                into: &accessibleInterfaceTypes[currentFilePath, default: []]
+            )
+        }
         return .visitChildren
     }
 
@@ -105,6 +165,11 @@ final class CouldBePrivateVisitor: CrossFileVisitorBase, CrossFilePatternVisitor
                conformances.contains(where: { projectProtocolNames.contains($0) }) {
                 continue
             }
+
+            // Skip types on the declaring file's accessible surface. No other file needs
+            // to name the type for a caller to hold values of it — inference hands them
+            // over — so "unreferenced elsewhere" does not mean "safe to narrow".
+            if accessibleInterfaceTypes[decl.file]?.contains(decl.name) == true { continue }
 
             let referencingFiles = references[decl.name] ?? []
             // Remove the declaring file — we only care about external references
@@ -171,6 +236,47 @@ final class CouldBePrivateVisitor: CrossFileVisitorBase, CrossFilePatternVisitor
 
         declarations.append((name: name, file: currentFilePath, node: node))
         declaredTypeNames.insert(name)
+    }
+
+    private func isPrivate(_ modifiers: DeclModifierListSyntax) -> Bool {
+        modifiers.contains { $0.name.text == "private" || $0.name.text == "fileprivate" }
+    }
+
+    /// Collects every type name written inside `type`, descending through the shapes a
+    /// member's annotation can take. `[String: RemovalEntry]` must yield `RemovalEntry`,
+    /// not just `Dictionary`, or the member exposing it goes unnoticed.
+    private func collectTypeNames(from type: TypeSyntax, into set: inout Set<String>) {
+        if let ident = type.as(IdentifierTypeSyntax.self) {
+            set.insert(ident.name.text)
+            for argument in ident.genericArgumentClause?.arguments ?? [] {
+                if let argumentType = argument.argument.as(TypeSyntax.self) {
+                    collectTypeNames(from: argumentType, into: &set)
+                }
+            }
+            return
+        }
+        // `Outer.Inner` — the qualified half is what a member would name, and the
+        // qualifier is a type in its own right that this rule tracks separately.
+        if let member = type.as(MemberTypeSyntax.self) {
+            set.insert(member.name.text)
+            return
+        }
+        collectWrappedTypeNames(from: type, into: &set)
+    }
+
+    /// The container shapes, split from `collectTypeNames` only to keep each within the
+    /// cyclomatic-complexity budget.
+    private func collectWrappedTypeNames(from type: TypeSyntax, into set: inout Set<String>) {
+        if let optional = type.as(OptionalTypeSyntax.self) {
+            collectTypeNames(from: optional.wrappedType, into: &set)
+        } else if let array = type.as(ArrayTypeSyntax.self) {
+            collectTypeNames(from: array.element, into: &set)
+        } else if let dictionary = type.as(DictionaryTypeSyntax.self) {
+            collectTypeNames(from: dictionary.key, into: &set)
+            collectTypeNames(from: dictionary.value, into: &set)
+        } else if let tuple = type.as(TupleTypeSyntax.self) {
+            for element in tuple.elements { collectTypeNames(from: element.type, into: &set) }
+        }
     }
 
     private func isSwiftUIApp(_ node: StructDeclSyntax) -> Bool {

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/ProtocolCouldBePrivateVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/ProtocolCouldBePrivateVisitor.swift
@@ -24,10 +24,25 @@ final class ProtocolCouldBePrivateVisitor: CrossFileVisitorBase, CrossFilePatter
     /// All declared protocol names (to distinguish from other types).
     private var declaredProtocolNames: Set<String> = []
 
+    /// Protocol inheritance, child → parents. A protocol's requirements are reachable
+    /// through anything that refines it, so a parent is only narrowable if every
+    /// descendant is too.
+    private var protocolInheritsFrom: [String: Set<String>] = [:]
+
+    /// The protocol currently being declared, so an inheritance clause can be attributed
+    /// to its child. Swift does not allow protocols to nest, so one name suffices.
+    private var currentProtocolName: String = ""
+
     // MARK: - Collect Protocol Declarations
 
     override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
         let name = node.name.text
+
+        // Set before the guards below: a protocol that is skipped as a *declaration*
+        // still refines its parents, and that edge is what keeps the parent from being
+        // narrowed. Dropping it for a public or test-file protocol would lose exactly the
+        // cases where the parent is most clearly reachable.
+        currentProtocolName = name
 
         // Skip test files
         if isTestOrFixtureFile() {
@@ -42,12 +57,21 @@ final class ProtocolCouldBePrivateVisitor: CrossFileVisitorBase, CrossFilePatter
         return .visitChildren
     }
 
+    override func visitPost(_ _: ProtocolDeclSyntax) {
+        currentProtocolName = ""
+    }
+
     // MARK: - Collect References
 
-    // Inheritance clauses: struct Foo: MyProtocol
+    // Inheritance clauses: struct Foo: MyProtocol, and protocol Q: P
     override func visit(_ node: InheritedTypeSyntax) -> SyntaxVisitorContinueKind {
         if let ident = node.type.as(IdentifierTypeSyntax.self) {
-            references[ident.name.text, default: []].insert(currentFilePath)
+            let parentName = ident.name.text
+            references[parentName, default: []].insert(currentFilePath)
+            // Inside `protocol Q: P`, currentProtocolName is "Q" and parentName is "P".
+            if !currentProtocolName.isEmpty {
+                protocolInheritsFrom[currentProtocolName, default: []].insert(parentName)
+            }
         }
         return .visitChildren
     }
@@ -70,21 +94,71 @@ final class ProtocolCouldBePrivateVisitor: CrossFileVisitorBase, CrossFilePatter
     // MARK: - Finalize
 
     func finalizeAnalysis() {
+        // Reverse the inheritance map once: parent → the protocols refining it.
+        var protocolChildren: [String: Set<String>] = [:]
+        for (child, parents) in protocolInheritsFrom {
+            for parent in parents {
+                protocolChildren[parent, default: []].insert(child)
+            }
+        }
+
         for decl in declarations {
             let referencingFiles = references[decl.name] ?? []
             let externalFiles = referencingFiles.subtracting([decl.file])
+            guard externalFiles.isEmpty else { continue }
 
-            if externalFiles.isEmpty {
-                addIssue(
-                    severity: .info,
-                    message: "Protocol '\(decl.name)' is only used in its declaring "
-                        + "file and could be private",
-                    filePath: decl.file,
-                    lineNumber: getLineNumber(for: decl.node),
-                    suggestion: "Add `private` to 'protocol \(decl.name)' to narrow its scope.",
-                    ruleName: .protocolCouldBePrivate
-                )
+            // A protocol nothing else names is still reachable when something refines it:
+            // `protocol Q: P` declared beside P puts P's only reference in P's own file,
+            // while a caller holding a `Q` elsewhere can call P's requirements through it.
+            // Narrowing P would stop that compiling.
+            var visited: Set<String> = []
+            if hasExternallyReferencedDescendant(
+                decl.name, children: protocolChildren, visited: &visited
+            ) {
+                continue
+            }
+
+            addIssue(
+                severity: .info,
+                message: "Protocol '\(decl.name)' is only used in its declaring "
+                    + "file and could be private",
+                filePath: decl.file,
+                lineNumber: getLineNumber(for: decl.node),
+                suggestion: "Add `private` to 'protocol \(decl.name)' to narrow its scope.",
+                ruleName: .protocolCouldBePrivate
+            )
+        }
+    }
+
+    /// Whether any protocol refining `protocolName`, at any depth, is referenced outside
+    /// its own declaring file.
+    ///
+    /// `visited` guards termination. Swift rejects inheritance cycles, so a cycle here
+    /// would mean a malformed or partially-parsed tree rather than real code — but this
+    /// walks a map built from source text, and a linter that hangs on bad input is worse
+    /// than one that under-reports.
+    ///
+    /// A child absent from `declarations` was skipped as a declaration for being `public`
+    /// or living in a test file. Its references are then all treated as external, which is
+    /// the conservative reading: a public refinement makes the parent reachable outright.
+    private func hasExternallyReferencedDescendant(
+        _ protocolName: String,
+        children: [String: Set<String>],
+        visited: inout Set<String>
+    ) -> Bool {
+        guard visited.insert(protocolName).inserted else { return false }
+        guard let directChildren = children[protocolName] else { return false }
+
+        for child in directChildren {
+            let childReferences = references[child] ?? []
+            let declaringFile = declarations.first { $0.name == child }?.file
+            let external = declaringFile.map { childReferences.subtracting([$0]) } ?? childReferences
+            if !external.isEmpty { return true }
+
+            if hasExternallyReferencedDescendant(child, children: children, visited: &visited) {
+                return true
             }
         }
+        return false
     }
 }

--- a/Tests/CoreTests/CrossFileAnalysis/CouldBePrivateFalsePositiveTests.swift
+++ b/Tests/CoreTests/CrossFileAnalysis/CouldBePrivateFalsePositiveTests.swift
@@ -1,0 +1,305 @@
+@testable import Core
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+/// False positives in the three `could-be-private` rules, each paired with a control.
+///
+/// Every case here asserts that something is **not** flagged, which a rule that had stopped
+/// firing would satisfy just as well. So each is accompanied by a control differing only in
+/// the element that makes the finding wrong — remove the protocol refinement, the member
+/// exposing the type, the getter, the cross-file call — and the row must come back.
+@Suite
+struct CouldBePrivateFalsePositiveTests {
+
+    private func walk(_ visitor: CrossFileVisitorBase, _ files: [String: SourceFileSyntax]) {
+        for (name, ast) in files.sorted(by: { $0.key < $1.key }) {
+            visitor.setFilePath(name)
+            visitor.setSourceLocationConverter(SourceLocationConverter(fileName: name, tree: ast))
+            visitor.walk(ast)
+        }
+    }
+
+    private func typeIssues(_ sources: [String: String]) -> [LintIssue] {
+        let files = sources.mapValues { Parser.parse(source: $0) }
+        let visitor = CouldBePrivateVisitor(fileCache: files)
+        visitor.setPattern(CouldBePrivate().pattern)
+        walk(visitor, files)
+        visitor.finalizeAnalysis()
+        return visitor.detectedIssues.filter { $0.ruleName == .couldBePrivate }
+    }
+
+    private func memberIssues(_ sources: [String: String]) -> [LintIssue] {
+        let files = sources.mapValues { Parser.parse(source: $0) }
+        let visitor = CouldBePrivateMemberVisitor(fileCache: files)
+        visitor.setPattern(CouldBePrivateMember().pattern)
+        walk(visitor, files)
+        visitor.finalizeAnalysis()
+        return visitor.detectedIssues.filter { $0.ruleName == .couldBePrivateMember }
+    }
+
+    private func protocolIssues(_ sources: [String: String]) -> [LintIssue] {
+        let files = sources.mapValues { Parser.parse(source: $0) }
+        let visitor = ProtocolCouldBePrivateVisitor(fileCache: files)
+        visitor.setPattern(ProtocolCouldBePrivate().pattern)
+        walk(visitor, files)
+        visitor.finalizeAnalysis()
+        return visitor.detectedIssues.filter { $0.ruleName == .protocolCouldBePrivate }
+    }
+
+    // MARK: - A type reachable only through a member's type
+
+    /// `RemovalEntry` is named nowhere but its own file, yet a caller reaching
+    /// `cache.entries["k"]` holds one. Inference, not spelling, is what exposes it.
+    @Test("a type exposed by a non-private member's annotation is not flagged")
+    func typeOnAccessibleSurfaceIsNotFlagged() {
+        let issues = typeIssues([
+            "Cache.swift": """
+            struct RemovalEntry {
+                let reason: String
+            }
+
+            struct RemovalCache {
+                var entries: [String: RemovalEntry] = [:]
+            }
+            """,
+            "Consumer.swift": """
+            struct CacheConsumer {
+                func describe(_ cache: RemovalCache) -> String {
+                    cache.entries.values.map(\\.reason).joined()
+                }
+            }
+            """
+        ])
+
+        #expect(issues.contains { $0.message.contains("RemovalEntry") } == false)
+    }
+
+    /// Control: the same type, no longer named by any member. Nothing can receive one by
+    /// inference, so the finding is correct and must still appear.
+    @Test("control — a type no member exposes is still flagged")
+    func typeOffAccessibleSurfaceIsStillFlagged() {
+        let issues = typeIssues([
+            "Cache.swift": """
+            struct RemovalEntry {
+                let reason: String
+            }
+
+            struct RemovalCache {
+                var count: Int = 0
+            }
+            """,
+            "Consumer.swift": """
+            struct CacheConsumer {
+                func describe(_ cache: RemovalCache) -> Int { cache.count }
+            }
+            """
+        ])
+
+        #expect(issues.contains { $0.message.contains("RemovalEntry") })
+    }
+
+    /// A `private` member is not part of the surface, so the type it names stays narrowable.
+    @Test("a type exposed only by a private member is still flagged")
+    func typeBehindPrivateMemberIsStillFlagged() {
+        let issues = typeIssues([
+            "Cache.swift": """
+            struct RemovalEntry {
+                let reason: String
+            }
+
+            struct RemovalCache {
+                private var entries: [String: RemovalEntry] = [:]
+                var count: Int { entries.count }
+            }
+            """,
+            "Consumer.swift": """
+            struct CacheConsumer {
+                func describe(_ cache: RemovalCache) -> Int { cache.count }
+            }
+            """
+        ])
+
+        #expect(issues.contains { $0.message.contains("RemovalEntry") })
+    }
+
+    // MARK: - Locals inside an implicit getter
+
+    /// `header` is a local binding in `var body: String { … }`, not a member at all.
+    @Test("a local inside an implicit getter is not reported as a member")
+    func localInImplicitGetterIsNotAMember() {
+        let issues = memberIssues([
+            "Report.swift": """
+            struct Report {
+                var body: String {
+                    let header = "title"
+                    return header + "!"
+                }
+            }
+            """
+        ])
+
+        #expect(issues.contains { $0.message.contains("header") } == false)
+    }
+
+    /// Control: the same name as a genuine stored property is still flagged, so the case
+    /// above is excluded for being a local rather than for the name being ignored.
+    @Test("control — a stored property of the same name is still flagged")
+    func storedPropertyIsStillFlagged() {
+        let issues = memberIssues([
+            "Report.swift": """
+            struct Report {
+                var header = "title"
+                var body: String { header + "!" }
+            }
+            """
+        ])
+
+        #expect(issues.contains { $0.message.contains("header") })
+    }
+
+    /// An explicit `get { }` block was already handled by the `AccessorDeclSyntax` override;
+    /// this pins that the new `.getter` counting did not start double-counting it.
+    @Test("a local inside an explicit getter is not reported as a member")
+    func localInExplicitGetterIsNotAMember() {
+        let issues = memberIssues([
+            "Report.swift": """
+            struct Report {
+                var body: String {
+                    get {
+                        let header = "title"
+                        return header + "!"
+                    }
+                }
+            }
+            """
+        ])
+
+        #expect(issues.contains { $0.message.contains("header") } == false)
+    }
+
+    // MARK: - Backtick-escaped member names
+
+    /// The declaration reads `` `default` `` and the call site reads `default`. Without
+    /// normalising both, the two never match and the member looks unreferenced.
+    @Test("a backticked member called from another file is not flagged")
+    func backtickedMemberCalledElsewhereIsNotFlagged() {
+        let issues = memberIssues([
+            "Configuration.swift": """
+            struct Configuration {
+                func `default`() -> Int { 42 }
+            }
+            """,
+            "User.swift": """
+            struct ConfigurationUser {
+                func value(_ config: Configuration) -> Int { config.default() }
+            }
+            """
+        ])
+
+        #expect(issues.contains { $0.message.contains("default") } == false)
+    }
+
+    /// Control: the same backticked member with no caller anywhere. Normalising the name
+    /// must not make every backticked member unflaggable.
+    @Test("control — a backticked member with no external caller is still flagged")
+    func backtickedMemberWithNoCallerIsStillFlagged() {
+        let issues = memberIssues([
+            "Configuration.swift": """
+            struct Configuration {
+                func `default`() -> Int { 42 }
+            }
+            """,
+            "Unrelated.swift": """
+            struct Unrelated {
+                func run() -> Int { 0 }
+            }
+            """
+        ])
+
+        #expect(issues.contains { $0.message.contains("default") })
+    }
+
+    // MARK: - A protocol reached through a refinement
+
+    /// `BaseCapability`'s only reference is in its own file — the inheritance clause of
+    /// `ExtendedCapability` beside it. A caller holding an `ExtendedCapability` elsewhere
+    /// still calls `perform()`, so narrowing the parent would not compile.
+    @Test("a protocol refined by an externally used protocol is not flagged")
+    func refinedProtocolIsNotFlagged() {
+        let issues = protocolIssues([
+            "Protocols.swift": """
+            protocol BaseCapability {
+                func perform()
+            }
+
+            protocol ExtendedCapability: BaseCapability {
+                func performTwice()
+            }
+            """,
+            "User.swift": """
+            struct CapabilityUser {
+                let capability: any ExtendedCapability
+                func run() { capability.perform() }
+            }
+            """
+        ])
+
+        #expect(issues.contains { $0.message.contains("BaseCapability") } == false)
+    }
+
+    /// Control: nothing outside the declaring file uses the child either, so both protocols
+    /// really are file-local and both findings are correct.
+    @Test("control — a refined protocol nobody uses externally is still flagged")
+    func unusedRefinedProtocolIsStillFlagged() {
+        let issues = protocolIssues([
+            "Protocols.swift": """
+            protocol BaseCapability {
+                func perform()
+            }
+
+            protocol ExtendedCapability: BaseCapability {
+                func performTwice()
+            }
+            """,
+            "Unrelated.swift": """
+            struct Unrelated {
+                func run() -> Int { 0 }
+            }
+            """
+        ])
+
+        #expect(issues.contains { $0.message.contains("BaseCapability") })
+    }
+
+    /// Reachability is transitive: a grandchild used externally keeps the grandparent
+    /// exposed just as a direct child would.
+    @Test("reachability through a refinement is transitive")
+    func transitiveRefinementIsNotFlagged() {
+        let issues = protocolIssues([
+            "Protocols.swift": """
+            protocol BaseCapability {
+                func perform()
+            }
+
+            protocol MiddleCapability: BaseCapability {
+                func performTwice()
+            }
+
+            protocol TopCapability: MiddleCapability {
+                func performThrice()
+            }
+            """,
+            "User.swift": """
+            struct CapabilityUser {
+                let capability: any TopCapability
+                func run() { capability.perform() }
+            }
+            """
+        ])
+
+        #expect(issues.contains { $0.message.contains("BaseCapability") } == false)
+        #expect(issues.contains { $0.message.contains("MiddleCapability") } == false)
+    }
+}


### PR DESCRIPTION
Recovers the `CouldBePrivate` false-positive fixes from `stash@{1}`, which predates the package split and can no longer be restored by `git stash pop`.

Each false positive was **reproduced against the built CLI before being fixed**, and the fixes were A/B'd with two binaries over the same corpora on the same afternoon.

## The four fixes

**A type reachable only through a member's type.** `RemovalEntry` named nowhere but its own file is still handed to callers by `var entries: [String: RemovalEntry]` — inference, not spelling, exposes it. Type names in a non-private member's annotation or return clause are now collected as that file's accessible surface. On this repo it retires `SelfAccess`, the return type of `SelfAccessAnalyzer.access(...)`, which `PropertyTestCandidacy` switches on without ever naming.

**Locals inside an implicit getter.** `var body: String { … }` with no `get` keyword is an `AccessorBlockSyntax` whose accessors are a bare `.getter` list containing no `AccessorDeclSyntax` — so the existing override never fired, `functionNestingDepth` stayed at 0, and every local `let` was collected as a stored property. Only `.getter` is counted; an explicit `get { }` already contains an accessor decl and would otherwise be double-counted.

**Backtick-escaped member names.** `func \`default\`()` reports a `.text` of `` `default` `` with backticks; the call site `config.default()` reports `default`. They never matched, so *every* backticked member looked unreferenced regardless of use. Normalised at all three sites — the declaration and both reference collectors.

**A protocol reached through a refinement.** `protocol Q: P` declared beside P puts P's only reference in P's own file, while a caller holding a `Q` elsewhere calls P's requirements through it. Inheritance edges are recorded per child and checked transitively, with a `visited` set for termination.

## One result stated precisely

The backtick fix's effect on this repo is **not** two more false positives fixed. The two `` `default` `` rows that disappear are static members on nested Options structs, and they go because `default` now collides with the very common `.default` in other files. That is this rule's standing name-based conservatism — documented in its own header as the cost of missing names like `name` or `reset()` — finally applied to backticked names too. Both rows already carried a hand-written `disable:this`, now redundant and left in place as a guard.

## Not included

The stash also carried a protocol-requirement fix for the member rule. **Main already handles it** via `typeConformanceNames` / `projectProtocolNames`, by a different mechanism — verified with a control where removing the protocol makes the rule fire on the identical shape. Porting it would have been dead code.

## Verification

Two binaries, same corpora, same afternoon: **7 rows removed, 0 added** (4 on fixtures, 3 on this repo). Nothing new is reported anywhere.

| | before | after |
|---|---|---|
| fixture 1 (type / getter / backtick) | 15 | 12 |
| fixture 2 (protocol refinement) | 10 | 9 |
| this repo | 37 | 34 |

- Full suite green: **3268 tests, 396 suites**, after `swift package clean`
- SwiftLint `--strict`: **13 violations before and after**, none in the changed files (an earlier revision added one `cyclomatic_complexity`; fixed by splitting the type walker)

Every absence-asserting test is paired with a control differing only in the element that makes the finding wrong. **Run against the unfixed visitors: all five controls pass, all six false-positive tests fail** — except the explicit-getter case, which passes both ways because it guards against double-counting rather than covering a fix.

`stash@{1}` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjbVm7qSbE3WKVfDMXNGdx