### PR TITLE
Let a project exclude a filename wherever it appears

### DIFF
--- a/Docs/user/reference.md
+++ b/Docs/user/reference.md
@@ -124,6 +124,13 @@ excluded_paths:
   - "Generated/"
   - "**/*.generated.swift"
 
+# Exclude files by name, wherever they appear in the tree.
+# Matched against the file's basename only, and compared exactly —
+# no substring or glob matching. See "Excluded Filenames" below.
+excluded_filenames:
+  - "Deprecations.swift"
+  - "Constants.swift"
+
 # Analyze nested first-party Swift packages (directories with their own
 # Package.swift) in the same run instead of skipping them. Default: false.
 # See "Nested Packages" below for the trade-offs.
@@ -180,6 +187,31 @@ is unnecessary.
 
 The flag only overrides this app-versus-library judgement. It does not change which
 files are discovered, and it is independent of nested-package handling below.
+
+### Excluded Filenames
+
+`excluded_paths` answers "where": everything under `Generated/`, or — through its
+`**/` form — everything matching a filename glob. `excluded_filenames` answers a
+narrower question: *this filename, wherever it appears*.
+
+```yaml
+excluded_filenames:
+  - "Deprecations.swift"
+  - "Constants.swift"
+```
+
+Matching is against the file's **basename only** and is **exact**. `"Constants"`
+excludes nothing, and neither does `"Sources/Alpha/Constants.swift"` — a path
+pattern belongs in `excluded_paths`.
+
+Reach for it when the same filename recurs across a tree and the violations in it
+are intended wherever it appears. Listing directories would mean enumerating them
+all and revisiting the list whenever one is added.
+
+An excluded file is excluded from **reporting**, not from **evidence**. Cross-file
+rules reason about whole-project usage, so the file is still parsed and still
+counts as a use — otherwise a type referenced only from `Constants.swift` would
+start looking unused. This is the same treatment `excluded_paths` gets.
 
 ### Nested Packages
 

