### PR TITLE
Make the rule docs and the registry agree, and keep them that way

### DIFF
--- a/Docs/rules/RULES.md
+++ b/Docs/rules/RULES.md
@@ -1,6 +1,6 @@
 # SwiftProjectLint Rules Reference
 
-SwiftProjectLint is a static analysis tool for SwiftUI projects. It parses Swift source files using SwiftSyntax AST visitors to detect anti-patterns spanning state management, performance, animations, architecture, code quality, security, accessibility, memory management, networking, UI patterns, modernization, and idempotency. This reference documents all 165 lint rules, organized by category.
+SwiftProjectLint is a static analysis tool for SwiftUI projects. It parses Swift source files using SwiftSyntax AST visitors to detect anti-patterns spanning state management, performance, animations, architecture, code quality, security, accessibility, memory management, networking, UI patterns, modernization, and idempotency. This reference documents all 205 lint rules, organized by category.
 
 Rules marked **opt-in** are disabled by default and must be explicitly listed under `enabled_only` in `.swiftprojectlint.yml`.
 
@@ -10,6 +10,9 @@ Rules marked **opt-in** are disabled by default and must be explicitly listed un
 
 | Rule | Severity |
 |------|----------|
+| [Flag Optional Pair State](flag-optional-pair-state.md) | Info |
+| [Mutually Exclusive Presentation State](mutually-exclusive-presentation-state.md) | Info |
+| [Redundant Derived Property](redundant-derived-property.md) | Info |
 | [Related Duplicate State Variable](related-duplicate-state-variable.md) | Warning |
 | [Unrelated Duplicate State Variable](unrelated-duplicate-state-variable.md) | Info |
 | [Uninitialized State Variable](uninitialized-state-variable.md) | Error |
@@ -32,7 +35,7 @@ Rules marked **opt-in** are disabled by default and must be explicitly listed un
 | [Large View Helper](large-view-helper.md) | Warning |
 | [ForEach Self ID](for-each-self-id.md) | Warning |
 | [Volatile View ID](volatile-view-id.md) | Warning |
-| [Unnecessary View Update](unnecessary-view-update.md) | Warning |
+| [Unnecessary View Update](unnecessary-view-update.md) | Info |
 | [ViewBuilder Complexity](view-builder-complexity.md) | Warning |
 | [Custom Modifier Performance](custom-modifier-performance.md) | Warning |
 | [Formatter In View Body](formatter-in-view-body.md) | Warning |
@@ -96,6 +99,7 @@ Rules marked **opt-in** are disabled by default and must be explicitly listed un
 
 | Rule | Severity |
 |------|----------|
+| [Effect Cycle](effect-cycle.md) | Warning |
 | [Magic Number](magic-number.md) | Info |
 | [Magic Layout Number](magic-layout-number.md) | Info *(opt-in)* |
 | [Hardcoded Strings](hardcoded-strings.md) | Info *(opt-in)* |
@@ -116,7 +120,7 @@ Rules marked **opt-in** are disabled by default and must be explicitly listed un
 | [Force Try](force-try.md) | Warning |
 | [Force Unwrap](force-unwrap.md) | Warning |
 | [Unconditional Trap](unconditional-trap.md) | Warning |
-| [Print Statement](print-statement.md) | Info |
+| [Print Statement](print-statement.md) | Warning |
 | [Catch Without Handling](catch-without-handling.md) | Warning |
 | [TODO Comment](todo-comment.md) | Info |
 | [Task Detached](task-detached.md) | Info |
@@ -249,10 +253,12 @@ Rules marked **opt-in** are disabled by default and must be explicitly listed un
 | Rule | Severity |
 |------|----------|
 | [Idempotency Violation](idempotency-violation.md) | Error |
+| [Non-Idempotent Action Name](non-idempotent-action-name.md) | Warning |
 | [Non-Idempotent In Retry Context](non-idempotent-in-retry-context.md) | Error |
 | [Missing Idempotency Key](missing-idempotency-key.md) | Error |
 | [Once Contract Violation](once-contract-violation.md) | Error |
 | [Tuple Equality With Unstable Components](tuple-equality-with-unstable-components.md) | Warning |
+| [Unannotated In Strict Replayable Context](unannotated-in-strict-replayable-context.md) | Error |
 
 ## Testability
 

