### PR TITLE
Gate pure-function candidates on the callee join

### DIFF
--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
@@ -158,6 +158,8 @@ extension ProjectLinter {
         /// Functions this project declares — lets the Pure Closure rule tell a closure that still
         /// hides logic from one merely forwarding to a function the reader already extracted.
         let projectFunctions: Set<String>
+        /// The one-hop callee join, resolved once in the pre-scan. See `PackagePurityJoin`.
+        let impurePackageFunctions: Set<String>
 
         /// Types whose initialiser has defaulted parameters — the gate for `lossyStructRebuild`.
         let defaultedInitializerTypes: Set<String>
@@ -185,6 +187,7 @@ extension ProjectLinter {
             equatableTypes: env.equatableTypes,
             valueTypes: env.valueTypes,
             projectFunctions: env.projectFunctions,
+            impurePackageFunctions: env.impurePackageFunctions,
             defaultedInitializerTypes: env.defaultedInitializerTypes,
             layerPolicies: env.layerPolicies
         )
@@ -206,6 +209,7 @@ extension ProjectLinter {
         equatableTypes: Set<String> = [],
         valueTypes: Set<String> = [],
         projectFunctions: Set<String> = [],
+        impurePackageFunctions: Set<String> = [],
         defaultedInitializerTypes: Set<String> = [],
         layerPolicies: [LayerPolicy] = []
     ) -> (file: ProjectFile, issues: [LintIssue], parsedAST: SourceFileSyntax)? {
@@ -230,6 +234,7 @@ extension ProjectLinter {
         det.knownEquatableTypes = equatableTypes
         det.knownValueTypes = valueTypes
         det.knownProjectFunctions = projectFunctions
+        det.knownImpurePackageFunctions = impurePackageFunctions
         det.knownDefaultedInitializerTypes = defaultedInitializerTypes
         det.layerPolicies = layerPolicies
 

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
@@ -236,8 +236,25 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         /// by its own fixpoint rather than by `collectTypes`.
         let cleanInstanceMethods: CleanInstanceMethodCatalog
 
+        /// Package function names this project's own purity oracle refutes with an
+        /// establishable witness — the one-hop callee join. Needs parsed bodies for the
+        /// same reason `cleanInstanceMethods` does, and shares the single parse below.
+        ///
+        /// A per-file visitor cannot compute this: the callee whose verdict sinks a
+        /// candidate is usually in another file. This pre-pass is the project's existing
+        /// answer to that, which is why the join arrives as a `known*` set rather than by
+        /// converting a rule to cross-file — the cross-file dispatch path does not forward
+        /// the `known*` catalogs at all, so a rule that moved onto it would silently lose
+        /// the type knowledge its candidacy test depends on. Measured, when that route was
+        /// tried: 377 candidate symbols dropped out.
+        let impurePackageFunctions: Set<String>
+
         static func collect(from filePaths: [String]) -> Self {
-            Self(
+            // Parsed once and shared: both body-needing collectors below walk the same
+            // trees, and parsing a project twice to build two catalogs is the kind of
+            // cost that does not show up until someone points the linter at a large tree.
+            let parsed = parseAll(filePaths)
+            return Self(
                 identifiable: collectTypes(IdentifiableTypeCollector.self, from: filePaths),
                 enums: collectTypes(EnumTypeCollector.self, from: filePaths),
                 actors: collectTypes(ActorTypeCollector.self, from: filePaths),
@@ -250,9 +267,8 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
                 defaultedInitializers: collectTypes(
                     DefaultedInitializerCollector.self, from: filePaths
                 ),
-                cleanInstanceMethods: CleanInstanceMethodCatalog.build(
-                    from: parseAll(filePaths)
-                )
+                cleanInstanceMethods: CleanInstanceMethodCatalog.build(from: parsed),
+                impurePackageFunctions: PackagePurityJoin(sources: parsed).settledImpureNames
             )
         }
     }
@@ -273,6 +289,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         resolved.knownEquatableTypes = collected.equatable
         resolved.knownValueTypes = collected.values
         resolved.knownCleanInstanceMethods = collected.cleanInstanceMethods
+        resolved.knownImpurePackageFunctions = collected.impurePackageFunctions
         resolved.knownProjectFunctions = collected.functions
         resolved.knownDefaultedInitializerTypes = collected.defaultedInitializers
         resolved.layerPolicies = configuration.architecturalLayers
@@ -303,6 +320,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
             equatableTypes: collected.equatable,
             valueTypes: collected.values,
             projectFunctions: collected.functions,
+            impurePackageFunctions: collected.impurePackageFunctions,
             defaultedInitializerTypes: collected.defaultedInitializers,
             layerPolicies: layerPolicies
         )

--- a/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetector.swift
+++ b/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetector.swift
@@ -42,6 +42,8 @@ public final class SourcePatternDetector: SourcePatternDetectorProtocol, @unchec
 
     /// Per type, sibling methods cleared as functions of their inputs. Set by `ProjectLinter`
     /// after a pre-scan and passed through to visitors.
+    public var knownImpurePackageFunctions: Set<String> = []
+
     public var knownCleanInstanceMethods = CleanInstanceMethodCatalog.empty
 
     /// Functions this project declares, by bare and labelled name. Set by `ProjectLinter` after a
@@ -195,6 +197,7 @@ public final class SourcePatternDetector: SourcePatternDetectorProtocol, @unchec
             visitor.knownProtocolTypes = knownProtocolTypes
             visitor.knownEquatableTypes = knownEquatableTypes
             visitor.knownValueTypes = knownValueTypes
+            visitor.knownImpurePackageFunctions = knownImpurePackageFunctions
             visitor.knownCleanInstanceMethods = knownCleanInstanceMethods
             visitor.knownProjectFunctions = knownProjectFunctions
             visitor.knownDefaultedInitializerTypes = knownDefaultedInitializerTypes

--- a/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetectorProtocol.swift
+++ b/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetectorProtocol.swift
@@ -43,6 +43,11 @@ public protocol SourcePatternDetectorProtocol {
     var knownValueTypes: Set<String> { get set }
 
     /// Per type, sibling methods cleared as functions of their inputs by the pre-scan.
+    /// Package function names the purity oracle refutes with an establishable witness —
+    /// the one-hop callee join, resolved once in the pre-scan. See
+    /// `PackagePurityJoin` and `BasePatternVisitor.knownImpurePackageFunctions`.
+    var knownImpurePackageFunctions: Set<String> { get set }
+
     var knownCleanInstanceMethods: CleanInstanceMethodCatalog { get set }
 
     /// Functions this project declares (bare and labelled names). Lets the Pure Closure rule tell a

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/PureFunctionCandidateVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/PureFunctionCandidateVisitor.swift
@@ -73,6 +73,10 @@ final class PureFunctionCandidateVisitor: BasePatternVisitor {
                 + "for the property rather than a failure."
         }
 
+        // The callee join: a candidate whose body reaches a package function this same
+        // oracle refutes is not offered at all.
+        if impureCallee(of: node) != nil { return .visitChildren }
+
         let restriction = PropertyTestCandidacy.restriction(of: node)
         let reachable = restriction == nil
         if !reachable { advice = Self.wideningAdvice }
@@ -124,6 +128,14 @@ final class PureFunctionCandidateVisitor: BasePatternVisitor {
         if candidate.isPartial {
             advice += " Narrow the law's domain to the values that do not throw."
         }
+        if let accessor = binding.accessorBlock,
+           PackagePurityJoin.impureCallee(
+               in: Syntax(accessor),
+               settledImpureNames: knownImpurePackageFunctions
+           ) != nil {
+            return .visitChildren
+        }
+
         let restriction = PropertyTestCandidacy.restriction(of: node)
         let reachable = restriction == nil
         if !reachable { advice = Self.wideningAdvice }
@@ -140,6 +152,30 @@ final class PureFunctionCandidateVisitor: BasePatternVisitor {
             testReachability: restriction.map(TestReachability.unreachable) ?? .reachable
         )
         return .visitChildren
+    }
+
+    /// The settled-impure package callee that disqualifies `node`, if any.
+    ///
+    /// **A function is not a purity candidate because its callee was never consulted.**
+    /// `PurityInferrer` decides each declaration alone, so `standardOutputViaEnv` —
+    /// whose one-line body calls a `standardOutput` that spawns a subprocess and drains
+    /// two pipes — read as pure and was offered here. Offering a false candidate is
+    /// worse than offering none: this rule is what seeds `swift-infer`, so a wrong seed
+    /// becomes a law nobody can hold.
+    ///
+    /// Measured in SwiftInferProperties before being built (its
+    /// `docs/measurements/purity-refuting-fixpoint-census.md`): 18 rows at one hop over
+    /// 2,396 `.pure` subjects. One hop is 62% of the fixpoint's effect, and is what
+    /// ships — see `PackagePurityJoin` for why the loop is a later phase.
+    ///
+    /// Suppression is silent. The over-claim is worth reporting on its own terms, and
+    /// that is a separate rule rather than a second job for this one.
+    private func impureCallee(of node: FunctionDeclSyntax) -> String? {
+        guard !knownImpurePackageFunctions.isEmpty, let body = node.body else { return nil }
+        return PackagePurityJoin.impureCallee(
+            in: Syntax(body),
+            settledImpureNames: knownImpurePackageFunctions
+        )
     }
 
     /// Appended to the message when no test can reach the declaration.

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/BasePatternVisitor.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/BasePatternVisitor.swift
@@ -75,6 +75,18 @@ open class BasePatternVisitor: SyntaxVisitor, PatternVisitorProtocol {
     /// one does not make its caller a function of mutable state. Built project-wide by
     /// `CleanInstanceMethodCatalog` in `ProjectLinter`'s pre-scan, because a type's methods are
     /// spread across its extensions and a single-file answer would miss most of them.
+    /// Package function names the purity oracle refutes with an establishable witness.
+    ///
+    /// The one-hop callee join. `PurityInferrer` decides each declaration alone, so a
+    /// one-line function whose helper spawns a subprocess reads as pure — the callee's
+    /// verdict is computed and then never consulted. A rule that offers purity
+    /// candidates consults this to avoid offering that caller.
+    ///
+    /// Built project-wide by `PackagePurityJoin` in the pre-scan, because the sinking
+    /// callee is usually in another file. Empty in unit tests that drive a visitor
+    /// directly, which is correct: a single file has no package to join against.
+    public var knownImpurePackageFunctions: Set<String> = []
+
     public var knownCleanInstanceMethods = CleanInstanceMethodCatalog.empty
 
     /// Functions **this project declares**, as bare names and labelled names (`matches(name:)`).

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/PackagePurityJoin.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/PackagePurityJoin.swift
@@ -1,0 +1,185 @@
+import SwiftEffectInference
+import SwiftSyntax
+
+/// **The one-hop callee join: a function that calls a package function this same
+/// oracle refutes is not a purity candidate.**
+///
+/// `PurityInferrer` decides each declaration in isolation. So
+/// `standardOutputViaEnv`, whose one-line body calls a `standardOutput` that
+/// spawns a subprocess and drains two pipes, is judged `.pure` — the callee's
+/// verdict is computed and then never consulted. This type consults it.
+///
+/// Measured in SwiftInferProperties before being built
+/// (`docs/measurements/purity-refuting-fixpoint-census.md` there): **18 rows at
+/// one hop over 2,396 `.pure` subjects, 29 at fixpoint over 6 hops.** The loop
+/// contributes 11 of the 29 — a 1.6x multiplier, *weaker* than the promoting
+/// direction's 2.1x — so **one hop is 62% of the effect and is what this ships**.
+/// The fixpoint is a later phase, deliberately not built here.
+///
+/// ## Why this refutes rather than promotes, which is the whole reason it exists
+///
+/// The mirror direction — *callee pure, so maybe the caller is* — was measured
+/// twice in SwiftInferProperties and declined twice: its freed rows all land on
+/// `.pureButPartial`, which nothing reads. Refutation lands on the verdict a
+/// consumer already acts on. It is also the only sound direction: withholding
+/// `.pure` tightens a gate, and an inferred *pure* would be a claim about a
+/// function's callees rather than about the function
+/// (`f(x) = g(x) + 1` with a pure `g` is not pure of anything).
+///
+/// ## The witness rule, and why it is narrower here than in the census
+///
+/// A refutation is either **evidence** (a named construct — I/O, a clock, a trap,
+/// `async`) or **ignorance** (`propagatedTry`: the function `throws` and its body
+/// has a `try` into a callee the leaf cannot see). Only evidence may propagate:
+/// spreading ignorance upward would retract candidates on the grounds that
+/// *something might* be impure, which is the Daikon trap through a new door.
+///
+/// **`PurityVerdict` carries no witness** — it is `pure` / `pureButPartial` /
+/// `refuted`, and the reason is `private` to SEI. That is open-threads item 31's
+/// complaint (*"nothing can name the callee that blocked a verdict"*) arriving as
+/// a constraint on this build rather than as a wish.
+///
+/// So the witness is established from public API only, and soundly:
+/// **`propagatedTry` requires a `throws` clause by definition, so a callee that is
+/// `.refuted` and does NOT throw cannot be an ignorance-only refutation.** It must
+/// carry one of the evidence causes. No marker set is replicated here, which is the
+/// point — a second copy of SEI's refuters in this repo is exactly the drift
+/// `PurityInferrer`'s relocation was done to end.
+///
+/// The cost is real and one-sided: a *throwing* callee that also carries a marker
+/// is a genuine witness this rule cannot see, so it under-refutes. That is the safe
+/// direction for a gate that suppresses advice — the failure mode is continuing to
+/// offer a candidate, which is today's behaviour, rather than withdrawing a true
+/// one. **If SEI ever publishes the refutation reason, this rule gets wider for
+/// free**, and that is the argument for item 31 that this build supplies.
+///
+/// ## Resolution is name-keyed, and a name must be settled
+///
+/// A name refutes only when **every** declaration carrying it is settled impure.
+/// One pure overload makes the call ambiguous and the name is dropped. This is not
+/// caution for its own sake: name-keying has been the dominant defect in three
+/// separate measurements of this seam, most sharply when a cascade let one refuted
+/// `classify` speak for six unrelated ones. Free-shape callees only (`foo(…)`, not
+/// `base.foo(…)`) for the same reason.
+public struct PackagePurityJoin: Sendable {
+
+    /// Names whose every in-package declaration is refuted with an establishable
+    /// witness. Empty when the join has nothing to say, which is the common case
+    /// for a small project and is not an error.
+    public let settledImpureNames: Set<String>
+
+    /// Builds the join over every source in the project.
+    ///
+    /// - Parameter sources: every parsed file, in a **fixed** order. Order does not
+    ///   affect the result — settledness is computed over the whole set rather than
+    ///   accumulated — but callers should pass `orderedSources` anyway, so that a
+    ///   future change which does depend on order cannot silently become
+    ///   hash-seed-dependent the way the idempotency family's hop counts once did.
+    public init(sources: [SourceFileSyntax]) {
+        let inferrer = PurityInferrer()
+        var byName: [String: [(verdict: PurityVerdict, throwsClause: Bool)]] = [:]
+        for source in sources {
+            let collector = PackageFunctionCollector(viewMode: .sourceAccurate)
+            collector.walk(source)
+            for declaration in collector.declarations {
+                byName[declaration.name.text, default: []].append(
+                    (
+                        inferrer.verdict(for: declaration),
+                        declaration.signature.effectSpecifiers?.throwsClause != nil
+                    )
+                )
+            }
+        }
+
+        var settled: Set<String> = []
+        for (name, declarations) in byName where !declarations.isEmpty {
+            // Settled impure: every declaration refuted, and every one of them
+            // non-throwing so the refutation cannot be `propagatedTry` ignorance.
+            let allSettled = declarations.allSatisfy { $0.verdict == .refuted && !$0.throwsClause }
+            if allSettled { settled.insert(name) }
+        }
+        self.settledImpureNames = settled
+    }
+
+    /// The name of the first settled-impure package function `function`'s body calls,
+    /// or `nil` when the join has no objection.
+    public func impureCallee(in function: FunctionDeclSyntax) -> String? {
+        guard let body = function.body else { return nil }
+        return Self.impureCallee(in: Syntax(body), settledImpureNames: settledImpureNames)
+    }
+
+    /// The same question against a precomputed name set.
+    ///
+    /// Static because the consumer that matters is a **per-file** visitor: the names are
+    /// resolved once in the project pre-scan and handed to every visitor as
+    /// `knownImpurePackageFunctions`, the way `knownCleanInstanceMethods` already is.
+    /// Rebuilding the join per file would parse the project once per file.
+    ///
+    /// Returns a name rather than a `Bool` so a caller can say *which* callee sank the
+    /// candidate. A gate that suppresses without being able to explain itself is the
+    /// shape this project's own *vocabulary nobody reads* note warns about.
+    public static func impureCallee(
+        in syntax: Syntax,
+        settledImpureNames: Set<String>
+    ) -> String? {
+        guard !settledImpureNames.isEmpty else { return nil }
+        let collector = FreeCalleeCollector(viewMode: .sourceAccurate)
+        collector.walk(syntax)
+        // A locally-declared helper shadows a package name, so its calls resolve inside
+        // this body and must not be joined on.
+        return collector.calleeNames
+            .subtracting(collector.locallyDeclaredNames)
+            .intersection(settledImpureNames)
+            .min()
+    }
+}
+
+/// Every function declaration a project-wide purity table should hold.
+///
+/// Mirrors `FunctionScannerVisitor`'s traversal rules in the two ways that matter
+/// for a name table. **Body-less declarations are skipped** — a protocol
+/// requirement has no body, so the oracle refutes it, and since a requirement also
+/// does not `throws`-gate the way an implementation does, admitting one would let
+/// `func load()` in a protocol declare every `load` in the project impure. That is
+/// a false-positive generator, not an edge case. **Nested functions are skipped**
+/// because their names are not package-visible and would collide with real ones.
+private final class PackageFunctionCollector: SyntaxVisitor {
+
+    private(set) var declarations: [FunctionDeclSyntax] = []
+    private var depth = 0
+
+    override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+        defer { depth += 1 }
+        guard depth == 0, node.body != nil else { return .visitChildren }
+        declarations.append(node)
+        return .visitChildren
+    }
+
+    override func visitPost(_: FunctionDeclSyntax) {
+        depth -= 1
+    }
+}
+
+/// Free-shape callee names in a body, plus the names declared locally within it.
+///
+/// Free-shape only: `base.foo(…)` is not resolvable by name in a project that
+/// declares a `FileManager`-reading `sorted(in:)` alongside every `xs.sorted()`,
+/// which is the collision that inflated a sibling census's base rate from 17 to
+/// 147. The member surface needs an index, not a name.
+private final class FreeCalleeCollector: SyntaxVisitor {
+
+    private(set) var calleeNames: Set<String> = []
+    private(set) var locallyDeclaredNames: Set<String> = []
+
+    override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+        locallyDeclaredNames.insert(node.name.text)
+        return .visitChildren
+    }
+
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        if let reference = node.calledExpression.as(DeclReferenceExprSyntax.self) {
+            calleeNames.insert(reference.baseName.text)
+        }
+        return .visitChildren
+    }
+}

--- a/Tests/CoreTests/Testability/PackagePurityJoinTests.swift
+++ b/Tests/CoreTests/Testability/PackagePurityJoinTests.swift
@@ -1,0 +1,425 @@
+@testable import Core
+import Foundation
+import SwiftParser
+import SwiftProjectLintModels
+@testable import SwiftProjectLintRules
+@testable import SwiftProjectLintVisitors
+import SwiftSyntax
+import Testing
+
+/// **The one-hop callee join, and the gate it drives on `pure-function-candidate`.**
+///
+/// The join is the build `docs/measurements/purity-refuting-fixpoint-census.md` in
+/// SwiftInferProperties recommended: a function calling a package function this same
+/// oracle refutes is not a purity candidate. 18 rows at one hop over that corpus.
+///
+/// Every test here is paired with a control, because a gate that suppresses is
+/// indistinguishable from a rule that stopped working unless something proves it
+/// still emits. The controls are the point.
+@Suite("The callee join — a caller is not pure because its callee was never consulted")
+struct PackagePurityJoinTests {
+
+    /// Findings from the rule, driven the way production drives it: the join is
+    /// resolved over every file first and handed to the per-file visitor as
+    /// `knownImpurePackageFunctions`, exactly as `ProjectLinter`'s pre-scan does.
+    ///
+    /// **The rule stayed per-file on purpose.** Converting it to cross-file was tried
+    /// and reverted: the cross-file dispatch path does not forward the `known*`
+    /// catalogs, so candidacy lost its type knowledge and 377 candidate symbols
+    /// silently vanished. The `known*` pre-scan is this project's existing answer to
+    /// "a per-file visitor needs a project-wide fact", and `knownCleanInstanceMethods`
+    /// is the precedent it follows.
+    private func findings(_ files: [String: String]) -> [LintIssue] {
+        let parsed = files.keys.sorted().map { (path: $0, tree: Parser.parse(source: files[$0] ?? "")) }
+        let join = PackagePurityJoin(sources: parsed.map(\.tree))
+        var issues: [LintIssue] = []
+        for entry in parsed {
+            let visitor = PureFunctionCandidateVisitor(patternCategory: .testability)
+            visitor.knownImpurePackageFunctions = join.settledImpureNames
+            visitor.setSourceLocationConverter(
+                SourceLocationConverter(fileName: entry.path, tree: entry.tree)
+            )
+            visitor.setFilePath(entry.path)
+            visitor.walk(entry.tree)
+            issues.append(contentsOf: visitor.detectedIssues)
+        }
+        return issues.filter { $0.ruleName == .pureFunctionCandidate }
+    }
+
+    private func symbols(_ files: [String: String]) -> Set<String> {
+        Set(findings(files).compactMap(\.symbol))
+    }
+
+    /// A free function of its inputs returning a stdlib `Equatable` — an
+    /// unambiguous candidate under `PropertyTestCandidacy`, appended to every
+    /// fixture below.
+    ///
+    /// **Without it, every suppression test in this suite passes trivially.** A
+    /// `#expect(!found.contains(x))` succeeds just as well when the rule produced no
+    /// findings at all, and the first draft of this suite did exactly that: three
+    /// tests were green because `PropertyTestCandidacy` had rejected the fixtures on
+    /// shape — nullary functions and calls to unknown instance methods — before the
+    /// join was ever consulted. Asserting the sentinel survives is what tells a
+    /// missing finding apart from a suppressed one.
+    private static let sentinel = """
+
+    func sentinelAdd(_ first: Int, _ second: Int) -> Int {
+        first + second
+    }
+    """
+
+    /// Findings over `files`, each with the sentinel appended, asserting the
+    /// sentinel survived.
+    private func gatedSymbols(
+        _ files: [String: String],
+        sourceLocation: Testing.SourceLocation = #_sourceLocation
+    ) -> Set<String> {
+        var withSentinel = files
+        if let first = files.keys.min() {
+            withSentinel[first] = (files[first] ?? "") + Self.sentinel
+        }
+        let found = symbols(withSentinel)
+        #expect(
+            found.contains("sentinelAdd"),
+            "the rule produced nothing at all, so any absence below is meaningless",
+            sourceLocation: sourceLocation
+        )
+        return found
+    }
+
+    // MARK: - The motivating case
+
+    /// **The row the census was built to count.** A one-line function whose callee
+    /// spawns a subprocess, judged `.pure` by an oracle that decides each
+    /// declaration alone. This is `DrainedProcess.standardOutputViaEnv` reduced to
+    /// its shape.
+    @Test("a caller of a subprocess-spawning helper is not offered as a candidate")
+    func suppressesCallerOfImpureHelper() {
+        let found = gatedSymbols([
+            "Proc.swift": """
+            func standardOutput(_ arguments: [String]) -> String {
+                let process = Process()
+                let pipe = Pipe()
+                _ = process
+                _ = pipe
+                return arguments.joined()
+            }
+
+            func standardOutputViaEnv(_ arguments: [String]) -> String {
+                standardOutput(arguments)
+            }
+            """
+        ])
+        #expect(found.contains("standardOutputViaEnv") == false, "the caller must not be offered")
+        #expect(found.contains("standardOutput") == false, "the callee is impure on its own terms")
+    }
+
+    /// **The control.** Identical shape, pure callee. Without this the test above
+    /// passes just as well against a rule that suppresses everything.
+    @Test("the same shape with a pure callee IS still offered")
+    func keepsCallerOfPureHelper() {
+        let found = gatedSymbols([
+            "Calc.swift": """
+            func double(_ value: Int) -> Int {
+                value * 2
+            }
+
+            func doubleViaHelper(_ value: Int) -> Int {
+                double(value)
+            }
+            """
+        ])
+        #expect(found.contains("doubleViaHelper"), "a pure callee must not sink the caller")
+        #expect(found.contains("double"), "the callee itself is a candidate")
+    }
+
+    /// The join is cross-file or it is nothing — the whole reason this rule stopped
+    /// being per-file. Callee and caller in different files.
+    @Test("the join reaches across files")
+    func joinsAcrossFiles() {
+        let found = gatedSymbols([
+            "A_Helper.swift": """
+            func writeLog(_ text: String) -> Int {
+                FileHandle.standardError.write(Data(text.utf8))
+                return text.count
+            }
+            """,
+            "B_Caller.swift": """
+            func lengthViaLog(_ text: String) -> Int {
+                writeLog(text)
+            }
+            """
+        ])
+        #expect(found.contains("lengthViaLog") == false, "a callee in another file must still be consulted")
+    }
+
+    // MARK: - Only evidence propagates
+
+    /// **Ignorance must not propagate, and this is the test that pins it.** A
+    /// `throws`ing callee whose body has a `try` is refuted by `propagatedTry` —
+    /// the oracle saying *I cannot see past this*, not *this is impure*. Retracting
+    /// a candidate on that basis would withdraw advice on no evidence.
+    ///
+    /// This is also the measured limit of the build: `PurityVerdict` carries no
+    /// witness, so the only witness establishable from public API is
+    /// *refuted AND does not throw*. A throwing callee is therefore never joined
+    /// on, which under-refutes rather than over-refutes.
+    @Test("a throwing callee does NOT sink the caller — that refutation may be ignorance")
+    func doesNotPropagateIgnorance() {
+        let found = gatedSymbols([
+            "Throwy.swift": """
+            func loadContents(_ path: String) throws -> String {
+                try somethingUnseen(path)
+            }
+
+            func lengthOf(_ path: String) -> Int {
+                (try? loadContents(path))?.count ?? 0
+            }
+            """
+        ])
+        #expect(
+            found.contains("lengthOf"),
+            "a `propagatedTry` refutation is the oracle's ignorance and must not retract advice"
+        )
+    }
+
+    // MARK: - Name resolution, which is where this seam has failed three times
+
+    /// One pure declaration of the name makes the call ambiguous, so the name is
+    /// dropped. Without this rule a single refuted `classify` speaks for every
+    /// unrelated `classify` in the project — measured at 46 false rows of 75 in the
+    /// sibling census's first cascade.
+    @Test("a name with one pure overload is not settled, so it sinks nothing")
+    func unsettledNameSinksNothing() {
+        let found = gatedSymbols([
+            "Two.swift": """
+            struct A {
+                func classify(_ value: Int) -> Int {
+                    print(value)
+                    return value
+                }
+            }
+
+            struct B {
+                func classify(_ value: String) -> Int {
+                    value.count
+                }
+            }
+
+            func classifyViaName(_ value: Int) -> Int {
+                classify(value)
+            }
+            """
+        ])
+        #expect(
+            found.contains("classifyViaName"),
+            "two declarations, one pure — the name cannot be settled impure"
+        )
+    }
+
+    /// **A protocol requirement has no body, so the oracle refutes it and it does
+    /// not `throws`-gate.** Admitting one would let `func load()` in a protocol
+    /// declare every `load` in the project impure — a false-positive generator, and
+    /// the reason the collector skips body-less declarations.
+    @Test("a body-less protocol requirement does not poison its name")
+    func protocolRequirementDoesNotPoisonName() {
+        let found = gatedSymbols([
+            "Proto.swift": """
+            protocol Loading {
+                func load() -> Int
+            }
+
+            func loadViaHelper(_ seed: Int) -> Int {
+                load() + seed
+            }
+
+            func load() -> Int {
+                42
+            }
+            """
+        ])
+        #expect(
+            found.contains("loadViaHelper"),
+            "a requirement is not an implementation; it must not settle the name"
+        )
+    }
+
+    /// A locally-declared helper shadows a package name, so calls to it resolve
+    /// inside the body and must not be joined on.
+    @Test("a local function shadowing an impure package name does not sink the caller")
+    func localShadowWins() {
+        let found = gatedSymbols([
+            "Shadow.swift": """
+            func emit(_ value: Int) -> Int {
+                print(value)
+                return value
+            }
+
+            func computeWithLocalEmit(_ value: Int) -> Int {
+                func emit(_ inner: Int) -> Int { inner + 1 }
+                return emit(value)
+            }
+            """
+        ])
+        #expect(
+            found.contains("computeWithLocalEmit"),
+            "the call resolves to the local declaration, not the package one"
+        )
+    }
+
+    /// Member-shape calls are not resolvable by name — `xs.sorted()` collides with
+    /// a project's own `sorted(in:)`, which inflated a sibling census's base rate
+    /// from 17 to 147. The join is free-shape only, so a member call to an impure
+    /// name is deliberately not joined on.
+    @Test("a member-shape call is not joined on, even to a settled-impure name")
+    func memberShapeIsNotJoined() {
+        let found = gatedSymbols([
+            "Member.swift": """
+            struct Sink {
+                func drain(_ value: Int) -> Int {
+                    print(value)
+                    return value
+                }
+            }
+
+            func viaMember(_ sink: Sink, _ value: Int) -> Int {
+                sink.drain(value)
+            }
+            """
+        ])
+        #expect(
+            found.contains("viaMember"),
+            "name-keying cannot resolve a member call; joining on one would be a guess"
+        )
+    }
+
+    // MARK: - The join in isolation
+
+    /// The join's own answer, independent of the rule that consumes it — so a
+    /// failure can be localised to the join or to the gate rather than to "somewhere
+    /// in the rule."
+    @Test("the join names the settled-impure callee, and says nothing about a pure one")
+    func joinReportsTheCallee() throws {
+        let source = Parser.parse(source: """
+        func writeIt(_ text: String) -> Int {
+            print(text)
+            return text.count
+        }
+
+        func pureHelper(_ value: Int) -> Int {
+            value + 1
+        }
+
+        func callsImpure(_ text: String) -> Int {
+            writeIt(text)
+        }
+
+        func callsPure(_ value: Int) -> Int {
+            pureHelper(value)
+        }
+        """)
+        let join = PackagePurityJoin(sources: [source])
+        #expect(join.settledImpureNames.contains("writeIt"))
+        #expect(join.settledImpureNames.contains("pureHelper") == false)
+
+        let functions = FunctionFinder(viewMode: .sourceAccurate)
+        functions.walk(source)
+        let byName = Dictionary(
+            uniqueKeysWithValues: functions.found.map { ($0.name.text, $0) }
+        )
+        #expect(join.impureCallee(in: try #require(byName["callsImpure"])) == "writeIt")
+        #expect(join.impureCallee(in: try #require(byName["callsPure"])) == nil)
+    }
+
+    /// An empty project has nothing to join against, and the join must be inert
+    /// rather than throwing or suppressing. This is the single-file unit-test path
+    /// every sibling suite in this directory drives.
+    @Test("an empty source set produces an inert join")
+    func emptyJoinIsInert() {
+        let join = PackagePurityJoin(sources: [])
+        #expect(join.settledImpureNames.isEmpty)
+    }
+}
+
+/// Collects top-level function declarations so a test can address one by name.
+private final class FunctionFinder: SyntaxVisitor {
+    private(set) var found: [FunctionDeclSyntax] = []
+
+    override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+        found.append(node)
+        return .visitChildren
+    }
+}
+
+/// **End-to-end: the join must actually be wired, not merely correct.**
+///
+/// The join was right and inert for a full build cycle. It sat behind
+/// `knownImpurePackageFunctions`, which the pre-scan populated and *one* of the two
+/// per-file detector construction sites forwarded — so `ProjectLinter` produced
+/// byte-identical output with the gate present and absent. Measured on a real
+/// corpus at the time: **0 suppressed**, where the unit tests above were all green.
+///
+/// Unit tests cannot catch that. They set `knownImpurePackageFunctions` themselves,
+/// which is exactly the wiring in question. Only a run through `ProjectLinter` can
+/// tell a correct gate from a gate nothing calls.
+@Suite("The callee join is wired end to end, not just correct in isolation")
+struct PackagePurityJoinWiringTests {
+
+    /// A caller of an I/O helper, plus a sentinel candidate, in separate files so the
+    /// join has to cross a file boundary the way it does in production.
+    private func makeProject() -> String {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PurityJoinWiring-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let helper = """
+        import Foundation
+
+        func writeAudit(_ text: String) -> Int {
+            FileHandle.standardError.write(Data(text.utf8))
+            return text.count
+        }
+        """
+        let caller = """
+        func auditedLength(_ text: String) -> Int {
+            writeAudit(text)
+        }
+
+        func sentinelJoin(_ first: Int, _ second: Int) -> Int {
+            first + second
+        }
+        """
+        try? helper.write(
+            to: root.appendingPathComponent("Helper.swift"), atomically: true, encoding: .utf8
+        )
+        try? caller.write(
+            to: root.appendingPathComponent("Caller.swift"), atomically: true, encoding: .utf8
+        )
+        return root.path
+    }
+
+    @Test("ProjectLinter does not offer a candidate whose callee it refutes")
+    func joinIsWiredThroughProjectLinter() async {
+        let projectPath = makeProject()
+        defer { try? FileManager.default.removeItem(atPath: projectPath) }
+
+        let system = PatternRegistryFactory.createConfiguredSystem()
+        let issues = await ProjectLinter().analyzeProject(
+            at: projectPath, detector: system.detector
+        )
+        let candidates = Set(
+            issues
+                .filter { $0.ruleName == .pureFunctionCandidate }
+                .compactMap(\.symbol)
+        )
+
+        #expect(
+            candidates.contains("sentinelJoin"),
+            "the rule produced nothing, so the absence below proves nothing"
+        )
+        #expect(
+            candidates.contains("auditedLength") == false,
+            "`auditedLength` calls `writeAudit`, which writes to stderr — join not wired"
+        )
+    }
+}


