### PR TITLE
Consume the shared nondeterminism classifier, and check the clock-determinism claim

### DIFF
--- a/Docs/rules/RULES.md
+++ b/Docs/rules/RULES.md
@@ -266,6 +266,7 @@ Rules marked **opt-in** are disabled by default and must be explicitly listed un
 | [ViewHosting Before Inspection](view-hosting-before-inspection.md) | Error |
 | [Observable Environment View Missing Inspection Hook](observable-environment-view-missing-inspection-hook.md) | Info |
 | [Unreachable Effect Closure](unreachable-effect-closure.md) | Info |
+| [Contradicted Clock Determinism](contradicted-clock-determinism.md) | Warning |
 
 ---
 

--- a/Docs/rules/contradicted-clock-determinism.md
+++ b/Docs/rules/contradicted-clock-determinism.md
@@ -1,0 +1,73 @@
+[← Back to Rules](RULES.md)
+
+## Contradicted Clock Determinism
+
+**Identifier:** `Contradicted Clock Determinism`
+**Category:** Testability
+**Severity:** Warning
+
+### Rationale
+
+**This is the only rule in the testability family that reports a contradiction rather than a smell.** The others describe code that *could* be more testable. This one says two parts of the same file disagree, and that a downstream tool is trusting the wrong half.
+
+`@ClockDeterministic` — or its doc-comment spelling `/// @lint.determinism clock_deterministic` — is a claim an author makes: *"my result does not vary with wall-clock time, **given** an injected `Clock`."* It exists because `.pure` implies synchronous, so an `async` function can never occupy the effect lattice's bottom tier no matter how well-behaved it is. The marker is what lets a consumer relax its **async veto** and admit such a function to property-based verification anyway.
+
+So the claim is load-bearing, and until this rule existed it was **parsed and never checked**. The author's word was the whole of the evidence. A wrong claim does not fail loudly — it produces a generated property test that passes locally and flakes later, which is the expensive failure mode the toolchain exists to prevent.
+
+```swift
+// Flagged — the annotation says one thing, the body does another
+@ClockDeterministic
+func expiry() async -> Date {
+    Date(timeIntervalSinceNow: 3600)
+}
+
+// Flagged — the acquisition is in this body, even though the use looks injected
+@ClockDeterministic
+func tick() async -> ContinuousClock.Instant {
+    let clock = ContinuousClock()
+    return clock.now
+}
+
+// Clean — the clock arrives as a parameter, which is what the claim asserts
+@ClockDeterministic
+func debounce<C: Clock>(clock: C) async throws {
+    try await Task.sleep(for: .seconds(1), tolerance: nil, clock: clock)
+}
+```
+
+### What counts as reaching for a clock
+
+The check refutes the **acquisition** of an ambient clock, not the *use* of one. An ambient clock has to be obtained somewhere, and obtaining it is syntactically distinctive in a way that using one is not — which is what lets `clock.now` on an injected parameter survive while `let clock = ContinuousClock()` does not.
+
+| form | reported | why |
+|---|---|---|
+| `Date()`, `Date.now` | yes | reads the host clock |
+| `Date(timeIntervalSinceNow:)` | yes | an offset *from* now still reads now |
+| `Date(timeIntervalSince1970:)` | no | fixed reference point, deterministic |
+| `ContinuousClock()`, `SuspendingClock()` | yes | constructing the host clock |
+| `Task.sleep(for:)` | yes | falls back to the host clock |
+| `Task.sleep(for:tolerance:clock:)` | no | sleeps on the clock it was handed |
+| `clock.now` where `clock` is a parameter | no | the point of the claim |
+| `UUID()`, `.shuffled()` | no | not the claim's subject — see below |
+
+Nested closures are included: an acquisition inside `Task { }` is still this function reaching for a clock nobody passed in.
+
+### Two limits worth knowing
+
+**A clean result is not a verified claim.** The claim holds only when nothing in the function *or anything it transitively calls* reaches for ambient time, and absence like that cannot be established by a syntactic pass. The oracle behind this rule therefore refuses to *confirm* the claim and offers only to *contradict* it — one witness is enough for a violation, which is why the refuting direction is tractable where the confirming one is not. This rule catches authors who are wrong in a visible way, not authors who are wrong.
+
+**Only clock nondeterminism counts.** `@ClockDeterministic` says the result does not vary with wall-clock time. It says nothing about a `UUID()` or a `.shuffled()`, so those do not contradict it — reporting them would fire on annotations that are perfectly honest about time. Inline randomness is [Non-Injected Nondeterminism](non-injected-nondeterminism.md)'s subject, and both rules read the same classifier so they cannot disagree about what an expression is.
+
+### Not a duplicate of Non-Injected Nondeterminism
+
+[Non-Injected Nondeterminism](non-injected-nondeterminism.md) reports inline clock reads in *any* function and says the code is hard to test. This rule fires only where the author claimed the opposite, and says the code contradicts itself.
+
+That difference is deliberate in the implementation too: the underlying oracle returns nothing for an **unannotated** function. A function reaching for a clock without having claimed otherwise contradicts nothing, and reporting it here would be the tool inventing a claim in order to violate it.
+
+### How to fix
+
+Take the clock as a parameter and read it there — that is the shape the annotation describes, and it is what makes the function testable with a `TestClock`. If the function genuinely depends on ambient time, drop the annotation instead: a consumer is relaxing its async veto on the strength of it.
+
+---
+
+*Generated from visitor source code and test cases in SwiftProjectLint. To contribute a rule correction or new rule, see the [contributor guide](../CONTRIBUTING.md).*