--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/LintConfiguration.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/LintConfiguration.swift
@@ -16,6 +16,16 @@ public struct LintConfiguration: Sendable {
     /// File path patterns to exclude globally (matched against relative paths).
     public let excludedPaths: [String]
 
+    /// Filenames to exclude globally, matched against the file's basename only and
+    /// compared exactly — no substring or glob matching.
+    ///
+    /// `excludedPaths` already covers location ("everything under `Generated/`") and,
+    /// through its `**/` form, name-shaped globs. This covers the case where the same
+    /// filename recurs all over a tree and the violations in it are intended wherever it
+    /// appears — `Deprecations.swift`, `Constants.swift` — so listing the directories
+    /// would mean enumerating them and revisiting the list whenever one is added.
+    public let excludedFilenames: [String]
+
     /// Per-rule overrides for severity and path exclusions.
     public let ruleOverrides: [RuleIdentifier: RuleOverride]
 
@@ -62,6 +72,7 @@ public struct LintConfiguration: Sendable {
         disabledRules: Set<RuleIdentifier> = [],
         enabledOnlyRules: Set<RuleIdentifier>? = nil,
         excludedPaths: [String] = [],
+        excludedFilenames: [String] = [],
         ruleOverrides: [RuleIdentifier: RuleOverride] = [:],
         architecturalLayers: [LayerPolicy] = [],
         enabledFrameworkAllowlists: Set<String>? = nil,
@@ -70,6 +81,7 @@ public struct LintConfiguration: Sendable {
         self.disabledRules = disabledRules
         self.enabledOnlyRules = enabledOnlyRules
         self.excludedPaths = excludedPaths
+        self.excludedFilenames = excludedFilenames
         self.ruleOverrides = ruleOverrides
         self.architecturalLayers = architecturalLayers
         self.enabledFrameworkAllowlists = enabledFrameworkAllowlists
@@ -83,6 +95,7 @@ public struct LintConfiguration: Sendable {
             disabledRules: disabledRules,
             enabledOnlyRules: enabledOnlyRules,
             excludedPaths: excludedPaths,
+            excludedFilenames: excludedFilenames,
             ruleOverrides: ruleOverrides,
             architecturalLayers: architecturalLayers,
             enabledFrameworkAllowlists: enabledFrameworkAllowlists,

--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/LintConfigurationLoader.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/LintConfigurationLoader.swift
@@ -18,6 +18,10 @@ import Yams
 ///   - "Tests/"
 ///   - "Generated/"
 ///
+/// excluded_filenames:
+///   - "Deprecations.swift"
+///   - "Constants.swift"
+///
 /// rules:
 ///   "Hardcoded Strings":
 ///     severity: info
@@ -52,6 +56,7 @@ public struct LintConfigurationLoader {
     private static func parse(yaml: [String: Any]) -> LintConfiguration {
         let disabledRules = parseRuleList(yaml["disabled_rules"])
         let excludedPaths = parseStringList(yaml["excluded_paths"])
+        let excludedFilenames = parseStringList(yaml["excluded_filenames"])
         let ruleOverrides = parseRuleOverrides(yaml["rules"])
         let architecturalLayers = parseArchitecturalLayers(yaml["architectural_layers"])
 
@@ -82,6 +87,7 @@ public struct LintConfigurationLoader {
             disabledRules: disabledRules,
             enabledOnlyRules: enabledOnlyRules,
             excludedPaths: excludedPaths,
+            excludedFilenames: excludedFilenames,
             ruleOverrides: ruleOverrides,
             architecturalLayers: architecturalLayers,
             enabledFrameworkAllowlists: enabledFrameworkAllowlists,

--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/FileAnalysis/FileAnalysisUtils.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/FileAnalysis/FileAnalysisUtils.swift
@@ -52,10 +52,14 @@ public struct FileAnalysisUtils {
     public static func findSwiftFiles(
         in path: String,
         excludedPaths: [String] = [],
+        excludedFilenames: [String] = [],
         includeNestedPackages: Bool = false
     ) -> [String] {
         enumerateSwiftFiles(
-            in: path, excludedPaths: excludedPaths, includeNestedPackages: includeNestedPackages
+            in: path,
+            excludedPaths: excludedPaths,
+            excludedFilenames: excludedFilenames,
+            includeNestedPackages: includeNestedPackages
         )
     }
 
@@ -68,15 +72,20 @@ public struct FileAnalysisUtils {
     /// - Parameters:
     ///   - path: The root directory path in which to search for Swift files.
     ///   - excludedPaths: Path patterns to exclude (matched against relative paths).
+    ///   - excludedFilenames: Basenames to exclude (matched against the file name only).
     /// - Returns: An array of full file paths to `.swift` files found within the directory and its subdirectories.
     @concurrent
     public static func findSwiftFiles(
         in path: String,
         excludedPaths: [String] = [],
+        excludedFilenames: [String] = [],
         includeNestedPackages: Bool = false
     ) async -> [String] {
         enumerateSwiftFiles(
-            in: path, excludedPaths: excludedPaths, includeNestedPackages: includeNestedPackages
+            in: path,
+            excludedPaths: excludedPaths,
+            excludedFilenames: excludedFilenames,
+            includeNestedPackages: includeNestedPackages
         )
     }
 
@@ -163,6 +172,7 @@ public struct FileAnalysisUtils {
     private static func enumerateSwiftFiles(
         in path: String,
         excludedPaths: [String] = [],
+        excludedFilenames: [String] = [],
         includeNestedPackages: Bool = false
     ) -> [String] {
         let fileManager = FileManager.default
@@ -213,12 +223,25 @@ public struct FileAnalysisUtils {
                 continue
             }
 
-            if !isDirectory, itemURL.pathExtension == "swift" {
+            if !isDirectory, isCollectableSwiftFile(itemURL, excludedFilenames: excludedFilenames) {
                 swiftFiles.append(itemURL.path)
             }
         }
 
         return swiftFiles
+    }
+
+    /// Whether `url` is a Swift file the caller asked to keep.
+    ///
+    /// Split out of `enumerateSwiftFiles` to keep that within the cyclomatic-complexity
+    /// budget. The filename comparison is against the basename alone and is exact:
+    /// `excludedPaths` already covers location and name-shaped globs, so this is for a
+    /// filename that recurs across the tree.
+    private static func isCollectableSwiftFile(
+        _ url: URL,
+        excludedFilenames: [String]
+    ) -> Bool {
+        url.pathExtension == "swift" && !excludedFilenames.contains(url.lastPathComponent)
     }
 
     /// Returns the canonical (symlink-resolved) path using POSIX `realpath(3)`.

--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/FileAnalysis/FileDiscoveryProtocol.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/FileAnalysis/FileDiscoveryProtocol.swift
@@ -6,11 +6,17 @@ public protocol FileDiscoveryProtocol: Sendable {
     /// Returns the paths of all Swift files under the given directory,
     /// excluding any paths matching the exclusion patterns.
     ///
-    /// - Parameter includeNestedPackages: When `true`, directories containing
-    ///   their own `Package.swift` are analyzed rather than skipped, so
-    ///   cross-file analysis can span first-party local packages.
+    /// - Parameters:
+    ///   - excludedFilenames: Basenames to exclude, compared exactly against the file
+    ///     name alone rather than the relative path.
+    ///   - includeNestedPackages: When `true`, directories containing
+    ///     their own `Package.swift` are analyzed rather than skipped, so
+    ///     cross-file analysis can span first-party local packages.
     func findSwiftFiles(
-        in directory: String, excludedPaths: [String], includeNestedPackages: Bool
+        in directory: String,
+        excludedPaths: [String],
+        excludedFilenames: [String],
+        includeNestedPackages: Bool
     ) async -> [String]
 }
 
@@ -19,10 +25,16 @@ public struct DefaultFileDiscovery: FileDiscoveryProtocol {
     public init() { /* no-op */ }
 
     public func findSwiftFiles(
-        in directory: String, excludedPaths: [String], includeNestedPackages: Bool
+        in directory: String,
+        excludedPaths: [String],
+        excludedFilenames: [String],
+        includeNestedPackages: Bool
     ) async -> [String] {
         await FileAnalysisUtils.findSwiftFiles(
-            in: directory, excludedPaths: excludedPaths, includeNestedPackages: includeNestedPackages
+            in: directory,
+            excludedPaths: excludedPaths,
+            excludedFilenames: excludedFilenames,
+            includeNestedPackages: includeNestedPackages
         )
     }
 }

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
@@ -126,6 +126,7 @@ extension ProjectLinter {
             disabledRules: disabledRules,
             enabledOnlyRules: configuration.enabledOnlyRules,
             excludedPaths: configuration.excludedPaths,
+            excludedFilenames: configuration.excludedFilenames,
             ruleOverrides: overrides,
             architecturalLayers: configuration.architecturalLayers,
             enabledFrameworkAllowlists: configuration.enabledFrameworkAllowlists,

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
@@ -190,15 +190,22 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         let reportableFilePaths = await fileDiscovery.findSwiftFiles(
             in: path,
             excludedPaths: configuration.excludedPaths,
+            excludedFilenames: configuration.excludedFilenames,
             includeNestedPackages: configuration.includeNestedPackages
         )
         let filePaths = reportableFilePaths.filter { !Self.isGeneratedFile(at: $0) }
 
-        guard !configuration.excludedPaths.isEmpty else { return (filePaths, []) }
+        // An excluded file is excluded from *reporting*, not from evidence: cross-file
+        // rules reason about whole-project usage, so dropping the file outright would
+        // make anything only used there look unused. Filename exclusions take the same
+        // second pass as path exclusions for that reason.
+        guard !configuration.excludedPaths.isEmpty
+            || !configuration.excludedFilenames.isEmpty else { return (filePaths, []) }
 
         let allFilePaths = await fileDiscovery.findSwiftFiles(
             in: path,
             excludedPaths: [],
+            excludedFilenames: [],
             includeNestedPackages: configuration.includeNestedPackages
         )
         let reportableSet = Set(filePaths)

--- a/Tests/CoreTests/ExcludedFilenamesTests.swift
+++ b/Tests/CoreTests/ExcludedFilenamesTests.swift
@@ -1,0 +1,175 @@
+@testable import Core
+import Foundation
+import SwiftProjectLintModels
+import Testing
+
+/// `excluded_filenames` — a global exclusion matched against a file's basename.
+///
+/// `excludedPaths` already covers location and, via its `**/` form, name-shaped globs.
+/// This exists for a filename that recurs across a tree where the violations are intended
+/// wherever it appears, so listing directories would mean enumerating them and revisiting
+/// the list whenever one is added.
+struct ExcludedFilenamesTests {
+
+    /// A tree with the same filename in two directories, plus one file that should always
+    /// be analysed. `Constants.swift` carries a force-unwrap so there is something to find.
+    private func makeProject() -> String {
+        let root = (FileManager.default.temporaryDirectory.path as NSString)
+            .appendingPathComponent("ExcludedFilenames-\(UUID().uuidString)")
+        for directory in ["Sources/Alpha", "Sources/Beta"] {
+            try? FileManager.default.createDirectory(
+                atPath: (root as NSString).appendingPathComponent(directory),
+                withIntermediateDirectories: true
+            )
+        }
+        let body = "func boom(_ value: Int?) -> Int { return value! }\n"
+        for path in [
+            "Sources/Alpha/Constants.swift",
+            "Sources/Beta/Constants.swift",
+            "Sources/Alpha/Regular.swift"
+        ] {
+            try? body.write(
+                toFile: (root as NSString).appendingPathComponent(path),
+                atomically: true, encoding: .utf8
+            )
+        }
+        return root
+    }
+
+    private func issues(at root: String, excludedFilenames: [String]) async -> [LintIssue] {
+        let linter = ProjectLinter()
+        let system = PatternRegistryFactory.createConfiguredSystem()
+        return await linter.analyzeProject(
+            at: root,
+            detector: system.detector,
+            configuration: LintConfiguration(excludedFilenames: excludedFilenames)
+        )
+    }
+
+    // MARK: - Discovery
+
+    @Test("an excluded filename is skipped in every directory it appears in")
+    func excludedFilenameIsSkippedEverywhere() async {
+        let root = makeProject()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let reported = await issues(at: root, excludedFilenames: ["Constants.swift"])
+
+        #expect(reported.contains { $0.filePath.hasSuffix("Constants.swift") } == false)
+        // Both copies go, not just the first one found.
+        #expect(reported.contains { $0.filePath.contains("Alpha/Constants.swift") } == false)
+        #expect(reported.contains { $0.filePath.contains("Beta/Constants.swift") } == false)
+    }
+
+    /// Control: without the setting the same tree reports both copies, so the exclusion
+    /// above is doing the work rather than the rule being silent on these files.
+    @Test("control — without the setting both copies are reported")
+    func withoutExclusionBothCopiesAreReported() async {
+        let root = makeProject()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let reported = await issues(at: root, excludedFilenames: [])
+
+        #expect(reported.contains { $0.filePath.contains("Alpha/Constants.swift") })
+        #expect(reported.contains { $0.filePath.contains("Beta/Constants.swift") })
+    }
+
+    @Test("files not named in the setting are still analysed")
+    func unlistedFilesAreStillAnalysed() async {
+        let root = makeProject()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let reported = await issues(at: root, excludedFilenames: ["Constants.swift"])
+
+        #expect(reported.contains { $0.filePath.hasSuffix("Regular.swift") })
+    }
+
+    /// The match is on the basename alone and is exact — a path fragment excludes nothing,
+    /// which is what `excludedPaths` is for.
+    @Test("matching is exact, not substring")
+    func matchingIsExact() async {
+        let root = makeProject()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let byFragment = await issues(at: root, excludedFilenames: ["Constants"])
+        let byPath = await issues(at: root, excludedFilenames: ["Sources/Alpha/Constants.swift"])
+
+        #expect(byFragment.contains { $0.filePath.hasSuffix("Constants.swift") })
+        #expect(byPath.contains { $0.filePath.hasSuffix("Constants.swift") })
+    }
+
+    // MARK: - Configuration plumbing
+
+    /// Every rebuild of a configuration has to carry this field. `resolveConfiguration`
+    /// reconstructs the whole value for Swift packages, and dropping a field there once
+    /// made `--include-nested-packages` a silent no-op for every package project.
+    ///
+    /// Asserted through `analyzeProject` on a tree with a `Package.swift` — the branch
+    /// that triggers the rebuild — rather than by calling the rebuild directly, which is
+    /// internal to the engine package. A dropped field shows up here as the excluded file
+    /// coming back.
+    @Test("the setting survives the Swift-package configuration rebuild")
+    func settingSurvivesResolveConfiguration() async {
+        let root = makeProject()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        try? "// swift-tools-version:6.0\n".write(
+            toFile: (root as NSString).appendingPathComponent("Package.swift"),
+            atomically: true, encoding: .utf8
+        )
+
+        let reported = await issues(at: root, excludedFilenames: ["Constants.swift"])
+
+        #expect(reported.contains { $0.filePath.hasSuffix("Constants.swift") } == false)
+        // The rebuild ran and the tree is otherwise analysed, so the absence above is the
+        // exclusion surviving rather than the whole run coming back empty.
+        #expect(reported.contains { $0.filePath.hasSuffix("Regular.swift") })
+    }
+
+    @Test("the setting survives withIncludeNestedPackages")
+    func settingSurvivesNestedPackageOverride() {
+        let configuration = LintConfiguration(excludedFilenames: ["Constants.swift"])
+            .withIncludeNestedPackages(true)
+
+        #expect(configuration.excludedFilenames == ["Constants.swift"])
+        #expect(configuration.includeNestedPackages)
+    }
+
+    @Test("excluded_filenames is read from YAML")
+    func yamlKeyIsParsed() throws {
+        let root = (FileManager.default.temporaryDirectory.path as NSString)
+            .appendingPathComponent("ExcludedFilenamesYAML-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(atPath: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let path = (root as NSString).appendingPathComponent(".swiftprojectlint.yml")
+        try """
+        excluded_filenames:
+          - "Deprecations.swift"
+          - "Constants.swift"
+        """.write(toFile: path, atomically: true, encoding: .utf8)
+
+        let configuration = LintConfigurationLoader.load(from: path)
+
+        #expect(configuration.excludedFilenames == ["Deprecations.swift", "Constants.swift"])
+    }
+
+    /// Absent key means no exclusions — and the default must be empty rather than nil-ish,
+    /// so an unconfigured project analyses everything.
+    @Test("an absent key leaves the list empty")
+    func absentKeyLeavesListEmpty() throws {
+        let root = (FileManager.default.temporaryDirectory.path as NSString)
+            .appendingPathComponent("ExcludedFilenamesEmpty-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(atPath: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let path = (root as NSString).appendingPathComponent(".swiftprojectlint.yml")
+        try "excluded_paths:\n  - \"Tests/\"\n".write(
+            toFile: path, atomically: true, encoding: .utf8
+        )
+
+        let configuration = LintConfigurationLoader.load(from: path)
+
+        #expect(configuration.excludedFilenames.isEmpty)
+        #expect(configuration.excludedPaths == ["Tests/"])
+    }
+}

--- a/Tests/CoreTests/ProjectLinterInjectionTests.swift
+++ b/Tests/CoreTests/ProjectLinterInjectionTests.swift
@@ -20,6 +20,7 @@ struct ProjectLinterInjectionTests {
         struct Call {
             let directory: String
             let excludedPaths: [String]
+            let excludedFilenames: [String]
             let includeNestedPackages: Bool
         }
 
@@ -34,13 +35,17 @@ struct ProjectLinterInjectionTests {
         }
 
         func findSwiftFiles(
-            in directory: String, excludedPaths: [String], includeNestedPackages: Bool
+            in directory: String,
+            excludedPaths: [String],
+            excludedFilenames: [String],
+            includeNestedPackages: Bool
         ) -> [String] {
             lock.withLock {
                 calls.append(
                     Call(
                         directory: directory,
                         excludedPaths: excludedPaths,
+                        excludedFilenames: excludedFilenames,
                         includeNestedPackages: includeNestedPackages
                     )
                 )


### PR DESCRIPTION
Adds `excluded_filenames`, recovered from `stash@{1}`.

## Why a second exclusion setting

`excluded_paths` answers *where*: everything under `Generated/`, or through its `**/` form everything matching a filename glob. This answers a narrower question — **this filename, wherever it appears** — for the case where the same name recurs across a tree and the violations in it are intended everywhere it does. `Deprecations.swift`, `Constants.swift`. Covering those by path means enumerating every directory and revisiting the list whenever one is added.

```yaml
excluded_filenames:
  - "Deprecations.swift"
  - "Constants.swift"
```

Matching is against the **basename alone** and is **exact**. A fragment (`"Constants"`) excludes nothing, and neither does a path (`"Sources/Alpha/Constants.swift"`) — that's what `excluded_paths` is for. A test pins both directions so the two settings can't quietly grow into each other.

## Two decisions

**Excluded from reporting, not from evidence.** Cross-file rules reason about whole-project usage, so dropping the file outright would make a type referenced only from `Constants.swift` look unused. `discoverFiles` gives filename exclusions the same second pass it already gives path exclusions, and its early-exit guard now tests both lists.

The stash **predates the evidence-only mechanism** and simply removed the files from discovery. Ported as-written it would have been a cross-file false-positive source, so this follows main's model instead.

**Three rebuild sites, all updated.** The initializer, `withIncludeNestedPackages`, and `resolveConfiguration`. The last already carries a comment recording that dropping a field there once made `--include-nested-packages` a silent no-op for every Swift-package project — the same trap, one field later.

## Verification

- Full suite green: **3289 tests, 399 suites**, after `swift package clean`
- SwiftLint `--strict`: **13 before and after**, none in the changed files (an earlier revision added a `cyclomatic_complexity`; fixed by extracting the collect decision)
- End-to-end through the built CLI with a real YAML config: 3 findings → 1, with both `Constants.swift` copies excluded and `Regular.swift` still analysed
- The rebuild test was verified by **removing the field again** — exactly that one test failed, the other seven passed

## Not included

Its stash companion, inline suppression for cross-file issues, **already landed on main** as `applyInlineSuppression` — in a better form, grouped by file with a defensive dedup for duplicate relative paths. Porting it would have been a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjbVm7qSbE3WKVfDMXNGdx