### PR TITLE
Make the reporting order total over everything a formatter renders

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "swift package clean",
+            "timeout": 60,
+            "statusMessage": "Cleaning Swift package build artifacts..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/LintIssue+Ordering.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/LintIssue+Ordering.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// A stable reporting order for findings, so two runs over unchanged sources emit the same report.
 ///
 /// Per-file analysis runs in a `TaskGroup` and collects results as they *complete*, which is a
@@ -9,32 +11,147 @@
 /// Sorting is done once, at the end of analysis, rather than per formatter. Every output format
 /// inherits the same order that way, and the ordering guarantee belongs to the analysis result
 /// rather than to whichever renderer happens to be asked for it.
+///
+/// ## Why the comparator reads fields no reader sorts by
+///
+/// The order must be **total over everything any formatter renders**, not just over the components
+/// a reader would think to sort by. `sorted(by:)` is not guaranteed stable, so two findings that
+/// compare equal may swap places between runs — and if they render differently, that swap is a
+/// spurious `diff` line, which is the whole problem this file exists to remove.
+///
+/// This was originally complete only for path, line, rule, message, suggestion and symbol, and the
+/// doc comment claimed that covered "everything the text report prints". It did not: `TextFormatter`
+/// renders `filepath:line: severity: [rule] message`, so **`severity` was printed and not
+/// compared**. Three more fields had the same gap — the tail of `locations` (the comparator read
+/// only `locations.first`, through `filePath`/`lineNumber`, while JSON and CSV render every
+/// element), the `nil`-versus-`""` distinction the old `?? ""` collapsed (synthesized `Codable`
+/// omits a `nil` key and emits `""` for an empty one), and the seed metadata that `pbt-seeds`
+/// carries. See `ReportOrderDeterminismLawsTests`, which states the law and holds these four
+/// witnesses.
+///
+/// **Stability is deliberately not the fix.** Decorating with the original index would make
+/// `sorted` stable, and stability preserves *arrival* order — which is the `TaskGroup` completion
+/// order, the nondeterminism being removed. A stable sort would pin the report to exactly the thing
+/// that varies.
 extension LintIssue {
 
     /// Whether `lhs` sorts before `rhs` in a report.
     ///
     /// Path and line come first, because a reader scanning one file wants its findings together and
-    /// in source order. The components after them exist to make the order **total**: `sorted(by:)`
-    /// is not guaranteed stable, so any two findings that compare equal may still swap places
-    /// between runs. Comparing on everything the text report prints — rule, message, suggestion —
-    /// means findings that tie are byte-identical in the output, so their relative order cannot be
-    /// observed. `symbol` is the last resort for the machine-readable formats, which carry fields
-    /// the text report does not.
+    /// in source order. Everything after them is a tiebreak of last resort, present for totality
+    /// rather than legibility — a reader never reaches them, because findings that get that far are
+    /// identical in every component a reader reads.
     ///
-    /// Written as a chain of comparisons rather than one tuple comparison because a tuple wide
-    /// enough to hold all six components is both a `large_tuple` violation and the kind of
-    /// expression that has timed out this project's type-checker on slower toolchains.
+    /// Written as a chain of `ComparisonResult` stages rather than one tuple comparison because a
+    /// tuple wide enough to hold all the components is both a `large_tuple` violation and the kind
+    /// of expression that has timed out this project's type-checker on slower toolchains. Split
+    /// into three stages for the same reason, and because they answer to different readers: the
+    /// text report, the machine-readable exports, and the `pbt-seeds` manifest.
     public static func precedes(_ lhs: LintIssue, _ rhs: LintIssue) -> Bool {
-        if lhs.filePath != rhs.filePath { return lhs.filePath < rhs.filePath }
-        if lhs.lineNumber != rhs.lineNumber { return lhs.lineNumber < rhs.lineNumber }
-        if lhs.ruleName != rhs.ruleName { return lhs.ruleName.rawValue < rhs.ruleName.rawValue }
-        if lhs.message != rhs.message { return lhs.message < rhs.message }
+        readerFacingOrder(lhs, rhs)
+            .then { exportedPayloadOrder(lhs, rhs) }
+            .then { seedMetadataOrder(lhs, rhs) }
+            == .orderedAscending
+    }
 
-        let leftSuggestion = lhs.suggestion ?? ""
-        let rightSuggestion = rhs.suggestion ?? ""
-        if leftSuggestion != rightSuggestion { return leftSuggestion < rightSuggestion }
+    /// The components a human scanning the report actually reads, in the order they read them.
+    ///
+    /// `severity` sits here rather than among the tiebreaks because `TextFormatter` prints it on
+    /// every line. It is compared on `rawValue` — an arbitrary but total order, which is all a
+    /// tiebreak owes; ranking `error` above `warning` would be a *reporting* decision, and this
+    /// stage only reaches severity once path, line, rule and message have all tied.
+    private static func readerFacingOrder(_ lhs: LintIssue, _ rhs: LintIssue) -> ComparisonResult {
+        order(lhs.filePath, rhs.filePath)
+            .then { order(lhs.lineNumber, rhs.lineNumber) }
+            .then { order(lhs.ruleName.rawValue, rhs.ruleName.rawValue) }
+            .then { order(lhs.message, rhs.message) }
+            .then { order(lhs.severity.rawValue, rhs.severity.rawValue) }
+    }
 
-        return (lhs.symbol ?? "") < (rhs.symbol ?? "")
+    /// What the machine-readable formats carry beyond the text report: the full location list, and
+    /// the two optionals whose emptiness is observable in JSON.
+    private static func exportedPayloadOrder(_ lhs: LintIssue, _ rhs: LintIssue) -> ComparisonResult {
+        order(lhs.suggestion, rhs.suggestion)
+            .then { order(lhs.symbol, rhs.symbol) }
+            .then { locationOrder(lhs.locations, rhs.locations) }
+    }
+
+    /// The `pbt-seeds` fields — what the manifest hands to `swift-infer`.
+    ///
+    /// `testReachability` is compared through `restriction` alone, and that is complete rather than
+    /// partial: `.reachable` and `.unknown` both carry no restriction *and* `effectiveKind` treats
+    /// them the same, so no formatter can distinguish them. Compare what is rendered.
+    private static func seedMetadataOrder(_ lhs: LintIssue, _ rhs: LintIssue) -> ComparisonResult {
+        order(lhs.role?.rawValue, rhs.role?.rawValue)
+            .then {
+                order(
+                    lhs.testReachability.restriction?.rawValue,
+                    rhs.testReachability.restriction?.rawValue
+                )
+            }
+            .then { effectOrder(lhs.effect, rhs.effect) }
+    }
+
+    /// Lexicographic over the whole list, shorter first — so an issue's second and later locations
+    /// are part of the order, not just the first one `filePath`/`lineNumber` expose.
+    private static func locationOrder(
+        _ lhs: [(filePath: String, lineNumber: Int)],
+        _ rhs: [(filePath: String, lineNumber: Int)]
+    ) -> ComparisonResult {
+        for (left, right) in zip(lhs, rhs) {
+            let element = order(left.filePath, right.filePath)
+                .then { order(left.lineNumber, right.lineNumber) }
+            if element != .orderedSame { return element }
+        }
+        return order(lhs.count, rhs.count)
+    }
+
+    /// Every field `PBTSeedEffect` encodes, because every one of them reaches the manifest.
+    private static func effectOrder(_ lhs: PBTSeedEffect?, _ rhs: PBTSeedEffect?) -> ComparisonResult {
+        guard let left = lhs else { return rhs == nil ? .orderedSame : .orderedAscending }
+        guard let right = rhs else { return .orderedDescending }
+
+        return order(left.declared.rawValue, right.declared.rawValue)
+            .then { order(left.resolved.rawValue, right.resolved.rawValue) }
+            .then { order(left.provenance.rawValue, right.provenance.rawValue) }
+            .then { order(left.anchor?.rawValue, right.anchor?.rawValue) }
+            .then { order(left.reason, right.reason) }
+            .then { order(left.depth ?? -1, right.depth ?? -1) }
+    }
+
+    /// A total order over `String?` that keeps `nil` and `""` **distinct**.
+    ///
+    /// The old comparator coalesced both to `""`, which made them tie while synthesized `Codable`
+    /// renders them differently — an omitted key against `"suggestion": ""`. `nil` sorts first,
+    /// arbitrarily; what matters is only that the two are separable.
+    private static func order(_ lhs: String?, _ rhs: String?) -> ComparisonResult {
+        switch (lhs, rhs) {
+        case (nil, nil): return .orderedSame
+        case (nil, _): return .orderedAscending
+        case (_, nil): return .orderedDescending
+        case let (left?, right?): return order(left, right)
+        }
+    }
+
+    private static func order<Value: Comparable>(_ lhs: Value, _ rhs: Value) -> ComparisonResult {
+        if lhs < rhs { return .orderedAscending }
+        if lhs > rhs { return .orderedDescending }
+        return .orderedSame
+    }
+}
+
+extension ComparisonResult {
+
+    /// The next comparison in a lexicographic chain, evaluated only on a tie.
+    ///
+    /// Lets `precedes` read as the ordered list of components it is, rather than as a ladder of
+    /// early returns — and keeps each stage returning a three-valued result, so "equal" never has
+    /// to be spelled as an optional `Bool`.
+    ///
+    /// `internal` rather than `fileprivate` only to satisfy `strict_fileprivate`; it is an
+    /// implementation detail of `LintIssue.precedes` and nothing else should reach for it.
+    func then(_ next: () -> ComparisonResult) -> ComparisonResult {
+        self == .orderedSame ? next() : self
     }
 }
 