--- a/Package.swift
+++ b/Package.swift
@@ -57,6 +57,21 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
         .package(url: "https://github.com/x-sheep/swift-property-based.git", from: "1.0.0"),
+        // The conformance-law catalog, test-only. This package already had the
+        // generator *engine* (`swift-property-based`, above) and used it for
+        // hand-written property suites, but nothing ran the laws the standard
+        // protocols already owe: `swift-infer discover` measured 59 such laws
+        // over 22 carriers across the seven nested packages, checked by nothing.
+        // `PropertyLawKit` is the catalog that runs them — one
+        // `check<Protocol>PropertyLaws` call per conformance.
+        //
+        // Test-only, and deliberately kit-only. Recording verdicts back to
+        // `swift-infer` needs `SwiftInferKitEvidence`, which would add a
+        // dependency edge from this package to SwiftInferProperties — the
+        // opposite direction from the one the toolchain's dependency graph has,
+        // where the two leaves meet only at SwiftEffectInference. Running the
+        // laws is the value; feeding the verdicts back is a separate decision.
+        .package(url: "https://github.com/Joseph-Cursio/SwiftPropertyLaws.git", from: "3.28.0"),
         .package(url: "https://github.com/Joseph-Cursio/LintStudioUI.git", from: "1.3.0"),
         // The leaf effect-lattice library — now the single source of truth for
         // the `Effect` type and its `lub`. SPL's `DeclaredEffect` is a typealias