--- a/Docs/rules/cf-absolute-time.md
+++ b/Docs/rules/cf-absolute-time.md
@@ -3,7 +3,7 @@
 ## CF Absolute Time
 
 **Identifier:** `CF Absolute Time`
-**Category:** Code Quality
+**Category:** Modernization
 **Severity:** Info
 
 ### Rationale

--- a/Docs/rules/completion-handler-data-task.md
+++ b/Docs/rules/completion-handler-data-task.md
@@ -3,7 +3,7 @@
 ## Completion Handler Data Task
 
 **Identifier:** `Completion Handler Data Task`
-**Category:** Code Quality
+**Category:** Modernization
 **Severity:** Info
 
 ### Rationale

--- a/Docs/rules/date-now.md
+++ b/Docs/rules/date-now.md
@@ -3,7 +3,7 @@
 ## Date Now
 
 **Identifier:** `Date Now`
-**Category:** Code Quality
+**Category:** Modernization
 **Severity:** Info
 
 ### Rationale

--- a/Docs/rules/dispatch-main-async.md
+++ b/Docs/rules/dispatch-main-async.md
@@ -3,7 +3,7 @@
 ## Dispatch Main Async
 
 **Identifier:** `Dispatch Main Async`
-**Category:** Code Quality
+**Category:** Modernization
 **Severity:** Info
 
 ### Rationale

--- a/Docs/rules/dispatch-semaphore-in-async.md
+++ b/Docs/rules/dispatch-semaphore-in-async.md
@@ -3,7 +3,7 @@
 ## Dispatch Semaphore in Async
 
 **Identifier:** `Dispatch Semaphore in Async`
-**Category:** Performance
+**Category:** Modernization
 **Severity:** Warning
 
 ### Rationale

--- a/Docs/rules/legacy-notification-observer.md
+++ b/Docs/rules/legacy-notification-observer.md
@@ -3,7 +3,7 @@
 ## Legacy Notification Observer
 
 **Identifier:** `Legacy Notification Observer`
-**Category:** Code Quality
+**Category:** Modernization
 **Severity:** Info
 
 ### Rationale

--- a/Docs/rules/legacy-random.md
+++ b/Docs/rules/legacy-random.md
@@ -3,7 +3,7 @@
 ## Legacy Random
 
 **Identifier:** `Legacy Random`
-**Category:** Code Quality
+**Category:** Modernization
 **Severity:** Info
 
 ### Rationale

--- a/Docs/rules/task-in-on-appear.md
+++ b/Docs/rules/task-in-on-appear.md
@@ -3,7 +3,7 @@
 ## Task in onAppear
 
 **Identifier:** `Task in onAppear`
-**Category:** UI Patterns
+**Category:** Modernization
 **Severity:** Warning
 
 ### Rationale

--- a/Docs/rules/thread-sleep.md
+++ b/Docs/rules/thread-sleep.md
@@ -3,7 +3,7 @@
 ## Thread Sleep
 
 **Identifier:** `Thread Sleep`
-**Category:** Code Quality
+**Category:** Modernization
 **Severity:** Warning
 
 ### Rationale

--- a/Docs/rules/unnecessary-view-update.md
+++ b/Docs/rules/unnecessary-view-update.md
@@ -4,7 +4,7 @@
 
 **Identifier:** `Unnecessary View Update`
 **Category:** Performance