--- a/Tests/CoreTests/Export/ReportOrderDeterminismLawsTests.swift
+++ b/Tests/CoreTests/Export/ReportOrderDeterminismLawsTests.swift
@@ -1,0 +1,216 @@
+@testable import Core
+import PropertyBased
+import SwiftProjectLintModels
+import Testing
+
+/// Laws over the reporting order — **the rendered report is a function of the finding *set*, not
+/// of the order analysis happened to produce them in.**
+///
+/// `LintIssue+Ordering` exists to make `diff old.txt new.txt` meaningful between two runs. Per-file
+/// analysis collects `TaskGroup` results as they complete, so the incoming order is different every
+/// run; `sortedForReporting()` is applied once, in `ProjectLinter`, and every formatter inherits it.
+///
+/// The guarantee that buys is stated in `LintIssue.precedes`' own doc comment:
+///
+/// > The components after them exist to make the order **total**: `sorted(by:)` is not guaranteed
+/// > stable, so any two findings that compare equal may still swap places between runs. Comparing
+/// > on everything the text report prints — rule, message, suggestion — means findings that tie are
+/// > byte-identical in the output, so their relative order cannot be observed. `symbol` is the last
+/// > resort for the machine-readable formats, which carry fields the text report does not.
+///
+/// That claim was false, and **not only for the machine-readable formats**. The old comparator
+/// chained six components — `filePath`, `lineNumber`, `ruleName`, `message`, `suggestion ?? ""`,
+/// `symbol ?? ""` — while four further things reach a formatter:
+///
+/// | field | compared before | rendered by |
+/// |---|---|---|
+/// | `severity` | no | **text**, JSON, CSV, HTML |
+/// | `locations[1...]` | no — only `locations.first`, via `filePath`/`lineNumber` | JSON, CSV |
+/// | `suggestion` / `symbol`, `nil` vs `""` | no — collapsed by `?? ""` | JSON (synthesized `Codable` omits a `nil` key and emits `""` for empty) |
+/// | `role`, `effect`, `testReachability` | no | `pbt-seeds` |
+///
+/// The first row is the sharp one. The doc comment above enumerates what the text report prints as
+/// "rule, message, suggestion", but `TextFormatter` renders
+/// `filepath:line: severity: [rule] message` — **severity is printed on every line and was not
+/// compared**. So the drift reached the primary human-facing report, not just the exports, and the
+/// comparator's own justification is where it hid.
+///
+/// So two findings could tie under `precedes`, render differently, and — `sorted(by:)` being
+/// unstable — swap places between runs. That is the regression-diff problem the ordering was
+/// written to eliminate, and it was open for every format the linter emits.
+///
+/// ## Why the existing tests did not catch it
+///
+/// `ProjectLinterOrderingTests.testOrderIsTotalAcrossShuffles` asserts exactly this guarantee and
+/// passes. Its three fixtures differ in `message` — a field the comparator *does* compare — so the
+/// tie it is looking for never occurs, and it cannot see the fields the comparator ignores.
+/// `testRepeatedRunsRenderIdenticalText` renders through `TextFormatter` only, the one format whose
+/// fields the comparator covers. Both are green, both are about the right thing, and between them
+/// they ratify the gap.
+///
+/// ## On the deliberately narrow alphabet
+///
+/// **This law is collision-dependent**: it can only fail where two findings *tie*, which needs a
+/// collision on all six compared components at once. A generator drawing realistic findings would
+/// essentially never produce one, and would report success by missing it. So the pool below is
+/// hand-built to collide — every witness pair is identical on all six compared components and
+/// differs in exactly one uncompared field — and the generator quantifies over the **arrival
+/// order**, which is the thing that actually varies run to run.
+@Suite
+struct ReportOrderDeterminismLawsTests {
+
+    // MARK: - The witness pairs
+
+    /// Two findings that tie under `precedes` and differ only in `severity`.
+    private static let severityPair = [
+        makeIssue(message: "same", severity: .error),
+        makeIssue(message: "same", severity: .warning)
+    ]
+
+    /// Two findings that tie under `precedes` and differ only in their *second* location.
+    /// `filePath`/`lineNumber` read `locations.first`, so the tail is invisible to the comparator
+    /// and fully rendered by JSON and CSV.
+    private static let locationTailPair = [
+        makeIssue(message: "multi", locations: [("A.swift", 1), ("B.swift", 5)]),
+        makeIssue(message: "multi", locations: [("A.swift", 1), ("C.swift", 9)])
+    ]
+
+    /// Two findings that tie under `precedes` because it collapses `nil` and `""` through `?? ""`,
+    /// while synthesized `Codable` distinguishes them: a `nil` key is omitted, an empty one is
+    /// emitted as `""`.
+    private static let nilVersusEmptyPair = [
+        makeIssue(message: "optional", suggestion: nil),
+        makeIssue(message: "optional", suggestion: "")
+    ]
+
+    /// Two seed-bearing findings that tie under `precedes` and differ only in `role` — the field
+    /// the linter exists to hand to `swift-infer`, and the one that says what law the symbol owes.
+    private static let seedRolePair = [
+        makeIssue(message: "seed", ruleName: .pureFunctionCandidate, symbol: "kernel", role: .comparator),
+        makeIssue(message: "seed", ruleName: .pureFunctionCandidate, symbol: "kernel", role: .predicate)
+    ]
+
+    /// A function rather than a stored `static let`: `any IssueFormatterProtocol` is not `Sendable`,
+    /// and a global holding one is shared mutable state as far as the compiler is concerned.
+    private static func witnesses() -> [(name: String, pair: [LintIssue], formatter: any IssueFormatterProtocol)] {
+        [
+            ("severity", severityPair, JSONFormatter()),
+            ("locations tail", locationTailPair, JSONFormatter()),
+            ("suggestion nil vs \"\"", nilVersusEmptyPair, JSONFormatter()),
+            ("seed role", seedRolePair, PBTSeedsFormatter())
+        ]
+    }
+
+    // MARK: - L1 — every rendered field is compared
+
+    /// **L1 — the comparator separates each witness pair.** Exactly one of the two precedes the
+    /// other.
+    ///
+    /// Each pair is identical on every *other* component and differs in exactly one field that a
+    /// formatter renders, so this is the direct statement that the field is compared. Before the
+    /// comparator was completed all four pairs **tied** here, and L2 then caught them rendering
+    /// differently; this law is the same finding stated where it is cheapest to read.
+    ///
+    /// Asserted separately from L2 so a failure says which half broke: this one names the field
+    /// that went blind, L2 names the format that observed it.
+    @Test
+    func everyRenderedFieldIsComparedByPrecedes() {
+        for (name, pair, _) in Self.witnesses() {
+            let forward = LintIssue.precedes(pair[0], pair[1])
+            let backward = LintIssue.precedes(pair[1], pair[0])
+
+            #expect(
+                forward != backward,
+                """
+                The '\(name)' pair ties under LintIssue.precedes. These two findings differ only \
+                in that field, and a formatter renders it — so sorted(by:), which is not stable, \
+                decides their order and the report can change between runs over unchanged sources.
+                """
+            )
+        }
+    }
+
+    // MARK: - L2 — a tie is unobservable
+
+    /// **L2 — findings that tie under `precedes` render identically.**
+    ///
+    /// This is `precedes`' documented claim, stated as a law. A tie that renders differently is a
+    /// pair whose position in the report is decided by `sorted(by:)`'s unspecified behaviour on
+    /// equal elements, which is precisely what the ordering exists to remove.
+    @Test
+    func tiedFindingsAreIndistinguishableInEveryFormat() {
+        for (name, pair, formatter) in Self.witnesses() {
+            let forward = formatter.format(issues: pair.sortedForReporting())
+            let backward = formatter.format(issues: pair.reversed().sortedForReporting())
+
+            #expect(
+                forward == backward,
+                """
+                Two findings tie under LintIssue.precedes but render differently in \
+                \(type(of: formatter)) — they differ in '\(name)', which the comparator does not \
+                compare. sorted(by:) is not stable, so their order in the report is unspecified \
+                and can change between runs over unchanged sources.
+                """
+            )
+        }
+    }
+
+    // MARK: - L3 — the report is a function of the finding set
+
+    /// **L3 — permutation invariance.** For any arrival order of the same findings, every formatter
+    /// renders the same bytes.
+    ///
+    /// The general form of L2, and the one that keeps earning its keep: it fails the day a field is
+    /// added to a formatter without being added to the comparator, which is how all four witnesses
+    /// above came to exist.
+    ///
+    /// Quantified over arrival order rather than over findings, because arrival order is what
+    /// actually varies between runs — the finding set is the same, the `TaskGroup` completion order
+    /// is not.
+    @Test
+    func everyFormatRendersTheSameBytesForAnyArrivalOrder() async {
+        let pool = Self.witnesses().flatMap(\.pair)
+        let formatters: [any IssueFormatterProtocol] = [
+            TextFormatter(), JSONFormatter(), CSVFormatter(), HTMLFormatter(), PBTSeedsFormatter()
+        ]
+        let reference = formatters.map { $0.format(issues: pool.sortedForReporting()) }
+
+        await propertyCheck(input: Gen<[LintIssue]>.shuffled(pool)) { arrival in
+            let sorted = arrival.sortedForReporting()
+            for (index, formatter) in formatters.enumerated() {
+                #expect(
+                    formatter.format(issues: sorted) == reference[index],
+                    """
+                    \(type(of: formatter)) rendered different bytes for a different arrival order \
+                    of the same findings. Two findings tie under LintIssue.precedes and are not \
+                    byte-identical in this format, so sorted(by:) decides their positions.
+                    """
+                )
+            }
+        }
+    }
+
+    // MARK: - Fixtures
+
+    /// Every default is chosen so that two calls differing in one argument tie under `precedes` —
+    /// the compared components are fixed unless a witness deliberately varies one.
+    private static func makeIssue(
+        message: String,
+        severity: IssueSeverity = .warning,
+        locations: [(filePath: String, lineNumber: Int)] = [("A.swift", 1)],
+        suggestion: String? = "fix it",
+        ruleName: RuleIdentifier = .forceUnwrap,
+        symbol: String? = nil,
+        role: PBTSeedRole? = nil
+    ) -> LintIssue {
+        LintIssue(
+            severity: severity,
+            message: message,
+            locations: locations,
+            suggestion: suggestion,
+            ruleName: ruleName,
+            symbol: symbol,
+            role: role
+        )
+    }
+}