@@ -69,7 +84,7 @@ let package = Package(
         // swift-syntax exact 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "fc82ec440e38c3467cf2621666937510ebde5301"
+            revision: "22342caf2015e528bb71cad3b677eb64fad11aaf"
         )
     ],
     targets: [
@@ -116,6 +131,7 @@ let package = Package(
                 "Core",
                 "SwiftProjectLintIdempotencyRules",
                 .product(name: "PropertyBased", package: "swift-property-based"),
+                .product(name: "PropertyLawKit", package: "SwiftPropertyLaws"),
                 .product(name: "SwiftEffectInference", package: "SwiftEffectInference")
             ],
             path: "Tests/CoreTests",

--- a/Packages/SwiftProjectLintIdempotencyRules/Package.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // root and SwiftProjectLintVisitors pins.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "fc82ec440e38c3467cf2621666937510ebde5301"
+            revision: "22342caf2015e528bb71cad3b677eb64fad11aaf"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier+Category.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier+Category.swift
@@ -132,7 +132,8 @@ extension RuleIdentifier {
         case .globalMutableState, .nonInjectedNondeterminism, .pureFunctionCandidate,
              .pureClosureCandidate, .extractablePureKernel, .missingEquatableOnStateType,
              .impureCallInViewBody, .viewHostingBeforeInspection,
-             .observableEnvironmentViewMissingInspectionHook, .unreachableEffectClosure:
+             .observableEnvironmentViewMissingInspectionHook, .unreachableEffectClosure,
+             .contradictedClockDeterminism:
             return .testability
 
             // Other/System Rules

--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/RuleIdentifier.swift
@@ -243,6 +243,12 @@ public enum RuleIdentifier: String, CaseIterable, Codable, Sendable {
     /// impure twin of `pureClosureCandidate`, which refutes exactly this shape.
     case unreachableEffectClosure = "Unreachable Effect Closure"
 
+    /// A function claiming `@ClockDeterministic` whose own body reaches for a
+    /// clock nobody passed in. The only rule in the family that reports a
+    /// *contradiction* rather than a smell: the author stated the property, so
+    /// this is not advice about style.
+    case contradictedClockDeterminism = "Contradicted Clock Determinism"
+
     /// A value rebuilt field-by-field from one you already have, where the initialiser has
     /// defaulted parameters — so a forgotten field takes its default SILENTLY.
     case lossyStructRebuild = "Lossy Struct Rebuild"

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/ContradictedClockDeterminism.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/ContradictedClockDeterminism.swift
@@ -1,0 +1,31 @@
+import Foundation
+import SwiftProjectLintModels
+import SwiftProjectLintRegistry
+import SwiftProjectLintVisitors
+
+/// Registrar for the Contradicted Clock Determinism rule.
+///
+/// `severity: .warning` rather than `.info`, which the neighbouring testability
+/// rules mostly use, because this is the only one in the family reporting a
+/// statement the author made and the code refutes. The others describe a shape
+/// that *could* be more testable; this one says two parts of the same file
+/// disagree, and a downstream tool is trusting the wrong half.
+struct ContradictedClockDeterminism: PatternRegistrarProtocol {
+
+    var pattern: SyntaxPattern {
+        SyntaxPattern(
+            name: .contradictedClockDeterminism,
+            visitor: ContradictedClockDeterminismVisitor.self,
+            severity: .warning,
+            category: .testability,
+            messageTemplate: "Annotated clock-deterministic, but the body reads a clock nobody "
+                + "passed in",
+            suggestion: "Take the clock as a parameter and read it there, or drop the annotation.",
+            description: "Reports a function claiming `@ClockDeterministic` (or "
+                + "`/// @lint.determinism clock_deterministic`) whose body constructs or reads an "
+                + "ambient clock — `Date()`, `ContinuousClock()`, `Task.sleep(for:)`. The claim "
+                + "exists so a consumer can relax its async veto, so an unchecked one admits a "
+                + "time-dependent function to property-based verification, where it flakes."
+        )
+    }
+}

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/Testability.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/Testability.swift
@@ -105,7 +105,8 @@ class Testability: BasePatternRegistrar {
         registry.register(registrars: [
             MissingEquatableOnStateType(),
             ImpureCallInViewBody(),
-            UnreachableEffectClosure()
+            UnreachableEffectClosure(),
+            ContradictedClockDeterminism()
         ])
     }
 }

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ContradictedClockDeterminismVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ContradictedClockDeterminismVisitor.swift
@@ -1,0 +1,70 @@
+import Foundation
+import SwiftProjectLintModels
+import SwiftProjectLintVisitors
+import SwiftSyntax
+
+/// Reports a function that claims `@ClockDeterministic` — or the doc-comment
+/// spelling `/// @lint.determinism clock_deterministic` — while its own body
+/// reaches for a clock nobody passed in.
+///
+/// **The claim is load-bearing downstream, which is why an unchecked one is
+/// worth a rule.** `@ClockDeterministic` exists so a consumer can relax an
+/// *async veto*: `.pure` implies synchronous, so an `async` function can never
+/// occupy the lattice's bottom tier no matter what it does, and the marker is
+/// what admits such a function to property-based verification anyway. Before
+/// this rule the marker was parsed and never checked, so an author's word was
+/// the whole of the evidence — and a wrong one does not fail loudly. It produces
+/// a generated property test that passes locally and flakes later, which is the
+/// expensive failure mode this project exists to prevent.
+///
+/// ## Why this reports contradictions only
+///
+/// The claim holds only when nothing in the function, or anything it
+/// transitively calls, reaches for ambient time. Absence like that is not
+/// establishable by a syntactic pass, so the shared oracle refuses to confirm
+/// the claim and offers only to contradict it — one witness is enough, and one
+/// witness is what a violation needs.
+///
+/// The consequence worth stating: **a clean result here is not a verified
+/// claim.** This rule catches authors who are wrong in a visible way, not
+/// authors who are wrong.
+///
+/// ## Why it is not the nondeterminism rule
+///
+/// `nonInjectedNondeterminism` reports inline clock reads in *any* function and
+/// says the code is hard to test. This one fires only where the author claimed
+/// the opposite, and says the code contradicts itself — a different severity of
+/// mistake, since a claim that is merely absent misleads nobody. That is also
+/// why the underlying oracle returns nothing for an unannotated function: the
+/// tool must not invent a claim in order to violate it.
+final class ContradictedClockDeterminismVisitor: BasePatternVisitor {
+
+    private var fileIsTestOrFixture = false
+    private let refuter = ClockDeterminismRefuter()
+
+    required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
+        super.init(pattern: pattern, viewMode: viewMode)
+    }
+
+    override func setFilePath(_ filePath: String) {
+        super.setFilePath(filePath)
+        fileIsTestOrFixture = isTestOrFixtureFile()
+    }
+
+    override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard !fileIsTestOrFixture else { return .visitChildren }
+        guard let marker = refuter.contradictedClaim(in: node) else { return .visitChildren }
+
+        addIssue(
+            severity: .warning,
+            message: "`\(node.name.text)` is annotated clock-deterministic but reads "
+                + "`\(marker)` — a clock nobody passed in",
+            filePath: getFilePath(for: Syntax(node)),
+            lineNumber: getLineNumber(for: Syntax(node)),
+            suggestion: "Take the clock as a parameter and read it there, or drop the "
+                + "annotation — a consumer relaxes its async veto on the strength of it.",
+            ruleName: .contradictedClockDeterminism
+        )
+        return .visitChildren
+    }
+}

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
@@ -5,23 +5,35 @@ import SwiftSyntax
 
 /// Detects nondeterministic sources used inline in logic rather than injected
 /// as a dependency: `Date()`, `UUID()`, `.random(in:)`, `.randomElement()`,
