### PR TITLE
Hold the nondeterminism rule at the scope it had before the move

### DIFF
--- a/Docs/rules/non-injected-nondeterminism.md
+++ b/Docs/rules/non-injected-nondeterminism.md
@@ -18,6 +18,16 @@ A property-based test re-runs logic against many randomized inputs and, when it 
 
 Uses in a parameter *default value* position are exempt (a defaulted `clock: () -> Date = { Date() }` is itself the injection seam), as are test files.
 
+### What this rule deliberately does not flag
+
+`ContinuousClock()`, `SuspendingClock()`, `Task.sleep(for:)`, `DispatchTime.now()`, the monotonic C functions (`mach_absolute_time`, `clock_gettime`), and `Date(timeIntervalSinceNow:)` all read a clock, and none of them are reported here.
+
+The line this rule draws is **arity**: a construction taking no input can only have come from ambient state. `Date(timeIntervalSinceNow: 60)` takes one, so it falls outside — a known miss, kept rather than quietly closed.
+
+The rest are the subject of [Contradicted Clock Determinism](contradicted-clock-determinism.md), which reports them only where a function claimed `@ClockDeterministic` and its body says otherwise. Both rules read the same classifier in SwiftEffectInference, so they cannot disagree about *what* an expression is — only about which of them should report it.
+
+Widening this rule to the fuller clock set is a decision to take on its own evidence. It briefly happened as a side effect of de-duplicating the two implementations, and was reverted: a rule that widens because its dependency learned new spellings has a scope nobody chose.
+
 ```swift
 // Before — reads the clock inline; can't be pinned by a test
 func isExpired(_ token: Token) -> Bool {

--- a/Package.swift
+++ b/Package.swift
@@ -84,7 +84,7 @@ let package = Package(
         // swift-syntax exact 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "22342caf2015e528bb71cad3b677eb64fad11aaf"
+            revision: "8127f26a3065a42277de52fb31c93240219a2152"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintIdempotencyRules/Package.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // root and SwiftProjectLintVisitors pins.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "22342caf2015e528bb71cad3b677eb64fad11aaf"
+            revision: "8127f26a3065a42277de52fb31c93240219a2152"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
@@ -24,13 +24,27 @@ import SwiftSyntax
 /// seam rather than a use, that fixture files are exempt, and what to tell the
 /// author.
 ///
-/// The move widened coverage, because the leaf's clock set is larger than the
-/// one this rule had grown independently. `ContinuousClock()`,
-/// `SuspendingClock()`, `Task.sleep(for:)`, `DispatchTime.now()`, the remaining
-/// C clock functions and `Date(timeIntervalSinceNow:)` now report where they did
-/// not before. That is within the rule's stated intent rather than an extension
-/// of it — timing a property cannot pin is exactly what the message describes,
-/// and the suggestion already named a clock as the thing to inject.
+/// ## Scope is declared, not inherited
+///
+/// The leaf classifies more time sources than this rule reports —
+/// `ContinuousClock()`, `SuspendingClock()`, `Task.sleep(for:)`,
+/// `DispatchTime.now()`, the monotonic C functions, and
+/// `Date(timeIntervalSinceNow:)`. Moving to the shared classifier briefly pulled
+/// all of them in, and they are **deliberately excluded again**: this rule's
+/// coverage is unchanged from before the migration, and a rule that widens
+/// because its dependency learned new spellings is a rule whose scope nobody
+/// chose.
+///
+/// The exclusions are not a claim that those constructs are testable. They are
+/// the rule keeping the line it has always drawn — bare acquisitions of a value
+/// the inputs do not determine — while `contradicted-clock-determinism` covers
+/// the fuller clock set for functions that claimed otherwise. Widening this one
+/// is a decision to take on its own evidence, not a side effect of
+/// de-duplication.
+///
+/// `reportedKinds` is where that scope lives, and it is exhaustive rather than
+/// a negative test: a kind added upstream fails to compile until someone says
+/// which side of the line it falls on.
 final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
 
     private var fileIsTestOrFixture = false
@@ -54,14 +68,31 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
         return .visitChildren
     }
 
-    /// Applies this rule's policy to a classified source: every kind reports,
-    /// but not in a fixture and not at an injection seam.
+    /// The kinds this rule reports — its scope, stated once.
+    ///
+    /// Exactly the set it covered before the shared classifier existed:
+    /// `Date()` / `Date.now` / `CFAbsoluteTimeGetCurrent()`, `UUID()`, the RNG
+    /// draws, and `Locale.current` / `TimeZone.current`. The time kinds absent
+    /// here are absent on purpose — see the type doc.
+    ///
+    /// `wallClockOffset` is excluded because the rule's line is arity: a
+    /// construction taking no input can only have come from ambient state, and
+    /// `Date(timeIntervalSinceNow:)` takes one. That is a *known* miss rather
+    /// than an oversight — it does read the clock — and it is preserved so this
+    /// change stays a narrowing and nothing else.
+    private static let reportedKinds: Set<NondeterminismSources.Kind> = [
+        .wallClockNow, .randomness, .identity, .ambientEnvironment
+    ]
+
+    /// Applies this rule's policy to a classified source: the reported kinds
+    /// fire, but not in a fixture and not at an injection seam.
     ///
     /// The exemptions are checked here rather than in the classifier because
     /// both are facts about *where* the expression sits, which is a property of
     /// this rule's contract rather than of the expression.
     private func report(_ source: NondeterminismSources.Source?, at node: Syntax) {
-        guard let source, !fileIsTestOrFixture, !isParameterDefaultValue(node) else { return }
+        guard let source, Self.reportedKinds.contains(source.kind) else { return }
+        guard !fileIsTestOrFixture, !isParameterDefaultValue(node) else { return }
         flag(source.marker, at: node)
     }
 

--- a/Packages/SwiftProjectLintVisitors/Package.swift
+++ b/Packages/SwiftProjectLintVisitors/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "22342caf2015e528bb71cad3b677eb64fad11aaf"
+            revision: "8127f26a3065a42277de52fb31c93240219a2152"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/NondeterminismSources.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/NondeterminismSources.swift
@@ -27,7 +27,24 @@ public enum NondeterminismSources {
     /// it: the nondeterminism rule reports every kind, and the
     /// clock-determinism rule is only interested in `.clock`.
     public enum Kind: Sendable, Equatable {
-        case clock
+        /// A bare read of the current wall-clock instant — `Date()`,
+        /// `Date.now`, `CFAbsoluteTimeGetCurrent()`.
+        case wallClockNow
+
+        /// A wall-clock instant derived *from* now —
+        /// `Date(timeIntervalSinceNow:)`.
+        case wallClockOffset
+
+        /// A monotonic clock read — `DispatchTime.now()`, `mach_absolute_time()`.
+        case monotonicClock
+
+        /// Obtaining a host clock object — `ContinuousClock()`,
+        /// `SuspendingClock()`.
+        case clockAcquisition
+
+        /// Suspending on a clock nobody supplied — `Task.sleep(for:)`.
+        case timedSuspension
+
         case randomness
         case identity
         case ambientEnvironment
@@ -61,14 +78,28 @@ public enum NondeterminismSources {
 
     private static func map(_ source: SwiftEffectInference.NondeterminismSource?) -> Source? {
         guard let source else { return nil }
-        let kind: Kind
-        switch source.kind {
-        case .clock: kind = .clock
-        case .randomness: kind = .randomness
-        case .identity: kind = .identity
-        case .ambientEnvironment: kind = .ambientEnvironment
+        return Source(kind: mapKind(source.kind), marker: source.marker)
+    }
+
+    /// Exhaustive, with no `default`: a kind added upstream must fail to compile
+    /// here and get a considered mapping, rather than quietly landing in
+    /// whichever local case happened to be the fallback.
+    ///
+    /// Split from `map` so the nil-guard's branch does not count against the
+    /// switch's complexity budget. The alternative — a dictionary lookup with a
+    /// fallback — would fit in one function and give up exactly the
+    /// exhaustiveness this exists for.
+    private static func mapKind(_ kind: SwiftEffectInference.NondeterminismSource.Kind) -> Kind {
+        switch kind {
+        case .wallClockNow: return .wallClockNow
+        case .wallClockOffset: return .wallClockOffset
+        case .monotonicClock: return .monotonicClock
+        case .clockAcquisition: return .clockAcquisition
+        case .timedSuspension: return .timedSuspension
+        case .randomness: return .randomness
+        case .identity: return .identity
+        case .ambientEnvironment: return .ambientEnvironment
         }
-        return Source(kind: kind, marker: source.marker)
     }
 }
 

--- a/Tests/CoreTests/Testability/NonInjectedNondeterminismVisitorTests.swift
+++ b/Tests/CoreTests/Testability/NonInjectedNondeterminismVisitorTests.swift
@@ -101,48 +101,65 @@ struct NonInjectedNondeterminismVisitorTests {
         #expect(analyze("func roll() -> Int { Int.random(in: 1...6) }").count == 1)
     }
 
-    // MARK: - Clock coverage gained with the shared classifier
+    // MARK: - Scope held at the pre-migration line
     //
-    // The rule's own marker set never knew the concrete clocks; the leaf's does.
-    // These are new reports, and they are the rule's stated subject — a
-    // property-based test can no more pin `Task.sleep(for:)` than `Date()`.
+    // The shared classifier knows more time sources than this rule reports.
+    // These pin the exclusions, because the failure they guard against is
+    // silent: a rule that widens whenever its dependency learns a new spelling
+    // has a scope nobody chose. Each of these DOES read a clock — they are
+    // `contradicted-clock-determinism`'s subject, not this rule's.
 
-    @Test func flagsConcreteClockConstruction() {
+    @Test func ignoresConcreteClockConstruction() {
         let source = """
         func timed() -> Duration { ContinuousClock().measure { } }
         func suspended() -> SuspendingClock.Instant { SuspendingClock().now }
         """
-        #expect(analyze(source).count == 2)
+        #expect(analyze(source).isEmpty)
     }
 
-    @Test func flagsTaskSleepOnTheHostClock() {
+    @Test func ignoresTaskSleep() {
         let source = """
         func wait() async throws { try await Task.sleep(for: .seconds(1)) }
-        """
-        #expect(analyze(source).count == 1)
-    }
-
-    @Test func ignoresTaskSleepOnASuppliedClock() {
-        // The injection seam, exactly as `using:` is for randomness.
-        let source = """
-        func wait<C: Clock>(clock: C) async throws {
-            try await Task.sleep(for: .seconds(1), tolerance: nil, clock: clock)
-        }
         """
         #expect(analyze(source).isEmpty)
     }
 
-    @Test func flagsDateOffsetFromNow() {
-        // `timeIntervalSinceNow:` reads the clock despite taking an argument —
-        // the case a "no-argument initializers only" rule could not express.
-        #expect(analyze("func soon() -> Date { Date(timeIntervalSinceNow: 60) }").count == 1)
+    @Test func ignoresMonotonicClockReads() {
+        let source = """
+        func ticks() -> UInt64 { mach_absolute_time() }
+        func stamp() -> DispatchTime { DispatchTime.now() }
+        """
+        #expect(analyze(source).isEmpty)
+    }
+
+    /// The rule's line is arity — a construction taking no input can only have
+    /// come from ambient state. This one takes an argument, so it is out, and
+    /// that is a known miss preserved deliberately rather than an oversight.
+    @Test func ignoresDateOffsetFromNow() {
+        #expect(analyze("func soon() -> Date { Date(timeIntervalSinceNow: 60) }").isEmpty)
     }
 
     @Test func ignoresReadingAnInjectedClock() {
-        // The shape the whole clock family exists to make possible.
         let source = """
         func at<C: Clock>(clock: C) -> C.Instant { clock.now }
         """
         #expect(analyze(source).isEmpty)
+    }
+
+    /// The non-vacuity guard for the four above. Without it, a `reportedKinds`
+    /// set that had emptied itself — or a classifier returning nil for
+    /// everything — would satisfy every exclusion test while the rule reported
+    /// nothing at all.
+    @Test func stillReportsItsOwnScopeAlongsideTheExclusions() {
+        let source = """
+        func mixed() async throws -> Date {
+            try await Task.sleep(for: .seconds(1))
+            _ = ContinuousClock()
+            return Date()
+        }
+        """
+        let issues = analyze(source)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Date()") == true)
     }
 }


### PR DESCRIPTION
Reverts the coverage widening introduced as a side effect of [#104](https://github.com/Joseph-Cursio/SwiftProjectLint/pull/104). Pairs with SwiftEffectInference [#12](https://github.com/Joseph-Cursio/SwiftEffectInference/pull/12).

## What

Consuming the shared classifier pulled in every time source the leaf knows — `ContinuousClock()`, `SuspendingClock()`, `Task.sleep(for:)`, `DispatchTime.now()`, the monotonic C functions, and `Date(timeIntervalSinceNow:)`. **They no longer report.** Coverage is identical to before the migration.

## Why the original argument wasn't good enough

I argued in #104 that those constructs are the rule's stated subject — a property can no more pin a sleep than a `Date()`. That's true, and it isn't sufficient. The widening arrived as a **side effect of de-duplication**, not on its own evidence. A rule that widens because its dependency learned new spellings has a scope nobody chose.

## How the scope is now expressed

`reportedKinds` on the visitor, exhaustive rather than a negative test — a kind added upstream fails to compile until someone says which side of the line it falls on.

That required splitting SEI's single `.clock` case into five (SEI #12). With one lumped case, the only way to express this scope would have been matching on marker spelling, which re-narrows *silently* whenever a string changes upstream — the exact failure mode this rule set keeps documenting.

| kind | reported here? |
|---|---|
| `wallClockNow` (`Date()`, `Date.now`, `CFAbsoluteTimeGetCurrent()`) | **yes** |
| `randomness`, `identity`, `ambientEnvironment` | **yes** |
| `wallClockOffset`, `monotonicClock`, `clockAcquisition`, `timedSuspension` | no |

## The one exclusion worth arguing about

`Date(timeIntervalSinceNow:)` **does** read the clock, and it is excluded. The rule's line is arity — a construction taking no input can only have come from ambient state, and this one takes an argument.

So this is a **known miss preserved deliberately**, not an oversight, and it is what keeps this change a pure narrowing rather than a narrowing plus an unrelated fix. Closing it is a one-line change to `reportedKinds`, and worth doing on its own evidence if you want it.

## Nothing became unreported

The fuller clock set is [Contradicted Clock Determinism](Docs/rules/contradicted-clock-determinism.md)'s subject, where a function claimed `@ClockDeterministic` and its body says otherwise. Both rules read one classifier, so they cannot disagree about *what* an expression is — only about which of them should report it. Documented in both rule docs.

## What a reviewer should scrutinise

- **The exclusion tests could pass vacuously.** A `reportedKinds` that had emptied itself, or a classifier returning `nil` for everything, would satisfy every "ignores X" test while the rule reported nothing at all. `stillReportsItsOwnScopeAlongsideTheExclusions` puts a `Task.sleep`, a `ContinuousClock()` and a `Date()` in one body and asserts exactly one issue, naming `Date()`. That test is load-bearing.
- **`mapKind` is split out of `map`** purely so the nil-guard's branch doesn't count against the switch's cyclomatic budget. The alternative that fits in one function — a dictionary with a fallback — gives up the exhaustiveness the split exists for.
- Full suite **3,339 tests in 405 suites** passing; SwiftLint clean.

## Note

Pin bumped to SEI `8127f26` in all three manifests. SwiftInferProperties follows in its own PR — until it lands, the two consumers are on different oracles and the new cross-repo pin guard fails, correctly.

Same as before: this branch was cut from a tree with pre-existing uncommitted changes (`LintIssue+Ordering.swift`, two untracked test files). Not staged; still in the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GyB5DUu2AFppW9fo7cBn8