--- a/Tests/CoreTests/Models/ModelsKitConformanceLawsTests.swift
+++ b/Tests/CoreTests/Models/ModelsKitConformanceLawsTests.swift
@@ -1,0 +1,255 @@
+// Emitted by `swift-infer scaffold-kit-suites --target SwiftProjectLintModels` on
+// 2026-08-11, then reviewed by hand: the `SwiftInferKitEvidence` import and the
+// `KitEvidenceRecorder.record` calls were removed, because recording verdicts back to
+// `swift-infer` would add a dependency edge from this package to SwiftInferProperties —
+// the opposite of the direction the toolchain's graph has. Running the laws is the value.
+//
+// **What these cover, and why they were missing.** This package has had the generator
+// engine (`swift-property-based`) and hand-written property suites for a while, but
+// nothing ran the laws the standard protocols already owe. `swift-infer discover`
+// measured 59 such laws over 22 carriers across the seven nested packages, checked by
+// nothing — the "real gap" branch of its own coverage note, since `Package.swift` did
+// not depend on SwiftPropertyLaws at all. This file closes the `SwiftProjectLintModels`
+// share of it: 7 carriers, 17 laws.
+//
+// **The two counts in one run do not reconcile, and the tool does not say why.** The same
+// invocation reports "10 carrier(s) have conformances whose laws PropertyLawKit checks"
+// and then "7 carrier(s) / 17 law(s) emitted live; 0 carrier(s) / 0 law(s) commented out
+// pending a hand-written `gen()`". Three carriers disappear between those two sentences,
+// and the second one actively reassures that nothing was dropped for want of a generator.
+//
+// By elimination the three are `SwiftUIViewType`, `SwiftUIProtocol` and `PatternCategory`
+// — the only `SwiftProjectLintModels` types carrying a kit-relevant conformance that got
+// no test, and all three are `CaseIterable`-only. `LayerPolicy` and `LintIssue` are not
+// among them: they conform to nothing the kit checks, so they were never in the 10.
+// Whether the three are dropped because no suite exists or for some other reason is not
+// stated anywhere in the output — worked out by hand, not read off the tool.
+//
+// On the assertion each test makes: it is strict-tier only, not
+// `allSatisfy { .passed }`. A blanket pass check is stricter than the kit intends and
+// fails on advisory findings — `Hashable.distribution` is Heuristic-tier and fails for
+// every small `CaseIterable` enum, because the domain cannot fill 1000 trials with
+// unique hashes. No generator fixes that; the domain is the type.
+import Foundation
+import PropertyLawKit
+@testable import SwiftProjectLintModels
+import Testing
+
+@Suite("PropertyLawKit conformance laws — SwiftProjectLintModels")
+struct ModelsKitConformanceLawsTests {
+
+    /// `IssueSeverity` conforms to `Codable`, so the kit checks these laws.
+    @Test("IssueSeverity — Codable laws")
+    func issueSeverityCodable() async throws {
+        let results = try await checkCodablePropertyLaws(
+            for: IssueSeverity.self,
+            using: Gen.oneOf(
+    Gen.always(IssueSeverity.error).eraseToAny(),
+    Gen.always(IssueSeverity.warning).eraseToAny(),
+    Gen.always(IssueSeverity.info).eraseToAny()
+)
+        )
+        // Strict-tier only, matching `EnforcementMode.default` — which the kit
+        // already enforces by throwing. A blanket `allSatisfy { .passed }` is
+        // STRICTER THAN THE KIT INTENDS and fails on advisory findings: measured
+        // here, `Hashable.distribution` (Heuristic) fails for every CaseIterable
+        // enum, because 25 cases cannot fill 1000 trials with unique hashes. No
+        // generator fixes that; the domain is the type.
+        #expect(results.allSatisfy { $0.tier != .strict || $0.outcome == .passed })
+    }
+
+    /// `PBTSeedEffect` conforms to `Codable`, so the kit checks these laws.
+    @Test("PBTSeedEffect — Codable laws")
+    func pBTSeedEffectCodable() async throws {
+        let results = try await checkCodablePropertyLaws(
+            for: PBTSeedEffect.self,
+            using: zip(Gen.oneOf(
+    Gen.always(PBTSeedEffect.Tier.pure).eraseToAny(),
+    Gen.always(PBTSeedEffect.Tier.idempotent).eraseToAny(),
+    Gen.always(PBTSeedEffect.Tier.observational).eraseToAny(),
+    Gen.always(PBTSeedEffect.Tier.externallyIdempotent).eraseToAny(),
+    Gen.always(PBTSeedEffect.Tier.nonIdempotent).eraseToAny()
+), Gen.oneOf(
+    Gen.always(PBTSeedEffect.Tier.pure).eraseToAny(),
+    Gen.always(PBTSeedEffect.Tier.idempotent).eraseToAny(),
+    Gen.always(PBTSeedEffect.Tier.observational).eraseToAny(),
+    Gen.always(PBTSeedEffect.Tier.externallyIdempotent).eraseToAny(),
+    Gen.always(PBTSeedEffect.Tier.nonIdempotent).eraseToAny()
+), Gen.oneOf(
+    Gen.always(PBTSeedEffect.Provenance.declared).eraseToAny(),
+    Gen.always(PBTSeedEffect.Provenance.inferredUpward).eraseToAny(),
+    Gen.always(PBTSeedEffect.Provenance.inferredDownward).eraseToAny()
+), Gen<Int>.int(in: -10_000...10_000).optional, Gen.oneOf(
+    Gen.always(PBTSeedEffect.Anchor.declaration).eraseToAny(),
+    Gen.always(PBTSeedEffect.Anchor.heuristic).eraseToAny()
+).optional, Gen<Character>.letterOrNumber.string(of: 0...8).optional)
+            .map {
+                PBTSeedEffect(
+                    declared: $0.0, resolved: $0.1, provenance: $0.2,
+                    depth: $0.3, anchor: $0.4, reason: $0.5
+                )
+            }
+        )
+        // Strict-tier only, matching `EnforcementMode.default` — which the kit
+        // already enforces by throwing. A blanket `allSatisfy { .passed }` is
+        // STRICTER THAN THE KIT INTENDS and fails on advisory findings: measured
+        // here, `Hashable.distribution` (Heuristic) fails for every CaseIterable
+        // enum, because 25 cases cannot fill 1000 trials with unique hashes. No
+        // generator fixes that; the domain is the type.
+        #expect(results.allSatisfy { $0.tier != .strict || $0.outcome == .passed })
+    }
+
+    /// `PBTSeedEffect` conforms to `Equatable`, so the kit checks these laws.
+    @Test("PBTSeedEffect — Equatable laws")
+    func pBTSeedEffectEquatable() async throws {
+        let results = try await checkEquatablePropertyLaws(
+            for: PBTSeedEffect.self,
+            using: zip(Gen.oneOf(
+    Gen.always(PBTSeedEffect.Tier.pure).eraseToAny(),
+    Gen.always(PBTSeedEffect.Tier.idempotent).eraseToAny(),
+    Gen.always(PBTSeedEffect.Tier.observational).eraseToAny(),
+    Gen.always(PBTSeedEffect.Tier.externallyIdempotent).eraseToAny(),
+    Gen.always(PBTSeedEffect.Tier.nonIdempotent).eraseToAny()
+), Gen.oneOf(
+    Gen.always(PBTSeedEffect.Tier.pure).eraseToAny(),
+    Gen.always(PBTSeedEffect.Tier.idempotent).eraseToAny(),
+    Gen.always(PBTSeedEffect.Tier.observational).eraseToAny(),
+    Gen.always(PBTSeedEffect.Tier.externallyIdempotent).eraseToAny(),
+    Gen.always(PBTSeedEffect.Tier.nonIdempotent).eraseToAny()
+), Gen.oneOf(
+    Gen.always(PBTSeedEffect.Provenance.declared).eraseToAny(),
+    Gen.always(PBTSeedEffect.Provenance.inferredUpward).eraseToAny(),
+    Gen.always(PBTSeedEffect.Provenance.inferredDownward).eraseToAny()
+), Gen<Int>.int(in: -10_000...10_000).optional, Gen.oneOf(
+    Gen.always(PBTSeedEffect.Anchor.declaration).eraseToAny(),
+    Gen.always(PBTSeedEffect.Anchor.heuristic).eraseToAny()
+).optional, Gen<Character>.letterOrNumber.string(of: 0...8).optional)
+            .map {
+                PBTSeedEffect(
+                    declared: $0.0, resolved: $0.1, provenance: $0.2,
+                    depth: $0.3, anchor: $0.4, reason: $0.5
+                )
+            }
+        )
+        // Strict-tier only, matching `EnforcementMode.default` — which the kit
+        // already enforces by throwing. A blanket `allSatisfy { .passed }` is
+        // STRICTER THAN THE KIT INTENDS and fails on advisory findings: measured
+        // here, `Hashable.distribution` (Heuristic) fails for every CaseIterable
+        // enum, because 25 cases cannot fill 1000 trials with unique hashes. No
+        // generator fixes that; the domain is the type.
+        #expect(results.allSatisfy { $0.tier != .strict || $0.outcome == .passed })
+    }
+
+    /// `PBTSeedRole` conforms to `Codable`, so the kit checks these laws.
+    @Test("PBTSeedRole — Codable laws")
+    func pBTSeedRoleCodable() async throws {
+        let results = try await checkCodablePropertyLaws(
+            for: PBTSeedRole.self,
+            using: Gen<PBTSeedRole?>.element(of: PBTSeedRole.allCases).compactMap(\.self)
+        )
+        // Strict-tier only, matching `EnforcementMode.default` — which the kit
+        // already enforces by throwing. A blanket `allSatisfy { .passed }` is
+        // STRICTER THAN THE KIT INTENDS and fails on advisory findings: measured
+        // here, `Hashable.distribution` (Heuristic) fails for every CaseIterable
+        // enum, because 25 cases cannot fill 1000 trials with unique hashes. No
+        // generator fixes that; the domain is the type.
+        #expect(results.allSatisfy { $0.tier != .strict || $0.outcome == .passed })
+    }
+
+    /// `ProjectFile` conforms to `Equatable`, so the kit checks these laws.
+    @Test("ProjectFile — Equatable laws")
+    func projectFileEquatable() async throws {
+        let results = try await checkEquatablePropertyLaws(
+            for: ProjectFile.self,
+            using: zip(
+                Gen<Character>.letterOrNumber.string(of: 0...8),
+                Gen<Character>.letterOrNumber.string(of: 0...8),
+                Gen<Character>.letterOrNumber.string(of: 0...8).optional
+            )
+            .map { ProjectFile(name: $0.0, content: $0.1, relativePath: $0.2) }
+        )
+        // Strict-tier only, matching `EnforcementMode.default` — which the kit
+        // already enforces by throwing. A blanket `allSatisfy { .passed }` is
+        // STRICTER THAN THE KIT INTENDS and fails on advisory findings: measured
+        // here, `Hashable.distribution` (Heuristic) fails for every CaseIterable
+        // enum, because 25 cases cannot fill 1000 trials with unique hashes. No
+        // generator fixes that; the domain is the type.
+        #expect(results.allSatisfy { $0.tier != .strict || $0.outcome == .passed })
+    }
+
+    /// `RuleIdentifier` conforms to `Codable`, so the kit checks these laws.
+    @Test("RuleIdentifier — Codable laws")
+    func ruleIdentifierCodable() async throws {
+        let results = try await checkCodablePropertyLaws(
+            for: RuleIdentifier.self,
+            using: Gen<RuleIdentifier?>.element(of: RuleIdentifier.allCases).compactMap(\.self)
+        )
+        // Strict-tier only, matching `EnforcementMode.default` — which the kit
+        // already enforces by throwing. A blanket `allSatisfy { .passed }` is
+        // STRICTER THAN THE KIT INTENDS and fails on advisory findings: measured
+        // here, `Hashable.distribution` (Heuristic) fails for every CaseIterable
+        // enum, because 25 cases cannot fill 1000 trials with unique hashes. No
+        // generator fixes that; the domain is the type.
+        #expect(results.allSatisfy { $0.tier != .strict || $0.outcome == .passed })
+    }
+
+    /// `TestReachability` conforms to `Equatable`, so the kit checks these laws.
+    @Test("TestReachability — Equatable laws")
+    func testReachabilityEquatable() async throws {
+        let results = try await checkEquatablePropertyLaws(
+            for: TestReachability.self,
+            using: Gen.oneOf(
+    Gen.always(TestReachability.reachable).eraseToAny(),
+    Gen<TestRestriction?>.element(of: TestRestriction.allCases)
+        .compactMap(\.self)
+        .map { TestReachability.unreachable($0) }
+        .eraseToAny(),
+    Gen.always(TestReachability.unknown).eraseToAny()
+)
+        )
+        // Strict-tier only, matching `EnforcementMode.default` — which the kit
+        // already enforces by throwing. A blanket `allSatisfy { .passed }` is
+        // STRICTER THAN THE KIT INTENDS and fails on advisory findings: measured
+        // here, `Hashable.distribution` (Heuristic) fails for every CaseIterable
+        // enum, because 25 cases cannot fill 1000 trials with unique hashes. No
+        // generator fixes that; the domain is the type.
+        #expect(results.allSatisfy { $0.tier != .strict || $0.outcome == .passed })
+    }
+
+    /// `TestRestriction` conforms to `Codable`, so the kit checks these laws.
+    @Test("TestRestriction — Codable laws")
+    func testRestrictionCodable() async throws {
+        let results = try await checkCodablePropertyLaws(
+            for: TestRestriction.self,
+            using: Gen<TestRestriction?>.element(of: TestRestriction.allCases).compactMap(\.self)
+        )
+        // Strict-tier only, matching `EnforcementMode.default` — which the kit
+        // already enforces by throwing. A blanket `allSatisfy { .passed }` is
+        // STRICTER THAN THE KIT INTENDS and fails on advisory findings: measured
+        // here, `Hashable.distribution` (Heuristic) fails for every CaseIterable
+        // enum, because 25 cases cannot fill 1000 trials with unique hashes. No
+        // generator fixes that; the domain is the type.
+        #expect(results.allSatisfy { $0.tier != .strict || $0.outcome == .passed })
+    }
+
+    /// `TestRestriction` conforms to `Equatable`, so the kit checks these laws.
+    @Test("TestRestriction — Equatable laws")
+    func testRestrictionEquatable() async throws {
+        let results = try await checkEquatablePropertyLaws(
+            for: TestRestriction.self,
+            using: Gen<TestRestriction?>.element(of: TestRestriction.allCases).compactMap(\.self)
+        )
+        // Strict-tier only, matching `EnforcementMode.default` — which the kit
+        // already enforces by throwing. A blanket `allSatisfy { .passed }` is
+        // STRICTER THAN THE KIT INTENDS and fails on advisory findings: measured
+        // here, `Hashable.distribution` (Heuristic) fails for every CaseIterable
+        // enum, because 25 cases cannot fill 1000 trials with unique hashes. No
+        // generator fixes that; the domain is the type.
+        #expect(results.allSatisfy { $0.tier != .strict || $0.outcome == .passed })
+    }
+}
+
+// MARK: - Blocked on a generator
+//
+// Each of these needs `static func gen() -> Generator<T, some SendableSequenceType>`
+// on the carrier. The reason above each call is the kit's own diagnosis.


