### PR TITLE
Bump the SEI pin to the default-argument purity refuter

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -84,7 +84,7 @@ let package = Package(
         // swift-syntax exact 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "8127f26a3065a42277de52fb31c93240219a2152"
+            revision: "c66fceb825eebf77477631388e1ba4326a7aa4e6"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintIdempotencyRules/Package.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // root and SwiftProjectLintVisitors pins.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "8127f26a3065a42277de52fb31c93240219a2152"
+            revision: "c66fceb825eebf77477631388e1ba4326a7aa4e6"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintVisitors/Package.swift
+++ b/Packages/SwiftProjectLintVisitors/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "8127f26a3065a42277de52fb31c93240219a2152"
+            revision: "c66fceb825eebf77477631388e1ba4326a7aa4e6"
         )
     ],
     targets: [


### PR DESCRIPTION
Moves all three manifests to SwiftEffectInference [`c66fceb`](https://github.com/Joseph-Cursio/SwiftEffectInference/pull/13).

**The fix**: a default argument is code the function runs, on exactly the calls that omit it — and the purity scan was handed only `function.body`. So this read the system clock on every defaulted call and was judged `.pure`:

```swift
func bridges(_ s: [Suggestion], now: Date = Date()) -> [BridgeSuggestion]
```

Measured over SwiftInferProperties' `Sources/` before the fix: 15 such functions, fourteen `Date()` and one pair reading `FileManager.default.currentDirectoryPath`, all hand-checked.

**Why all three manifests**: `SEIPinAgreementTests` requires it, and it says plainly what it cannot reach — the cross-repo gap. This bump closes that too. SwiftInferProperties' `SEICrossRepoPinTests` has been red since this repo moved to `8127f26` alone, which meant the linter and the inference engine were not compiling against one purity oracle — the whole claim the shared leaf exists to support.

**Verification**: 3,327 tests green against the new SEI, with no behavioural movement. The new refuter only ever withholds `.pure`, which is the sound direction on the effect lattice; it cannot turn a refutation into a pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191tgcdyDVUj74KwKp5Wtso
