### PR TITLE
Report ViewHosting ordering only where the view can actually trap

### DIFF
--- a/Docs/rules/view-hosting-before-inspection.md
+++ b/Docs/rules/view-hosting-before-inspection.md
@@ -24,6 +24,10 @@ Measured on macOS 27 against a minimal reproduction of [nalexn/ViewInspector#329
 
 Only the last works, and it is what ViewInspector's maintainer prescribed when closing that issue: *"hosting the view should be the last step, after you setup the inspection."*
 
+**The finding is gated on the view being able to trap at all.** The ordering is only dangerous for a view in this rule's precondition — one reading `@Environment(SomeType.self)`. Every other view inspects out-of-tree perfectly well, which is ViewInspector's ordinary mode of operation, so reporting the ordering alone means reporting an `error` against tests that pass and will keep passing. A project-wide pre-scan (`ObservableEnvironmentViewCollector`) catalogs the views that read the observable form, and a finding requires the test file to name one of them.
+
+The catalog is optional, and the two empty states are not the same. An **empty** catalog means the project was scanned and has no such view, so the rule stays silent. A **`nil`** catalog means no pre-scan ran — a single-file invocation — and the rule keeps its ungated behaviour rather than going quiet where it has no way to know better.
+
 `ViewHostingBeforeInspectionVisitor` walks each `FunctionDeclSyntax` body and compares **sibling** statements only. If a single statement contains both the hosting call and an inspection call, the inspection is nested inside the hosting closure — the correct async shape — and nothing is reported. A violation requires the two calls to be in *different* top-level statements with the hosting first.
 
 That sibling restriction is the whole difficulty of the rule. The correct async form places `ViewHosting.host` textually first, so a naive position comparison flags working code.
@@ -73,3 +77,15 @@ func testServer() throws {
 
 ### Companion
 [Observable Environment View Missing Inspection Hook](observable-environment-view-missing-inspection-hook.md) catches the same hazard from the *view* side, before any test is written.
+
+### Known Limitations
+
+- **The catalog match is per file, not per test.** The view under test is often built by a helper
+  elsewhere in the same file, so its type name never appears in the test function — a function-scoped
+  match would miss exactly the cases that matter. The cost is that a test file exercising both a
+  trapping view and a safe one reports the safe test too.
+- **A view reached only through an existential or a generic is invisible.** The gate matches
+  identifier tokens, so a test that never names the concrete view type is not reported even when the
+  view can trap.
+
+---

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
@@ -147,6 +147,8 @@ extension ProjectLinter {
         let categories: [PatternCategory]?
         let ruleIdentifiers: [RuleIdentifier]?
         let identifiableTypes: Set<String>
+        /// `View` names reading `@Environment(SomeType.self)`; `nil` when no pre-scan ran.
+        let observableEnvironmentViews: Set<String>?
         let enumTypes: Set<String>
         let actorTypes: Set<String>
         let localTypes: Set<String>
@@ -179,6 +181,7 @@ extension ProjectLinter {
             categories: env.categories,
             ruleIdentifiers: env.ruleIdentifiers,
             identifiableTypes: env.identifiableTypes,
+            observableEnvironmentViews: env.observableEnvironmentViews,
             enumTypes: env.enumTypes,
             actorTypes: env.actorTypes,
             localTypes: env.localTypes,
@@ -201,6 +204,7 @@ extension ProjectLinter {
         categories: [PatternCategory]?,
         ruleIdentifiers: [RuleIdentifier]?,
         identifiableTypes: Set<String> = [],
+        observableEnvironmentViews: Set<String>? = nil,
         enumTypes: Set<String> = [],
         actorTypes: Set<String> = [],
         localTypes: Set<String> = [],
@@ -226,6 +230,7 @@ extension ProjectLinter {
         let parsedAST = Parser.parse(source: content)
         let det = SourcePatternDetector(registry: registry)
         det.knownIdentifiableTypes = identifiableTypes
+        det.knownObservableEnvironmentViews = observableEnvironmentViews
         det.knownEnumTypes = enumTypes
         det.knownActorTypes = actorTypes
         det.knownLocalTypeNames = localTypes

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
@@ -231,6 +231,9 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         let values: Set<String>
         let functions: Set<String>
         let defaultedInitializers: Set<String>
+        /// `View` names reading `@Environment(SomeType.self)`. See
+        /// `ObservableEnvironmentViewCollector` for why the keypath form is excluded.
+        let observableEnvironmentViews: Set<String>
         /// Per type, the sibling methods that are themselves functions of their inputs. Unlike the
         /// name sets above this needs the parsed bodies, not just declarations, so it is resolved
         /// by its own fixpoint rather than by `collectTypes`.
@@ -267,6 +270,9 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
                 defaultedInitializers: collectTypes(
                     DefaultedInitializerCollector.self, from: filePaths
                 ),
+                observableEnvironmentViews: collectTypes(
+                    ObservableEnvironmentViewCollector.self, from: filePaths
+                ),
                 cleanInstanceMethods: CleanInstanceMethodCatalog.build(from: parsed),
                 impurePackageFunctions: PackagePurityJoin(sources: parsed).settledImpureNames
             )
@@ -285,6 +291,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         resolved.knownActorTypes = collected.actors
         resolved.knownLocalTypeNames = collected.local
         resolved.knownObservableTypes = collected.observable
+        resolved.knownObservableEnvironmentViews = collected.observableEnvironmentViews
         resolved.knownProtocolTypes = collected.protocols
         resolved.knownEquatableTypes = collected.equatable
         resolved.knownValueTypes = collected.values
@@ -312,6 +319,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
             categories: categories,
             ruleIdentifiers: ruleIdentifiers,
             identifiableTypes: collected.identifiable,
+            observableEnvironmentViews: collected.observableEnvironmentViews,
             enumTypes: collected.enums,
             actorTypes: collected.actors,
             localTypes: collected.local,

--- a/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetector.swift
+++ b/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetector.swift
@@ -30,6 +30,9 @@ public final class SourcePatternDetector: SourcePatternDetectorProtocol, @unchec
 
     /// Type names known to be declared as protocols across the project.
     /// Set by `ProjectLinter` after a pre-scan phase and passed through to visitors.
+    /// `View` names reading `@Environment(SomeType.self)`; `nil` when no pre-scan ran.
+    public var knownObservableEnvironmentViews: Set<String>?
+
     public var knownProtocolTypes: Set<String> = []
 
     /// Type names known to be `Equatable` across the project. Set by
@@ -189,6 +192,7 @@ public final class SourcePatternDetector: SourcePatternDetectorProtocol, @unchec
             // specific ruleNames regardless of which pattern was used to init.
             let visitor = entry.type.init(pattern: entry.patterns[0])
             visitor.setSourceLocationConverter(converter)
+            visitor.knownObservableEnvironmentViews = knownObservableEnvironmentViews
             visitor.knownIdentifiableTypes = knownIdentifiableTypes
             visitor.knownEnumTypes = knownEnumTypes
             visitor.knownActorTypes = knownActorTypes

--- a/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetectorProtocol.swift
+++ b/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetectorProtocol.swift
@@ -33,6 +33,9 @@ public protocol SourcePatternDetectorProtocol {
     var knownObservableTypes: Set<String> { get set }
 
     /// Type names known to be declared as protocols across the project.
+    /// `View` names reading `@Environment(SomeType.self)`; `nil` when no pre-scan ran.
+    var knownObservableEnvironmentViews: Set<String>? { get set }
+
     var knownProtocolTypes: Set<String> { get set }
 
     /// Type names known to be `Equatable` across the project (Equatable /

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ViewHostingBeforeInspectionVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ViewHostingBeforeInspectionVisitor.swift
@@ -78,6 +78,8 @@ final class ViewHostingBeforeInspectionVisitor: BasePatternVisitor {
             return .visitChildren
         }
 
+        guard exercisesAViewThatCanTrap(node) else { return .visitChildren }
+
         addIssue(
             severity: .error,
             message: "ViewHosting.host(…) runs before the view is inspected — inspect after "
@@ -91,6 +93,46 @@ final class ViewHostingBeforeInspectionVisitor: BasePatternVisitor {
         )
         return .visitChildren
     }
+
+    // MARK: - The trap precondition
+
+    /// Whether this test touches a view that can actually trap out-of-tree.
+    ///
+    /// The ordering this rule detects is only dangerous for a view reading
+    /// `@Environment(SomeType.self)`, which has no default and traps inside
+    /// `EnvironmentValues.subscript.getter` when the body is evaluated outside SwiftUI.
+    /// Every other view inspects out-of-tree perfectly well — that is ViewInspector's
+    /// ordinary mode — so reporting the ordering alone means reporting an error against
+    /// tests that pass and will keep passing.
+    ///
+    /// The catalog arrives from a project-wide pre-scan. When it is `nil` nobody looked,
+    /// and the rule keeps its previous behaviour rather than going silent on a
+    /// single-file run that has no way to know better. When it is present but empty the
+    /// project genuinely has no such view, and silence is the right answer.
+    ///
+    /// Matching is per **file**, not per function: the view under test is often built by a
+    /// helper elsewhere in the same test file, so a function-scoped check would miss the
+    /// cases that matter. A test file naming one of these views anywhere is enough.
+    private func exercisesAViewThatCanTrap(_ node: FunctionDeclSyntax) -> Bool {
+        guard let catalog = knownObservableEnvironmentViews else { return true }
+        guard !catalog.isEmpty else { return false }
+        return !identifiersInFile(containing: node).isDisjoint(with: catalog)
+    }
+
+    /// Every identifier token in the file, computed once per visitor instance.
+    private func identifiersInFile(containing node: FunctionDeclSyntax) -> Set<String> {
+        if let cached = cachedFileIdentifiers { return cached }
+        var found: Set<String> = []
+        for token in node.root.tokens(viewMode: .sourceAccurate) {
+            if case .identifier(let text) = token.tokenKind {
+                found.insert(text)
+            }
+        }
+        cachedFileIdentifiers = found
+        return found
+    }
+
+    private var cachedFileIdentifiers: Set<String>?
 
     // MARK: - Detection
 

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/BasePatternVisitor.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/BasePatternVisitor.swift
@@ -98,6 +98,15 @@ open class BasePatternVisitor: SyntaxVisitor, PatternVisitorProtocol {
     /// closure — from one that is merely **forwarding to a function the reader already extracted**,
     /// `{ search.matches(name: $0.name) }`. The two are syntactically identical, so without this the
     /// rule re-reports its own advice and the extraction loop never terminates.
+    /// `View` names reading `@Environment(SomeType.self)`, or `nil` when no project-wide
+    /// pre-scan ran.
+    ///
+    /// The optionality is the point. An empty set means "the project was scanned and no view
+    /// reads the observable form", which is a reason to stay silent; `nil` means "nobody
+    /// looked", which is not. A rule gating on this must treat the two differently or it goes
+    /// quiet in exactly the single-file case where it has no way to know better.
+    public var knownObservableEnvironmentViews: Set<String>?
+
     public var knownProjectFunctions: Set<String> = []
 
     /// Types whose initialiser has DEFAULTED parameters — built by `DefaultedInitializerCollector`.

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/ObservableEnvironmentViewCollector.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/ObservableEnvironmentViewCollector.swift
@@ -1,0 +1,65 @@
+import SwiftSyntax
+
+/// A fast SyntaxVisitor that collects the names of `View` types reading
+/// `@Environment(SomeType.self)` — the `@Observable` form, which has **no default value**.
+///
+/// Used as a project-wide pre-scan so that a per-file visitor can tell whether a view is
+/// capable of the trap at all. Evaluating such a view's `body` outside SwiftUI does not
+/// fail, it traps inside `EnvironmentValues.subscript.getter`, killing the test process.
+/// The keypath form `@Environment(\.someKey)` is not collected: it resolves to a default
+/// and evaluates out-of-tree without complaint.
+///
+/// The distinction matters because it is the whole precondition of
+/// `ViewHostingBeforeInspectionVisitor`. That rule reports a test that hosts before it
+/// inspects, and the ordering is only dangerous for a view in this set — every other view
+/// inspects out-of-tree perfectly well, which is ViewInspector's ordinary mode of
+/// operation. Without this catalog the rule fires on the ordering alone and reports an
+/// error against tests that pass and will keep passing.
+public final class ObservableEnvironmentViewCollector: SyntaxVisitor, TypeCollectorProtocol {
+    public var collectedTypes: Set<String> { viewNames }
+
+    /// Names of `View` conformers that read at least one `@Environment(SomeType.self)`.
+    private(set) var viewNames: Set<String> = []
+
+    public init() {
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override public func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        if Self.conformsToView(node), Self.readsObservableEnvironment(node) {
+            viewNames.insert(node.name.text)
+        }
+        return .visitChildren
+    }
+
+    private static func conformsToView(_ node: StructDeclSyntax) -> Bool {
+        guard let inheritance = node.inheritanceClause else { return false }
+        return inheritance.inheritedTypes.contains { inherited in
+            inherited.type.as(IdentifierTypeSyntax.self)?.name.text == "View"
+        }
+    }
+
+    /// True when any stored property carries `@Environment(SomeType.self)`.
+    ///
+    /// The argument has to be a member access ending in `.self` on a capitalised base —
+    /// `@Environment(\.dependencies)` is a keypath expression and does not match, which is
+    /// the case this collector exists to exclude.
+    private static func readsObservableEnvironment(_ node: StructDeclSyntax) -> Bool {
+        for member in node.memberBlock.members {
+            guard let variable = member.decl.as(VariableDeclSyntax.self) else { continue }
+            for attribute in variable.attributes {
+                guard let attr = attribute.as(AttributeSyntax.self),
+                      attr.attributeName.as(IdentifierTypeSyntax.self)?.name.text == "Environment",
+                      let args = attr.arguments?.as(LabeledExprListSyntax.self),
+                      let first = args.first?.expression.as(MemberAccessExprSyntax.self),
+                      first.declName.baseName.text == "self",
+                      let base = first.base?.as(DeclReferenceExprSyntax.self),
+                      base.baseName.text.first?.isUppercase == true else {
+                    continue
+                }
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/Tests/CoreTests/Testability/ViewHostingBeforeInspectionVisitorTests.swift
+++ b/Tests/CoreTests/Testability/ViewHostingBeforeInspectionVisitorTests.swift
@@ -7,7 +7,10 @@ import Testing
 @Suite
 struct ViewHostingBeforeInspectionVisitorTests {
 
-    private func run(_ source: String) -> ViewHostingBeforeInspectionVisitor {
+    private func run(
+        _ source: String,
+        observableEnvironmentViews: Set<String>? = nil
+    ) -> ViewHostingBeforeInspectionVisitor {
         let pattern = SyntaxPattern(
             name: .viewHostingBeforeInspection,
             visitor: ViewHostingBeforeInspectionVisitor.self,
@@ -18,8 +21,69 @@ struct ViewHostingBeforeInspectionVisitorTests {
             description: ""
         )
         let visitor = ViewHostingBeforeInspectionVisitor(pattern: pattern)
+        visitor.knownObservableEnvironmentViews = observableEnvironmentViews
         visitor.walk(Parser.parse(source: source))
         return visitor
+    }
+
+    /// The shape the rule detects: hosting, then a sibling inspection.
+    private static let hostThenInspect = """
+    func testThing() throws {
+        let view = ContentView()
+        ViewHosting.host(view: view)
+        _ = try view.inspect().find(ViewType.Text.self)
+    }
+    """
+
+    /// The same shape, with the view built by a helper so its type name never appears in
+    /// the test function itself.
+    private static let hostThenInspectViaHelper = """
+    private func makeSubject() -> some View { ContentView() }
+
+    func testThing() throws {
+        let view = makeSubject()
+        ViewHosting.host(view: view)
+        _ = try view.inspect().find(ViewType.Text.self)
+    }
+    """
+
+    // MARK: - The trap precondition
+    //
+    // The ordering is only dangerous for a view reading `@Environment(SomeType.self)`, which
+    // has no default and traps out-of-tree. Reporting the ordering alone flags tests that
+    // pass and keep passing: measured against SwiftLintRuleStudio, all eight findings named
+    // views using the keypath form or no environment at all, and all five suites passed.
+
+    @Test("a view outside the catalog is not reported")
+    func viewWithoutObservableEnvironmentIsSilent() {
+        let visitor = run(Self.hostThenInspect, observableEnvironmentViews: ["OtherView"])
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    @Test("a view in the catalog is still reported")
+    func viewWithObservableEnvironmentIsFlagged() {
+        let visitor = run(Self.hostThenInspect, observableEnvironmentViews: ["ContentView"])
+        #expect(visitor.detectedIssues.count == 1)
+    }
+
+    @Test("an empty catalog means the project was scanned and has no such view")
+    func emptyCatalogIsSilent() {
+        let visitor = run(Self.hostThenInspect, observableEnvironmentViews: [])
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    @Test("no catalog at all keeps the previous behaviour")
+    func absentCatalogStillReports() {
+        // `nil` means nobody looked. Going quiet here would silence the rule on every
+        // single-file run, which is the opposite of what the gate is for.
+        let visitor = run(Self.hostThenInspect, observableEnvironmentViews: nil)
+        #expect(visitor.detectedIssues.count == 1)
+    }
+
+    @Test("the view can be named by a helper elsewhere in the file")
+    func catalogMatchIsFileScoped() {
+        let visitor = run(Self.hostThenInspectViaHelper, observableEnvironmentViews: ["ContentView"])
+        #expect(visitor.detectedIssues.count == 1)
     }
 
     // MARK: - Flagged


### PR DESCRIPTION
## What changed

`ViewHosting Before Inspection` now requires the test file to name a view that can actually trap — one reading `@Environment(SomeType.self)` — instead of firing on statement order alone.

A new project-wide pre-scan, `ObservableEnvironmentViewCollector`, catalogs those views and is plumbed through `CollectedTypes` alongside the other `known*` catalogs.

## Why

The rule's own rationale is narrower than its implementation. The trap it describes needs the `@Observable` environment form, which has no default, so out-of-tree body evaluation traps inside `EnvironmentValues.subscript.getter`. Every other view inspects out-of-tree perfectly well — that is ViewInspector's ordinary mode.

Pointed at **SwiftLintRuleStudio** the rule produced **8 errors — the only errors in a 26-repository sweep — against five test suites that pass.** None of the five views under test reads the observable form; the closest is `@Environment(\.dependencies)`, a keypath lookup that has a default. I ran all 18 tests in those suites: they pass, no trap, no crash indicators.

## What a reviewer should scrutinise

**The catalog is `Set<String>?`, not `Set<String>`, and that is load-bearing.** An **empty** catalog means the project was scanned and has no such view — a reason to stay silent. **`nil`** means no pre-scan ran, and the rule keeps its previous ungated behaviour. A non-optional set would make a single-file invocation indistinguishable from a clean project and silence the rule wherever it runs without the engine. The four states are covered by tests.

**Both call paths needed wiring, and that is worth knowing for the next catalog.** `configuredDetector` was not enough: the CLI reaches `analyzeFile` through `FileAnalysisEnvironment`, and the 8 findings survived the first fix until that second path forwarded the catalog too. I only caught it by re-running the CLI rather than trusting the unit tests.

**The match is per file, not per test function** — the view under test is often built by a helper elsewhere in the file, so its type name never appears in the test itself and a function-scoped match would miss exactly the cases that matter. The cost is real and now documented under Known Limitations: a file exercising both a trapping view and a safe one reports the safe test too. My end-to-end fixture shows precisely that.

## Verification

- Fixture carrying both shapes: `TrapView` (observable environment) is reported; the rule no longer fires on ordering alone.
- **SwiftLintRuleStudio: 8 → 0**, with the sibling rule still reporting `Observable Environment View Missing Inspection Hook` where the shape exists.
- All 18 tests in the five previously-flagged suites pass.
- `swift package clean && swift test`: **3368 tests in 409 suites pass** (5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUiBG9dnCecA2iYHPBAFNb