### PR DESCRIPTION
## What changed

Three commits:

1. **`LintIssue.precedes` is now total** over every field any formatter renders, with `ReportOrderDeterminismLawsTests` stating the law and holding a witness for each gap that was open.
2. **PropertyLawKit conformance laws** for `SwiftProjectLintModels` — 7 carriers, 17 laws.
3. **`.codex/hooks.json`** — `swift package clean` on SessionStart.

## Why

The comparator's own doc comment claimed its tiebreaks covered "everything the text report prints — rule, message, suggestion". `TextFormatter` renders `filepath:line: severity: [rule] message`, so **severity was printed on every line and never compared.** Two findings differing only in severity tied under `precedes`, and `sorted(by:)` is not stable, so they could swap between runs — a spurious diff line in the primary human-facing report, which is the exact failure this file exists to prevent. The justification is where the gap hid.

Three more fields had the same shape: the tail of `locations` (the comparator read only `locations.first` while JSON and CSV render every element), the `nil`-versus-`""` distinction that `?? ""` collapsed (synthesized `Codable` omits a nil key and emits `""` for empty), and the `pbt-seeds` metadata.

## What a reviewer should scrutinise

**Stability is deliberately not the fix.** Decorating with the original index would make `sorted` stable, but stability preserves *arrival* order — which is the `TaskGroup` completion order, the nondeterminism being removed. A stable sort would pin the report to precisely the thing that varies.

**Two comparisons are narrower than they look, and I claim they are complete anyway.** `testReachability` is compared through `restriction` alone, because `.reachable` and `.unknown` both carry no restriction *and* `effectiveKind` treats them the same, so no formatter can distinguish them. Severity is compared on `rawValue` — arbitrary but total; ranking error above warning would be a *reporting* decision, and that stage is only reached once path, line, rule and message have all tied. Both are worth disagreeing with if you think a formatter can tell them apart.

**The kit suite's assertion is strict-tier only**, not `allSatisfy { .passed }`. A blanket pass check is stricter than the kit intends: `Hashable.distribution` is Heuristic-tier and fails for every small `CaseIterable` enum, because the domain cannot supply 1000 unique hashes. No generator fixes that.

**The scaffold was edited by hand** — the `SwiftInferKitEvidence` import and `KitEvidenceRecorder.record` calls are removed, because recording verdicts upstream would add a dependency edge from this package to SwiftInferProperties, the opposite of the toolchain graph's direction.

`swift test` passes: 3350 tests / 407 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUiBG9dnCecA2iYHPBAFNb