### PR TITLE
Bump the SEI pin to the masked-IO and shared-classifier refuters

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -84,7 +84,7 @@ let package = Package(
         // swift-syntax exact 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "c66fceb825eebf77477631388e1ba4326a7aa4e6"
+            revision: "3ea25f29de9e0fbb86a6a8f20b2c42ead58a039e"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintIdempotencyRules/Package.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // root and SwiftProjectLintVisitors pins.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "c66fceb825eebf77477631388e1ba4326a7aa4e6"
+            revision: "3ea25f29de9e0fbb86a6a8f20b2c42ead58a039e"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintVisitors/Package.swift
+++ b/Packages/SwiftProjectLintVisitors/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "c66fceb825eebf77477631388e1ba4326a7aa4e6"
+            revision: "3ea25f29de9e0fbb86a6a8f20b2c42ead58a039e"
         )
     ],
     targets: [


### PR DESCRIPTION
Three manifests to SwiftEffectInference [`3ea25f2`](https://github.com/Joseph-Cursio/SwiftEffectInference/pull/14). Joint act with [SwiftInferProperties #302](https://github.com/Joseph-Cursio/SwiftInferProperties/pull/302), which bumps on the same SHA.

## What moved upstream

Two refuters, both **withholding** `.pure`, which is the sound direction on the effect lattice:

- **`FileHandle` / `Process` / `Pipe` join `sideEffectMarkers`.** `throwsOnlyItsOwnErrors` exists because gating on `throws` had been masking exactly these, but that gate only ever covered *throwing* functions. `FileHandle.standardError.write(_:)` does not throw, and it is the commonest I/O call in a Swift CLI.
- **`hasRefutingMarker` consults `NondeterminismSources`** as a **union** with the existing token set, not a replacement. The distinction is load-bearing: the classifier is AST-precise and therefore *narrower* in places — it reads `Date(timeIntervalSince1970:)` as deterministic — so swapping would **relax** a gate whose over-refutation is deliberate and documented. Both run; either refutes.

`String` and `Data` deliberately stay out of both mechanisms: matched by bare identifier they would refute nearly everything, and `String(contentsOf:)` / `Data(contentsOf:)` throw, so the `try` gate already reaches them.

## Effect here

This repo consumes the oracle through `PureFunctionCandidateVisitor` and `PureClosureCandidateVisitor`, so the effect is strictly **fewer purity candidates offered** — a candidate can be withheld, never wrongly promoted from refuted to pure.

**3,339 tests green in 405 suites**, no assertion moved. `SEIPinAgreementTests` green (three manifests agree), and the sibling's `SEICrossRepoPinTests` green (all four agree).

`Package.resolved` is gitignored here, so the three manifests are the whole pin.

## What a reviewer should scrutinise

1. **That no rule silently lost coverage.** Fewer candidates is the intended direction, but "fewer" and "none" are different, and a rule whose corpus stopped exhibiting a shape would pass just as quietly. Worth a look at whether any pure-candidate test still has a positive witness.
2. **The union, not the pin.** If you disagree with anything here it is upstream, in whether the token set should have been *replaced* by the classifier. SEI's own control test is the thing that distinguishes the two.

## Pre-existing, not from this change

`swiftlint lint --quiet --strict` reports **27 violations**, byte-identical to `main` with these changes stashed. Two are inside generated `.swiftinfer/verify-workdir/` scratch directories that the lint run is picking up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiTVLz7q5xnBrt9HC1Ma2k

