### PR TITLE
Recognise a label on the image, and move two thresholds

### DIFF
--- a/Docs/rules/large-view-body.md
+++ b/Docs/rules/large-view-body.md
@@ -7,10 +7,10 @@
 **Severity:** Warning
 
 ### Rationale
-A view body with more than 20 statements is difficult to comprehend and slows Xcode's type-checker. SwiftUI's type inference is applied to the entire `body` expression at once; very large bodies can cause compilation timeouts and degraded editor responsiveness.
+A view body with more than 25 statements is difficult to comprehend and slows Xcode's type-checker. SwiftUI's type inference is applied to the entire `body` expression at once; very large bodies can cause compilation timeouts and degraded editor responsiveness.
 
 ### Discussion
-`PerformanceVisitor` triggers this rule when the `body` getter contains more than 20 statements. The statement count targets the actual type-checker bottleneck — the body expression itself.
+`PerformanceVisitor` triggers this rule when the `body` getter contains more than 25 statements. The statement count targets the actual type-checker bottleneck — the body expression itself.
 
 Note: A related rule, **Large View Helper**, flags individual helper computed properties or methods within a View struct that exceed 50 lines. Well-factored views with many small helpers do not trigger either rule.
 
@@ -41,7 +41,7 @@ struct DashboardView: View {
             Text("Line 1")
             Text("Line 2")
             Text("Line 3")
-            // ... 20+ statements in the body
+            // ... 25+ statements in the body
             Text("Line 25")
         }
     }

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/ButtonAccessibilityChecker.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/ButtonAccessibilityChecker.swift
@@ -30,9 +30,18 @@ class ButtonAccessibilityChecker {
         let hasText = containsText(node)
         let hasLabel = containsLabel(node)
         let hasStringTitle = AccessibilityTreeTraverser.buttonHasStringTitle(node)
-        let hasAccessibilityLabel = AccessibilityTreeTraverser.hasAccessibilityModifier(
-            in: node, modifierName: "accessibilityLabel"
-        )
+        // Check both directions. `hasAccessibilityModifier` walks *up* the button's own
+        // modifier chain and so misses the label placed on the image inside the label
+        // closure — `Button { } label: { Image(...).accessibilityLabel("…") }` — which is
+        // a perfectly ordinary way to name an icon button, and was being reported as
+        // having no label at all.
+        let hasAccessibilityLabel =
+            AccessibilityTreeTraverser.hasAccessibilityModifier(
+                in: node, modifierName: "accessibilityLabel"
+            )
+            || AccessibilityTreeTraverser.containsAccessibilityModifier(
+                in: Syntax(node), modifierName: "accessibilityLabel"
+            )
 
         // Label() provides accessible text automatically
         if hasLabel {

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/ColorAccessibilityChecker.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/ColorAccessibilityChecker.swift
@@ -14,8 +14,14 @@ class ColorAccessibilityChecker {
         "clear", "gray", "primary", "secondary", "accentColor"
     ]
 
-    /// Maximum opacity value considered a background tint (not a primary color indicator).
-    private static let backgroundTintOpacityThreshold = 0.2
+    /// Maximum opacity value considered a background tint or decorative stroke rather than
+    /// a primary colour indicator.
+    ///
+    /// 0.35 rather than 0.2 so that the common decorative border —
+    /// `.stroke(Color.x.opacity(0.3), lineWidth: 1)` — is read as decoration. The rule is
+    /// about colour carrying *information* a colourblind reader would lose; a hairline
+    /// border at a third opacity is not carrying it.
+    private static let backgroundTintOpacityThreshold = 0.35
 
     init(visitor: AccessibilityVisitor) {
         self.visitor = visitor

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Performance/Visitors/PerformanceVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Performance/Visitors/PerformanceVisitor.swift
@@ -18,6 +18,15 @@ class PerformanceVisitor: BasePatternVisitor {
     var currentFilePath: String = ""
     private var isInViewBody: Bool = false
     private var viewBodySize: Int = 0
+
+    /// Statement count above which a `body` is reported as large.
+    ///
+    /// 25 rather than 20: the number is a judgement about where a body stops being
+    /// readable and starts costing type-checker time, and 20 fired on bodies that are
+    /// ordinary SwiftUI composition. Named here because it was written out at three
+    /// comparison sites, where changing one and missing the others would make the rule
+    /// disagree with itself about what "large" means.
+    private static let largeViewBodyStatementThreshold = 25
     private var isInViewStruct: Bool = false
 
     // For tracking unnecessary view updates
@@ -60,7 +69,7 @@ class PerformanceVisitor: BasePatternVisitor {
                        case .getter(let stmts) = accessorBlock.accessors {
                         self.walk(stmts)
                         // After walking, check and report large body
-                        if viewBodySize > 20 {
+                        if viewBodySize > Self.largeViewBodyStatementThreshold {
                             addIssue(
                                 severity: .warning,
                                 message: "Large view body in '\(currentViewName)' with \(viewBodySize) statements",
@@ -178,7 +187,7 @@ class PerformanceVisitor: BasePatternVisitor {
     }
 
     override func visitPost(_ node: VariableDeclSyntax) {
-        if isInViewBody, viewBodySize > 20 {
+        if isInViewBody, viewBodySize > Self.largeViewBodyStatementThreshold {
             addIssue(
                 severity: .warning,
                 message: "Large view body in '\(currentViewName)' with \(viewBodySize) statements",
@@ -193,7 +202,7 @@ class PerformanceVisitor: BasePatternVisitor {
     }
 
     override func visitPost(_ node: FunctionDeclSyntax) {
-        if isInViewBody, viewBodySize > 20 {
+        if isInViewBody, viewBodySize > Self.largeViewBodyStatementThreshold {
             addIssue(
                 severity: .warning,
                 message: "Large view body in '\(currentViewName)' with \(viewBodySize) statements",

--- a/Tests/CoreTests/AccessibilityAndViewThresholdTests.swift
+++ b/Tests/CoreTests/AccessibilityAndViewThresholdTests.swift
@@ -1,0 +1,139 @@
+@testable import Core
+import Foundation
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+/// Three rules recalibrated so they stop firing on shapes that are not the thing they warn
+/// about. Each absence is paired with a control on the other side of the line.
+@Suite
+struct AccessibilityAndViewThresholdTests {
+
+    private func accessibilityIssues(_ source: String) -> [LintIssue] {
+        TestRegistryManager.initializeSharedRegistry()
+        let visitor = AccessibilityVisitor(patternCategory: .accessibility)
+        visitor.walk(Parser.parse(source: source))
+        return visitor.detectedIssues
+    }
+
+    private func performanceIssues(_ source: String) -> [LintIssue] {
+        let visitor = PerformanceVisitor(patternCategory: .performance)
+        let syntax = Parser.parse(source: source)
+        visitor.setSourceLocationConverter(
+            SourceLocationConverter(fileName: "TestFile.swift", tree: syntax)
+        )
+        visitor.setFilePath("TestFile.swift")
+        visitor.walk(syntax)
+        return visitor.detectedIssues
+    }
+
+    private func viewBody(statements: Int) -> String {
+        let lines = (0..<statements)
+            .map { "            Text(\"line \($0)\")" }
+            .joined(separator: "\n")
+        return """
+        struct SizedView: View {
+            var body: some View {
+                VStack {
+        \(lines)
+                }
+            }
+        }
+        """
+    }
+
+    // MARK: - A label on the image rather than the button
+
+    /// `hasAccessibilityModifier` walks *up* the button's own modifier chain, so a label
+    /// placed on the image inside the label closure was invisible to it — and naming the
+    /// image is an ordinary way to name an icon button.
+    @Test("a label inside the button's label closure counts as labelled")
+    func labelInsideClosureCounts() {
+        let issues = accessibilityIssues("""
+        struct IconRow: View {
+            var body: some View {
+                Button {
+                    act()
+                } label: {
+                    Image(systemName: "star")
+                        .accessibilityLabel("Favourite")
+                }
+            }
+        }
+        """)
+
+        #expect(issues.contains { $0.ruleName == .iconOnlyButtonMissingLabel } == false)
+    }
+
+    /// Control: the same button with no label anywhere is still flagged, so the rule has
+    /// not simply gone quiet on icon buttons.
+    @Test("control — an icon button with no label anywhere is still flagged")
+    func unlabelledIconButtonStillFlagged() {
+        let issues = accessibilityIssues("""
+        struct IconRow: View {
+            var body: some View {
+                Button {
+                    act()
+                } label: {
+                    Image(systemName: "star")
+                }
+            }
+        }
+        """)
+
+        #expect(issues.contains { $0.ruleName == .iconOnlyButtonMissingLabel })
+    }
+
+    // MARK: - Decorative stroke opacity
+
+    /// A hairline border at a third opacity is decoration, not colour carrying information
+    /// a colourblind reader would lose.
+    @Test("a stroke at 0.3 opacity is treated as decorative")
+    func decorativeStrokeIsExempt() {
+        let issues = accessibilityIssues("""
+        struct CardBorder: View {
+            var body: some View {
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color.red.opacity(0.3), lineWidth: 1)
+            }
+        }
+        """)
+
+        #expect(issues.contains { $0.ruleName == .inaccessibleColorUsage } == false)
+    }
+
+    /// Control: above the threshold the colour is doing real work again and still fires,
+    /// so the exemption is the opacity and not the `.stroke` shape.
+    @Test("control — a stroke at 0.5 opacity still fires")
+    func strongerStrokeStillFires() {
+        let issues = accessibilityIssues("""
+        struct CardBorder: View {
+            var body: some View {
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color.red.opacity(0.5), lineWidth: 1)
+            }
+        }
+        """)
+
+        #expect(issues.contains { $0.ruleName == .inaccessibleColorUsage })
+    }
+
+    // MARK: - Large view body threshold
+
+    @Test("a body of 22 statements is no longer called large")
+    func mediumBodyIsNotLarge() {
+        let issues = performanceIssues(viewBody(statements: 22))
+
+        #expect(issues.contains { $0.ruleName == .largeViewBody } == false)
+    }
+
+    /// Control: past the new threshold the rule still fires, so raising it did not switch
+    /// the rule off.
+    @Test("control — a body of 30 statements is still large")
+    func largeBodyStillFires() {
+        let issues = performanceIssues(viewBody(statements: 30))
+
+        #expect(issues.contains { $0.ruleName == .largeViewBody })
+    }
+}


### PR DESCRIPTION
Three recalibrations, recovered from `stash@{1}`.

## Icon-Only Button Missing Label — a label on the image counts

`hasAccessibilityModifier` walks *up* the button's own modifier chain, so `Button { } label: { Image(…).accessibilityLabel("…") }` was reported as having no label at all — and naming the image is an ordinary way to name an icon button. The downward search added for the navigation-link rule (#97) is its complement; this is its second caller.

## Inaccessible Color Usage — decorative opacity

Treats opacity up to **0.35** as decorative, not 0.2. The rule is about colour carrying *information* a colourblind reader would lose; a hairline border at `.stroke(Color.x.opacity(0.3), lineWidth: 1)` isn't carrying it. A control pins that 0.5 still fires, so the exemption is the opacity rather than the `.stroke` shape.

## Large View Body — 25 statements, not 20

The number is a judgement about where a body stops being readable and starts costing type-checker time, and 20 fired on ordinary SwiftUI composition.

The threshold was written out at **three** comparison sites, so it's now a named constant — changing one and missing the others would leave the rule disagreeing with itself about what "large" means. `Docs/rules/large-view-body.md` is updated to match, since it states the number in three places of its own.

## A correction to what I flagged earlier

The stash also deleted this rule's `lineCount > 100` trigger, and I flagged that as a shipped-detection-path removal to hold. **It's already done on main** — `largeViewBody` is emitted from statement count alone and the doc already describes a single trigger. That concern came from reading the stash against its own base rather than against main.

## Verification

Two binaries, same corpus, same afternoon: **zero delta on this repo**. The two surviving `Inaccessible Color Usage` rows aren't opacity-guarded and nothing here reaches them — the behaviour change is demonstrated on fixtures, not on this corpus, which is the honest way round to state it.

- Full suite green: **3287 tests, 399 suites**, after `swift package clean`
- SwiftLint `--strict`: **13 before and after**, none in the changed files
- Existing `PerformanceVisitorCoverageTests` still pass at the new threshold — checked deliberately, since they generate bodies sized against the old one

Every absence-asserting test is paired with a control on the other side of the line.

## Still held

The remaining `ButtonAccessibilityChecker` change — inverting the text-button hint rule from "flag when missing" to "flag when present" — is deliberately not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjbVm7qSbE3WKVfDMXNGdx