-/// `.shuffled()`, the legacy C RNG/clock functions, and `Date.now` /
-/// `Locale.current` / `TimeZone.current`.
+/// `.shuffled()`, the legacy C RNG/clock functions, `Date.now` /
+/// `Locale.current` / `TimeZone.current`, and the concrete clocks
+/// (`ContinuousClock()`, `Task.sleep(for:)`).
 ///
 /// Inline nondeterminism is the #1 blocker to property-testing pure logic: a
 /// property can't pin the value or reproduce a counterexample, so the function
 /// stops being a function of its inputs. A source supplied as a parameter
 /// default (`init(id: UUID = UUID())`) is the injection seam, not inline use,
 /// and is exempt.
+///
+/// **What this classifies, it no longer decides.** The marker sets and the
+/// argument-aware matching that used to live here moved to
+/// `SwiftEffectInference.NondeterminismSources` — an equivalent copy had grown
+/// there alongside the clock-determinism refuter, and two implementations of one
+/// scan in two repositories is what the shared leaf exists to prevent. What
+/// stays here is everything the leaf cannot know: that a parameter default is a
+/// seam rather than a use, that fixture files are exempt, and what to tell the
+/// author.
+///
+/// The move widened coverage, because the leaf's clock set is larger than the
+/// one this rule had grown independently. `ContinuousClock()`,
+/// `SuspendingClock()`, `Task.sleep(for:)`, `DispatchTime.now()`, the remaining
+/// C clock functions and `Date(timeIntervalSinceNow:)` now report where they did
+/// not before. That is within the rule's stated intent rather than an extension
+/// of it — timing a property cannot pin is exactly what the message describes,
+/// and the suggestion already named a clock as the thing to inject.
 final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
 
     private var fileIsTestOrFixture = false
-
-    private static let noArgInitTypes: Set<String> = ["Date", "UUID"]
-    private static let bareFunctions: Set<String> = [
-        "arc4random", "arc4random_uniform", "drand48", "CFAbsoluteTimeGetCurrent"
-    ]
-    private static let randomMembers: Set<String> = ["random", "randomElement", "shuffled"]
 
     required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
         super.init(pattern: pattern, viewMode: viewMode)
@@ -33,54 +45,24 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
     }
 
     override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
-        guard !fileIsTestOrFixture, !isParameterDefaultValue(Syntax(node)) else {
-            return .visitChildren
-        }
-        if let source = nondeterministicCallSource(node) {
-            flag(source, at: Syntax(node))
-        }
+        report(NondeterminismSources.source(of: node), at: Syntax(node))
         return .visitChildren
     }
 
     override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
-        guard !fileIsTestOrFixture, !isParameterDefaultValue(Syntax(node)) else {
-            return .visitChildren
-        }
-        guard let base = node.base?.as(DeclReferenceExprSyntax.self)?.baseName.text else {
-            return .visitChildren
-        }
-        let name = node.declName.baseName.text
-        if (base == "Date" && name == "now")
-            || ((base == "Locale" || base == "TimeZone") && name == "current") {
-            flag("\(base).\(name)", at: Syntax(node))
-        }
+        report(NondeterminismSources.source(of: node), at: Syntax(node))
         return .visitChildren
     }
 