### PR DESCRIPTION
Builds the one-hop join [SwiftInferProperties #304](https://github.com/Joseph-Cursio/SwiftInferProperties/pull/304) measured and recommended. `PurityInferrer` decides each declaration alone, so `DrainedProcess.standardOutputViaEnv` — whose one-line body calls a `standardOutput` that spawns a subprocess and drains two pipes — read as `.pure` and was offered as a property-test candidate. The callee's verdict was computed and never consulted.

## Result

**1,979 candidates → 1,967 on SwiftInferProperties' `Sources/`. 12 suppressed across 9 symbols**, and eight are the census's own named rows:

`standardOutputViaEnv` · `compositionGenerator` · `loadAggregate` · `macOSPlatformLine` · `renderDependenciesBlock` · `renderTargetDependenciesBlock` · `timeToAdoptionSection` · `candidateValuesExpression`

Nothing else moved. Offering a false candidate is worse than offering none — this rule seeds `swift-infer`, so a wrong seed becomes a law nobody can hold.

## Two things I got wrong first, both worth the PR body

**I converted the rule to cross-file. That was the wrong road and I reverted it.** The cross-file dispatch path does not forward the `known*` catalogs at all, so candidacy lost its type knowledge and **377 candidate symbols silently vanished**. The `known*` pre-scan is this project's existing answer to *"a per-file visitor needs a project-wide fact"*, and `knownCleanInstanceMethods` is the precedent — it needs parsed bodies for the same reason and is resolved the same way. Both body-needing collectors now share one parse instead of parsing the project twice.

**Then the correct design shipped inert.** The join was right, tested, and wired to *one* of the two per-file detector construction sites — so `ProjectLinter` produced byte-identical output with the gate present and absent. **0 suppressed on a real corpus, every unit test green.** `PackagePurityJoinWiringTests` now runs the whole thing through `ProjectLinter` over a two-file temp project, because unit tests structurally cannot catch this: they set `knownImpurePackageFunctions` themselves, which is the wiring in question. I falsified it by breaking the assignment, watching it fail, and restoring.

## The witness rule is narrower than the census's, deliberately

Only **evidence** may propagate — spreading `propagatedTry` ignorance would retract advice because something *might* be impure.

But `PurityVerdict` is `pure` / `pureButPartial` / `refuted` with **no witness**, and the reason is `private` to SEI. That is open-threads item 31's complaint (*"nothing can name the callee that blocked a verdict"*) arriving as a constraint on this build rather than a wish. So the witness is established from public API only:

> `propagatedTry` requires a `throws` clause **by definition**, so a callee that is `.refuted` and does **not** throw cannot be an ignorance-only refutation.

No marker set is replicated here — a second copy of SEI's refuters is exactly the drift `PurityInferrer`'s relocation ended. The cost is one-sided: a *throwing* callee that also carries a marker is a genuine witness this cannot see, so it under-refutes, which is the safe direction for a gate that suppresses advice. **If SEI publishes the refutation reason, this gets wider for free** — that is the argument for item 31 this build supplies.

## Name resolution

Names must be **settled** (every declaration carrying the name refuted) and callees are **free-shape only**. Name-keying has been the dominant defect at this seam three times over. Body-less protocol requirements are skipped, because `func load()` in a protocol would otherwise declare every `load` in the project impure — a false-positive generator, not an edge case.

## Verification

- **3,350 tests green** (11 new). `swiftlint --strict` unchanged at its **27 pre-existing** violations.
- Every suppression test carries a **sentinel candidate**. Three tests in the first draft were green because `PropertyTestCandidacy` rejected the fixtures on shape before the join was consulted — asserting the sentinel survives is what tells a missing finding from a suppressed one. The pure-callee control pair does the rest.

## What a reviewer should scrutinise

1. **Threading through two detector sites is a smell.** `ProjectLinter.configuredDetector` and `ProjectLinter+FileAnalysis.analyzeFile` each wire `known*` by hand, and the second set is missing `knownCleanInstanceMethods` on `main` today. Consolidating them is a real cleanup I did not attempt here.
2. **The cross-file engine's `configureBaseVisitor` gap is still open.** I routed around it rather than fixing it; any future cross-file rule needing type knowledge will hit the same 377-symbol cliff.
3. **Suppression is silent.** Defensible for a seed list, but if you would rather see the over-claim reported, that is the separate rule I deliberately did not build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiTVLz7q5xnBrt9HC1Ma2k
