### PR TITLE
Take the purity oracle's file-read fix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -84,7 +84,7 @@ let package = Package(
         // swift-syntax exact 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "3ea25f29de9e0fbb86a6a8f20b2c42ead58a039e"
+            revision: "fff33cff0e5dca156fcaf9ee95ecc2dbd38877a5"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintIdempotencyRules/Package.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // root and SwiftProjectLintVisitors pins.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "3ea25f29de9e0fbb86a6a8f20b2c42ead58a039e"
+            revision: "fff33cff0e5dca156fcaf9ee95ecc2dbd38877a5"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintVisitors/Package.swift
+++ b/Packages/SwiftProjectLintVisitors/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "3ea25f29de9e0fbb86a6a8f20b2c42ead58a039e"
+            revision: "fff33cff0e5dca156fcaf9ee95ecc2dbd38877a5"
         )
     ],
     targets: [


### PR DESCRIPTION
## What changed

`SwiftEffectInference` pinned revision moves `3ea25f29` → `fff33cff`, in **three** manifests, plus the resolved file.

## Why

The new revision refutes purity for a file read whose `throws` was swallowed by `try?`. Before it, a non-throwing convenience wrapper around `resourceValues`, `String(contentsOf:)` or `Data(contentsOf:)` was judged pure, and this linter reported it as a property-test candidate.

## What a reviewer should scrutinise

**Three pins, and they must move together.** The root package plus `Packages/SwiftProjectLintVisitors` and `Packages/SwiftProjectLintIdempotencyRules`, which consume the oracle directly. SwiftPM refuses a graph requiring one dependency at two revisions:

```
error: swifteffectinference is required using two different revision-based
requirements (fff33cff… and 3ea25f29…), which is not supported
```

That is the useful failure — bumping only the root fails to resolve rather than silently keeping the old oracle in a nested package. Worth remembering for the next bump.

## Verification

- `swift package clean && swift test`: **3368 tests in 409 suites pass** — no rule's expectations changed, so the oracle is stricter without moving any existing finding.
- The probe holding the four `try?` shapes drops from **4 candidates to 1**, the survivor being the pure arithmetic control.
- `MacCloud_client_MacOS` drops from **2 pure-closure candidates to 1**: the `map` closure calling `resourceValues` is gone, and the remaining finding is a genuine one in the crypto path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUiBG9dnCecA2iYHPBAFNb