-    private func nondeterministicCallSource(_ node: FunctionCallExprSyntax) -> String? {
-        // Bare init / function: `Date()`, `UUID()` (only the no-argument forms
-        // are nondeterministic), `arc4random()`, `CFAbsoluteTimeGetCurrent()`.
-        if let ref = node.calledExpression.as(DeclReferenceExprSyntax.self) {
-            let name = ref.baseName.text
-            if Self.noArgInitTypes.contains(name), node.arguments.isEmpty {
-                return "\(name)()"
-            }
-            if Self.bareFunctions.contains(name) {
-                return "\(name)()"
-            }
-        }
-        // Member call: `Int.random(in:)`, `array.randomElement()`, `.shuffled()`.
-        if let member = node.calledExpression.as(MemberAccessExprSyntax.self),
-           Self.randomMembers.contains(member.declName.baseName.text) {
-            // A `using:` argument injects the RNG — `Int.random(in: r, using: &rng)`
-            // is reproducible from a seed, which is exactly the testable form. Only
-            // the system-RNG forms (no `using:`) are non-injected nondeterminism.
-            if node.arguments.contains(where: { $0.label?.text == "using" }) {
-                return nil
-            }
-            return ".\(member.declName.baseName.text)(…)"
-        }
-        return nil
+    /// Applies this rule's policy to a classified source: every kind reports,
+    /// but not in a fixture and not at an injection seam.
+    ///
+    /// The exemptions are checked here rather than in the classifier because
+    /// both are facts about *where* the expression sits, which is a property of
+    /// this rule's contract rather than of the expression.
+    private func report(_ source: NondeterminismSources.Source?, at node: Syntax) {
+        guard let source, !fileIsTestOrFixture, !isParameterDefaultValue(node) else { return }
+        flag(source.marker, at: node)
     }
 
     private func flag(_ source: String, at node: Syntax) {

--- a/Packages/SwiftProjectLintVisitors/Package.swift
+++ b/Packages/SwiftProjectLintVisitors/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "fc82ec440e38c3467cf2621666937510ebde5301"
+            revision: "22342caf2015e528bb71cad3b677eb64fad11aaf"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/NondeterminismSources.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/NondeterminismSources.swift
@@ -1,0 +1,106 @@
+import SwiftEffectInference
+import SwiftSyntax
+
+/// Thin forwarder onto the shared nondeterminism classifier in
+/// `SwiftEffectInference`.
+///
+/// The marker sets and the argument-aware shape matching used to live in
+/// `NonInjectedNondeterminismVisitor`, and an equivalent copy grew in SEI
+/// alongside its clock-determinism refuter — two implementations of the same
+/// scan in two repositories, which is the arrangement the shared leaf exists to
+/// prevent. The classifier now lives there and this forwards to it, so a
+/// clock-reading expression cannot mean one thing to the linter and another to
+/// the oracle.
+///
+/// Same forwarding rationale as `PurityInferrer`: `MemberImportVisibility`
+/// requires the *using* module to import the member's defining module, so a
+/// `typealias` would force `SwiftProjectLintRules` to take a direct SEI
+/// dependency. Re-declaring the result types here keeps that edge out of the
+/// rules package, which is why `Kind` and `Source` are local shapes rather than
+/// SEI's — the rules package never names an SEI type today, and this does not
+/// start.
+public enum NondeterminismSources {
+
+    /// Which kind of unpredictability a source introduces.
+    ///
+    /// Mirrors `SwiftEffectInference.NondeterminismSource.Kind`. Rules filter on
+    /// it: the nondeterminism rule reports every kind, and the
+    /// clock-determinism rule is only interested in `.clock`.
+    public enum Kind: Sendable, Equatable {
+        case clock
+        case randomness
+        case identity
+        case ambientEnvironment
+    }
+
+    /// A classified source: what it is, and how to name it in a diagnostic.
+    ///
+    /// Carries no position — every consumer here is a `BasePatternVisitor`,
+    /// which already resolves file and line from the node it was handed.
+    public struct Source: Sendable, Equatable {
+        public let kind: Kind
+        public let marker: String
+
+        public init(kind: Kind, marker: String) {
+            self.kind = kind
+            self.marker = marker
+        }
+    }
+
+    /// Classifies a call expression — `Date()`, `Int.random(in:)`,
+    /// `Task.sleep(for:)` — or `nil` when it is determined by its inputs.
+    public static func source(of call: FunctionCallExprSyntax) -> Source? {
+        map(SwiftEffectInference.NondeterminismSources.source(of: call))
+    }
+
+    /// Classifies a member access not in call position — `Date.now`,
+    /// `Locale.current` — or `nil`.
+    public static func source(of member: MemberAccessExprSyntax) -> Source? {
+        map(SwiftEffectInference.NondeterminismSources.source(of: member))
+    }
+
+    private static func map(_ source: SwiftEffectInference.NondeterminismSource?) -> Source? {
+        guard let source else { return nil }
+        let kind: Kind
+        switch source.kind {
+        case .clock: kind = .clock
+        case .randomness: kind = .randomness
+        case .identity: kind = .identity
+        case .ambientEnvironment: kind = .ambientEnvironment
+        }
+        return Source(kind: kind, marker: source.marker)
+    }
+}
+
+/// Thin forwarder onto SEI's clock-determinism refuter.
+///
+/// The refuter only ever **contradicts** the `@ClockDeterministic` claim — it
+/// has no method that confirms one, by design: the claim holds only when nothing
+/// in the function or its transitive callees reaches for ambient time, and
+/// absence is not establishable by a syntactic pass. One witness that the claim
+/// is false is, which is all a lint rule needs.
+public struct ClockDeterminismRefuter: Sendable {
+
+    private let underlying = SwiftEffectInference.ClockDeterminismRefuter()
+
+    public init() {
+        // No configuration: the underlying refuter is stateless.
+    }
+
+    /// The ambient-time source contradicting `function`'s own
+    /// `@ClockDeterministic` claim, or `nil`.
+    ///
+    /// Returns `nil` when the claim is **absent**, which is the guard that keeps
+    /// this from becoming a rule about unannotated code: a function reaching for
+    /// a clock without having claimed otherwise contradicts nothing, and
+    /// reporting it would be the tool inventing a claim in order to violate it.
+    /// The `nonInjectedNondeterminism` rule is what covers unannotated inline
+    /// clock reads, and it deliberately answers a different question.
+    ///
+    /// Composing the claim with its contradiction is done in SEI rather than
+    /// here, so the marker's spelling and its refutation cannot drift apart
+    /// across the two repositories.
+    public func contradictedClaim(in function: FunctionDeclSyntax) -> String? {
+        underlying.contradictedClaim(in: function)?.marker
+    }
+}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Many of these rules exist just so I can explore the effects. Some rules are bad 
 
 # Swift Project Linter
 
-A static analysis tool for SwiftUI projects that detects architectural issues, performance problems, and code quality concerns. Parses Swift source files using SwiftSyntax AST visitors to identify anti-patterns across 202 rules in 13 categories.
+A static analysis tool for SwiftUI projects that detects architectural issues, performance problems, and code quality concerns. Parses Swift source files using SwiftSyntax AST visitors to identify anti-patterns across 203 rules in 13 categories.
 
 The origin of this project began with a limitation of SwiftLint: it processes a single file at a time and cannot identify cross-file issues.
 
@@ -18,7 +18,7 @@ Motivating example: I was watching the "Quality Coding" channel on YouTube. Jon 
 
 - **SwiftSyntax AST Analysis**: Precise, AST-based pattern detection — no regex
 - **Cross-File Analysis**: Detects issues spanning multiple files (duplicate state, view hierarchies)
-- **202 Lint Rules** across 13 categories
+- **203 Lint Rules** across 13 categories
 - **Three delivery targets**: macOS app GUI, CLI for CI/CD, and a reusable Core library
 - **YAML configuration**: `.swiftprojectlint.yml` for per-project rule customization
 - **Inline suppression**: `// swiftprojectlint:disable` comments for per-line control
@@ -49,7 +49,7 @@ swift run CLI /path/to/project --categories stateManagement,performance --thresh
 
 ## Rules
 
-202 rules across 13 categories. See [Docs/rules/RULES.md](Docs/rules/RULES.md) for the full reference.
+203 rules across 13 categories. See [Docs/rules/RULES.md](Docs/rules/RULES.md) for the full reference.
 
 | Category | Rules |
 |----------|-------|
@@ -65,7 +65,7 @@ swift run CLI /path/to/project --categories stateManagement,performance --thresh
 | UI Patterns | 7 |
 | Modernization | 25 |
 | Idempotency | 7 |
-| Testability | 10 |
+| Testability | 11 |
 
 Rules marked **opt-in** are disabled by default and must be explicitly listed under `enabled_only` in `.swiftprojectlint.yml`.
 

--- a/Tests/CoreTests/Testability/ContradictedClockDeterminismVisitorTests.swift
+++ b/Tests/CoreTests/Testability/ContradictedClockDeterminismVisitorTests.swift
@@ -1,0 +1,111 @@
+@testable import Core
+import Foundation
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+/// The rule reports a *contradiction*, so the two halves that matter are: it
+/// fires when the author claimed clock-determinism and the body refutes it, and
+/// it stays silent in every other combination. The silence half is the larger
+/// one — a rule that reported unannotated clock reads would be duplicating
+/// `nonInjectedNondeterminism` while pretending the author had said something.
+@Suite
+struct ContradictedClockDeterminismVisitorTests {
+
+    private func analyze(_ source: String, filePath: String = "Logic.swift") -> [LintIssue] {
+        let visitor = ContradictedClockDeterminismVisitor(patternCategory: .testability)
+        let syntax = Parser.parse(source: source)
+        let converter = SourceLocationConverter(fileName: filePath, tree: syntax)
+        visitor.setSourceLocationConverter(converter)
+        visitor.setFilePath(filePath)
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == .contradictedClockDeterminism }
+    }
+
+    @Test func flagsAttributeClaimContradictedByDate() {
+        let source = """
+        @ClockDeterministic
+        func stale() async -> Date { Date() }
+        """
+        let issues = analyze(source)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Date()") == true)
+        #expect(issues.first?.message.contains("stale") == true)
+    }
+
+    @Test func flagsDocCommentClaimContradictedByTaskSleep() {
+        let source = """
+        /// @lint.determinism clock_deterministic
+        func debounce() async throws { try await Task.sleep(for: .seconds(1)) }
+        """
+        let issues = analyze(source)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Task.sleep") == true)
+    }
+
+    @Test func flagsClaimContradictedByALocallyConstructedClock() {
+        // The acquisition is in this body even though the *use* looks injected.
+        let source = """
+        @ClockDeterministic
+        func tick() async -> ContinuousClock.Instant {
+            let clock = ContinuousClock()
+            return clock.now
+        }
+        """
+        #expect(analyze(source).count == 1)
+    }
+
+    @Test func flagsClaimContradictedInsideANestedClosure() {
+        let source = """
+        @ClockDeterministic
+        func schedule() async { Task { let stamp = Date(); print(stamp) } }
+        """
+        #expect(analyze(source).count == 1)
+    }
+
+    // MARK: - Silence
+
+    /// The guard that keeps this from becoming a rule about unannotated code.
+    /// `nonInjectedNondeterminism` covers that, and says something different.
+    @Test func ignoresUnannotatedClockReads() {
+        #expect(analyze("func stamp() -> Date { Date() }").isEmpty)
+    }
+
+    @Test func ignoresAnHonestClaimOnAnInjectedClock() {
+        let source = """
+        @ClockDeterministic
+        func debounce<C: Clock>(clock: C) async throws {
+            try await Task.sleep(for: .seconds(1), tolerance: nil, clock: clock)
+        }
+        """
+        #expect(analyze(source).isEmpty)
+    }
+
+    @Test func ignoresAClaimWhoseOnlyTimeIsAFixedReferencePoint() {
+        let source = """
+        @ClockDeterministic
+        func epoch() async -> Date { Date(timeIntervalSince1970: 0) }
+        """
+        #expect(analyze(source).isEmpty)
+    }
+
+    /// Randomness is not the claim's subject. `@ClockDeterministic` says the
+    /// result does not vary with wall-clock time; it says nothing about a UUID,
+    /// and refuting on one would contradict an annotation that is honest.
+    @Test func ignoresNonClockNondeterminismUnderTheClaim() {
+        let source = """
+        @ClockDeterministic
+        func identify() async -> UUID { UUID() }
+        """
+        #expect(analyze(source).isEmpty)
+    }
+
+    @Test func ignoresTestFiles() {
+        let source = """
+        @ClockDeterministic
+        func stale() async -> Date { Date() }
+        """
+        #expect(analyze(source, filePath: "LogicTests.swift").isEmpty)
+    }
+}

--- a/Tests/CoreTests/Testability/NonInjectedNondeterminismVisitorTests.swift
+++ b/Tests/CoreTests/Testability/NonInjectedNondeterminismVisitorTests.swift
@@ -100,4 +100,49 @@ struct NonInjectedNondeterminismVisitorTests {
         // Regression guard: only the `using:`-injected form is exempt.
         #expect(analyze("func roll() -> Int { Int.random(in: 1...6) }").count == 1)
     }
+
+    // MARK: - Clock coverage gained with the shared classifier
+    //
+    // The rule's own marker set never knew the concrete clocks; the leaf's does.
+    // These are new reports, and they are the rule's stated subject — a
+    // property-based test can no more pin `Task.sleep(for:)` than `Date()`.
+
+    @Test func flagsConcreteClockConstruction() {
+        let source = """
+        func timed() -> Duration { ContinuousClock().measure { } }
+        func suspended() -> SuspendingClock.Instant { SuspendingClock().now }
+        """
+        #expect(analyze(source).count == 2)
+    }
+
+    @Test func flagsTaskSleepOnTheHostClock() {
+        let source = """
+        func wait() async throws { try await Task.sleep(for: .seconds(1)) }
+        """
+        #expect(analyze(source).count == 1)
+    }
+
+    @Test func ignoresTaskSleepOnASuppliedClock() {
+        // The injection seam, exactly as `using:` is for randomness.
+        let source = """
+        func wait<C: Clock>(clock: C) async throws {
+            try await Task.sleep(for: .seconds(1), tolerance: nil, clock: clock)
+        }
+        """
+        #expect(analyze(source).isEmpty)
+    }
+
+    @Test func flagsDateOffsetFromNow() {
+        // `timeIntervalSinceNow:` reads the clock despite taking an argument —
+        // the case a "no-argument initializers only" rule could not express.
+        #expect(analyze("func soon() -> Date { Date(timeIntervalSinceNow: 60) }").count == 1)
+    }
+
+    @Test func ignoresReadingAnInjectedClock() {
+        // The shape the whole clock family exists to make possible.
+        let source = """
+        func at<C: Clock>(clock: C) -> C.Instant { clock.now }
+        """
+        #expect(analyze(source).isEmpty)
+    }
 }