-**Severity:** Warning
+**Severity:** Info
 
 ### Rationale
 When a state variable is assigned the value it already holds, SwiftUI still schedules a redraw because it observes the assignment, not whether the value changed. Unnecessary reassignments cause spurious re-renders that degrade scrolling performance and battery life.

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/Accessibility.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/Accessibility.swift
@@ -44,7 +44,7 @@ class Accessibility: BasePatternRegistrar {
             SyntaxPattern(
                 name: .inaccessibleColorUsage,
                 visitor: AccessibilityVisitor.self,
-                severity: .warning,
+                severity: .info,
                 category: .accessibility,
                 messageTemplate: "Color usage may not be accessible for colorblind users",
                 suggestion: "Use semantic colors or add alternative indicators beyond color",

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/Architecture.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/Architecture.swift
@@ -12,7 +12,7 @@ class Architecture: BasePatternRegistrar {
             SyntaxPattern(
                 name: .missingDependencyInjection,
                 visitor: ArchitectureVisitor.self,
-                severity: .warning,
+                severity: .info,
                 category: .architecture,
                 messageTemplate: "Consider using dependency injection for {dependency}",
                 suggestion: "Inject dependencies through initializers or environment",

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/PrintStatement.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/PrintStatement.swift
@@ -12,7 +12,7 @@ struct PrintStatement: PatternRegistrarProtocol {
         SyntaxPattern(
             name: .printStatement,
             visitor: PrintStatementVisitor.self,
-            severity: .info,
+            severity: .warning,
             category: .codeQuality,
             messageTemplate: "print() statement found — consider using os.Logger or removing before release",
             suggestion: "Use os.Logger for structured logging or remove print statements before release.",

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/VariableShadowing.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/VariableShadowing.swift
@@ -13,7 +13,7 @@ struct VariableShadowing: PatternRegistrarProtocol {
         SyntaxPattern(
             name: .variableShadowing,
             visitor: VariableShadowingVisitor.self,
-            severity: .warning,
+            severity: .error,
             category: .codeQuality,
             messageTemplate: "Variable shadows a declaration from an outer scope",
             suggestion: "Rename the inner variable to avoid confusion with the outer declaration.",

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/MemoryManagement/PatternRegistrars/MemoryManagement.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/MemoryManagement/PatternRegistrars/MemoryManagement.swift
@@ -21,7 +21,7 @@ class MemoryManagement: BasePatternRegistrar {
             SyntaxPattern(
                 name: .largeObjectInState,
                 visitor: MemoryManagementVisitor.self,
-                severity: .warning,
+                severity: .info,
                 category: .memoryManagement,
                 messageTemplate: "Large object stored in state: {objectType}",
                 suggestion: "Consider using @StateObject or moving to a separate model",

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Networking/PatternRegistrars/Networking.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Networking/PatternRegistrars/Networking.swift
@@ -12,7 +12,7 @@ class Networking: BasePatternRegistrar {
             SyntaxPattern(
                 name: .missingErrorHandling,
                 visitor: NetworkingVisitor.self,
-                severity: .error,
+                severity: .warning,
                 category: .networking,
                 messageTemplate: "Network call missing error handling",
                 suggestion: "Add proper error handling for network operations",
@@ -21,7 +21,7 @@ class Networking: BasePatternRegistrar {
             SyntaxPattern(
                 name: .synchronousNetworkCall,
                 visitor: NetworkingVisitor.self,
-                severity: .warning,
+                severity: .error,
                 category: .networking,
                 messageTemplate: "Synchronous network call detected",
                 suggestion: "Use async/await or completion handlers for network calls",

--- a/Tests/CoreTests/Packaging/RuleDocumentationConsistencyTests.swift
+++ b/Tests/CoreTests/Packaging/RuleDocumentationConsistencyTests.swift
@@ -1,0 +1,165 @@
+@testable import Core
+import Foundation
+import Testing
+
+/// Laws over the rule documentation — **what `Docs/rules/` says about a rule must be what the code
+/// does.**
+///
+/// A rule's severity and category are written down in three places: the registrar that declares the
+/// `SyntaxPattern`, the per-rule page under `Docs/rules/`, and the row for it in `Docs/rules/RULES.md`.
+/// Nothing kept them in step, and by the time these tests were written all three had drifted:
+///
+/// - **Nine pages disagreed with the registry on severity.** Six of those were not the page's fault —
+///   the visitor was passing an explicit severity to `addIssue(severity:message:…)`, which overrides
+///   `pattern.severity`, so the registrar declared one value and the user saw another. The pages
+///   documented what the user saw. The registrars were corrected to match, not the pages.
+/// - **Nine pages named a category that predated `modernization`.**
+/// - **Six rules had a page but no row in `RULES.md`,** so they were undiscoverable from the index.
+/// - **`RULES.md` claimed to document 165 rules** while listing 199 of 205.
+///
+/// `READMERuleCountTests` already pins the counts the README states. These do the same for the rule
+/// reference, which is the document a user actually reads to find out what a finding means.
+///
+/// Both checks run against the live registry rather than by parsing Swift source, so they cannot go
+/// stale the way a hand-maintained list would.
+@Suite("Packaging — the rule docs match the registry")
+@MainActor
+struct RuleDocumentationConsistencyTests {
+
+    // MARK: - Fixtures
+
+    private static var docsDirectory: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // Packaging
+            .deletingLastPathComponent()   // CoreTests
+            .deletingLastPathComponent()   // Tests
+            .deletingLastPathComponent()   // repository root
+            .appendingPathComponent("Docs/rules")
+    }
+
+    private static var rulesIndex: String {
+        get throws {
+            try String(contentsOf: docsDirectory.appendingPathComponent("RULES.md"), encoding: .utf8)
+        }
+    }
+
+    /// Every registered pattern, which is the authority these tests measure the docs against.
+    private static var registeredPatterns: [SyntaxPattern] {
+        TestRegistryManager.initializeSharedRegistry()
+        return TestRegistryManager.sharedPatternRegistry.getAllPatterns()
+    }
+
+    /// `.forceTry` → `force-try.md`, the same slug the suppression key uses.
+    private static func documentationFile(for rule: RuleIdentifier) -> URL {
+        docsDirectory.appendingPathComponent("\(rule.suppressionKey).md")
+    }
+
+    /// The raw `**Severity:** …` / `**Category:** …` field from a page's header.
+    private static func headerField(_ field: String, in page: String) -> String? {
+        for line in page.components(separatedBy: "\n") where line.hasPrefix("**\(field):**") {
+            return line.dropFirst("**\(field):**".count).trimmingCharacters(in: .whitespaces)
+        }
+        return nil
+    }
+
+    /// Every severity word a header names.
+    ///
+    /// Three rules choose their severity per finding — `computedPropertyView` reports `.info` when
+    /// `@ViewBuilder` is present and `.warning` otherwise, `missingPreview` splits on access level —
+    /// and their pages say so rather than picking one. The check is therefore that the registry's
+    /// severity is *among* the ones the page names, not that the page names only it. A page claiming
+    /// a severity the registry never declares still fails, which is the drift worth catching.
+    private static func severitiesNamed(in header: String) -> Set<String> {
+        let words = header.lowercased().components(separatedBy: CharacterSet.alphanumerics.inverted)
+        return Set(words.filter { ["error", "warning", "info"].contains($0) })
+    }
+
+    /// The trailing category, ignoring any parenthetical.
+    private static func categoryNamed(in header: String) -> String {
+        header.components(separatedBy: " *").first?
+            .components(separatedBy: " (").first?
+            .trimmingCharacters(in: .whitespaces) ?? header
+    }
+
+    private static func displayName(for category: PatternCategory) -> String {
+        switch category {
+        case .stateManagement: return "State Management"
+        case .performance: return "Performance"
+        case .architecture: return "Architecture"
+        case .codeQuality: return "Code Quality"
+        case .security: return "Security"
+        case .accessibility: return "Accessibility"
+        case .memoryManagement: return "Memory Management"
+        case .networking: return "Networking"
+        case .uiPatterns: return "UI Patterns"
+        case .animation: return "Animation"
+        case .modernization: return "Modernization"
+        case .idempotency: return "Idempotency"
+        case .testability: return "Testability"
+        case .other: return "Other"
+        }
+    }
+
+    // MARK: - The per-rule pages
+
+    @Test("every rule page states the severity the registry declares")
+    func testDocumentedSeverityMatchesRegistry() throws {
+        for pattern in Self.registeredPatterns {
+            let file = Self.documentationFile(for: pattern.name)
+            guard let page = try? String(contentsOf: file, encoding: .utf8) else { continue }
+            guard let stated = Self.headerField("Severity", in: page) else { continue }
+
+            let named = Self.severitiesNamed(in: stated)
+            #expect(
+                named.contains("\(pattern.severity)".lowercased()),
+                "\(file.lastPathComponent) says \(stated); the registry declares \(pattern.severity)"
+            )
+        }
+    }
+
+    @Test("every rule page states the category the registry declares")
+    func testDocumentedCategoryMatchesRegistry() throws {
+        for pattern in Self.registeredPatterns {
+            let file = Self.documentationFile(for: pattern.name)
+            guard let page = try? String(contentsOf: file, encoding: .utf8) else { continue }
+            guard let stated = Self.headerField("Category", in: page) else { continue }
+
+            let expected = Self.displayName(for: pattern.category)
+            #expect(
+                Self.categoryNamed(in: stated) == expected,
+                "\(file.lastPathComponent) says \(stated); the registry declares \(expected)"
+            )
+        }
+    }
+
+    // MARK: - The index
+
+    @Test("every selectable rule has a row in RULES.md")
+    func testIndexListsEverySelectableRule() throws {
+        let index = try Self.rulesIndex
+
+        for rule in RuleIdentifier.selectableRules.sorted(by: { $0.rawValue < $1.rawValue }) {
+            #expect(
+                index.contains("[\(rule.rawValue)]("),
+                "RULES.md has no row for \(rule.rawValue) — the rule is undiscoverable from the index"
+            )
+        }
+    }
+
+    @Test("the count RULES.md states equals the number of rows it carries")
+    func testIndexCountMatchesItsOwnRows() throws {
+        let index = try Self.rulesIndex
+        let rows = index.components(separatedBy: "\n").filter { $0.hasPrefix("| [") }.count
+
+        // The count the prose states, e.g. "documents all 205 lint rules".
+        let words = index.components(separatedBy: CharacterSet.whitespacesAndNewlines)
+        let stated = words.indices
+            .filter { $0 + 1 < words.count && words[$0 + 1] == "lint" }
+            .compactMap { Int(words[$0]) }
+
+        #expect(stated.isEmpty == false, "RULES.md should state how many rules it documents")
+        for count in stated {
+            #expect(count == rows, "RULES.md states \(count) rules and lists \(rows)")
+        }
+    }
+}


### PR DESCRIPTION
## What changed

An audit of all 207 rule docs against the code, in three commits: a code bug, the doc corrections, and tests so neither recurs.

## 1. Seven rules declared a severity they never report

`BasePatternVisitor` has two `addIssue` overloads. One uses `pattern.severity` from the registrar; the other takes an explicit severity and **wins**. Seven rules use the second and pass something else:

| rule | declared | reported |
|---|---|---|
| `inaccessibleColorUsage` | warning | info |
| `largeObjectInState` | warning | info |
| `missingDependencyInjection` | warning | info |
| `missingErrorHandling` | error | warning |
| `printStatement` | info | warning |
| `synchronousNetworkCall` | warning | error |
| `variableShadowing` | warning | error |

**The registrars are corrected to match the visitors, not the reverse** — the visitors are what ships, and the rule pages already documented the reported value. **No finding a user sees changes.** What changes is the catalog: `getAllPatterns()` feeds the rule browser and the docs, and all of them were being told a value the linter would never emit.

`variableShadowing` is the one worth looking at. Its call sites pass `.error` into a helper that forwards `severity: severity`, so the literal is three frames from the `ruleName:` — the version of this bug no simple scan finds. I only caught it because the doc test failed.

## 2. Doc corrections

- **Nine pages named a category predating `modernization`** — and `RULES.md` already filed them under Modernization, so the index and the pages disagreed with each other too.
- **Six rules had a page but no index row**, reachable only by guessing the filename: Effect Cycle, Flag Optional Pair State, Mutually Exclusive Presentation State, Non-Idempotent Action Name, Redundant Derived Property, Unannotated In Strict Replayable Context.
- **`RULES.md` claimed 165 rules while listing 199.** Now 205 rows, exactly `RuleIdentifier.selectableRules.count`.
- **`unnecessary-view-update`** said Warning in both page and index; the registrar says `.info` and nothing overrides it. This one is the reverse of the seven above — the page was wrong.

## 3. Tests

Four laws against `getAllPatterns()` rather than parsed source.

**What a reviewer should scrutinise: the severity law is deliberately weaker than equality.** Three rules choose severity per finding — `computedPropertyView` reports `.info` with `@ViewBuilder` and `.warning` without; `missingPreview` splits on access level — and their pages say so rather than picking one, which is better documentation than either single word. So the law is that the registry's severity is *among* those the page names. A page claiming a severity the registry never declares still fails. If you would rather those three pages picked one word and got exact equality, that is the alternative.

## Verification

`swift package clean && swift test`: **3363 tests in 409 suites pass**.

## Not changed

`Docs/rules/pure-function-candidate.md` and `pure-closure-candidate.md` share several paragraphs by design; only the census counts were wrong, fixed in #119. The audit found no other numeric copy-paste and no remaining self-links across the 207 pages — only 7 paragraphs are shared between docs, all legitimate boilerplate between genuine siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUiBG9dnCecA2iYHPBAFNb