### PR DESCRIPTION
Consumer half of SwiftEffectInference [#9](https://github.com/Joseph-Cursio/SwiftEffectInference/issues/9). Pairs with SEI [#10](https://github.com/Joseph-Cursio/SwiftEffectInference/pull/10) and [#11](https://github.com/Joseph-Cursio/SwiftEffectInference/pull/11).

Three commits, each building and passing.

## 1. Bump the SEI pin — `fc82ec4` → `22342ca`

All three manifests together, as `SEIPinAgreementTests` requires. Source-compatible: new types only.

## 2. `NonInjectedNondeterminismVisitor` reads the shared classifier

This rule's marker sets had an **equivalent copy in SEI**, grown independently — the same no-argument-`Date()` rule, the same `using:` exemption, written twice in two repositories. SEI's `PurityInferrer` doc already named *this visitor* as the AST-precise counterpart its token scan approximates, so the duplication was known and documented before it existed in code.

Classification moved to the leaf; **judgement stayed here** — that a parameter default is an injection seam rather than a use, that fixture files are exempt, and what to tell the author. The leaf cannot know any of those.

The forwarder re-declares its result types locally, following `PurityInferrer`'s precedent, so `MemberImportVisibility` doesn't force `SwiftProjectLintRules` to take a direct SEI dependency edge. That package names no SEI type today and this doesn't start.

### ⚠️ This widens the rule's coverage — the thing to review

The leaf's clock set is larger than the one this rule had grown. **New reports:** `ContinuousClock()`, `SuspendingClock()`, `Task.sleep(for:)`, `DispatchTime.now()`, `mach_absolute_time()` and friends, and `Date(timeIntervalSinceNow:)`.

I judged this within the rule's stated intent rather than an extension of it — a property-based test can no more pin a sleep than a `Date()`, and the existing suggestion already named a clock as the thing to inject. But it will fire on code that was previously clean, so **it's a behaviour change on a shipped rule and worth a second opinion.** `Task.sleep(for:tolerance:clock:)` stays clean, being the same injection seam `using:` is for randomness.

**All 12 existing tests pass unchanged** — that's the check that the extraction preserved behaviour. Six new ones cover the widened set and its seam.

## 3. New rule: Contradicted Clock Determinism

`@ClockDeterministic` was parsed and never checked, in *either* repository, while downstream it relaxes an async veto. The author's word was the whole of the evidence, and a wrong one doesn't fail loudly — it yields a generated property test that passes locally and flakes later.

- **Reports contradictions only.** The oracle refuses to *confirm* the claim (absence of ambient time across a call graph isn't syntactically establishable) and offers only to contradict it. The rule doc states the consequence rather than leaving it implicit: **a clean result is not a verified claim.**
- **`.warning`, unlike its `.info` neighbours.** They describe code that could be more testable; this says two parts of one file disagree.
- **Not a duplicate of `nonInjectedNondeterminism`.** That reports inline clock reads anywhere. This fires only where the author claimed otherwise — and the oracle returns nothing for unannotated functions, so the tool cannot invent a claim in order to violate it. There's a test pinning that, and another pinning that `UUID()` under the claim is *ignored* (the claim is about time; refuting on randomness would contradict an honest annotation).

Rule doc added, `RULES.md` and the README counts updated (202→203, Testability 10→11) — the README count guard caught that, which is what it's for.

## Verification

Full suite: **3,338 tests in 405 suites passing.** New and changed files are SwiftLint-clean.

## Note for the author

This branch was cut from a working tree that already had **uncommitted changes** — `LintIssue+Ordering.swift` (134 insertions) plus two untracked test files under `Tests/CoreTests/Export/` and `Tests/CoreTests/Models/`. I deliberately did **not** stage them; they're still in the working tree. The test run above included them, so if they're mid-flight, that number isn't a clean read of this branch alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GyB5DUu2AFppW9fo7cBn8