### PR TITLE
Stop asking for a conformance the compiler already synthesised

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/MissingEquatableOnStateTypeVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/MissingEquatableOnStateTypeVisitor.swift
@@ -46,6 +46,8 @@ final class MissingEquatableOnStateTypeVisitor: CrossFileVisitorBase, CrossFileP
     private var declaredConformances: [String: Set<String>] = [:]
     /// Base nominal names of value types observed in a state property wrapper.
     private var stateUsedTypes: Set<String> = []
+    /// Enums the compiler makes `Equatable` without a declaration.
+    private var synthesizedEquatableTypes: Set<String> = []
 
     // MARK: - Phase 1: collect
 
@@ -56,6 +58,13 @@ final class MissingEquatableOnStateTypeVisitor: CrossFileVisitorBase, CrossFileP
 
     override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
         recordValueType(node.name.text, node.inheritanceClause, Syntax(node))
+        // A payload-free enum is `Equatable` and `Hashable` without saying so, and telling the
+        // reader to add a conformance the compiler already synthesised is advice they cannot
+        // act on. `EquatableConformanceCollector` has always known this; the rule did not, so
+        // the gate and the nag disagreed about the same language guarantee.
+        if SynthesizedConformance.isImplicitlyEquatable(node) {
+            synthesizedEquatableTypes.insert(node.name.text)
+        }
         return .visitChildren
     }
 
@@ -108,6 +117,7 @@ final class MissingEquatableOnStateTypeVisitor: CrossFileVisitorBase, CrossFileP
     func finalizeAnalysis() {
         for name in stateUsedTypes.sorted() {
             guard let declaration = valueTypeDecls[name] else { continue } // external type → can't judge
+            guard !synthesizedEquatableTypes.contains(name) else { continue }
             let conformances = declaredConformances[name] ?? []
             guard conformances.isDisjoint(with: Self.equatableConformances) else { continue }
 

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/EquatableConformanceCollector.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/EquatableConformanceCollector.swift
@@ -46,25 +46,10 @@ public final class EquatableConformanceCollector: SyntaxVisitor, TypeCollectorPr
         //
         // This is a language guarantee, not a heuristic, so it cannot admit a
         // type that is not really `Equatable`.
-        if hasNoAssociatedValues(node) {
+        if SynthesizedConformance.isImplicitlyEquatable(node) {
             equatableTypes.insert(node.name.text)
         }
         return .visitChildren
-    }
-
-    /// Whether every case of `node` is payload-free.
-    ///
-    /// An enum with associated values is `Equatable` only when it *declares* it
-    /// (and only if every payload is itself `Equatable`), which the compiler
-    /// checks — so those stay gated on the declared conformance above.
-    private func hasNoAssociatedValues(_ node: EnumDeclSyntax) -> Bool {
-        for member in node.memberBlock.members {
-            guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else { continue }
-            for element in caseDecl.elements where element.parameterClause != nil {
-                return false
-            }
-        }
-        return true
     }
 
     override public func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/SynthesizedConformance.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/SynthesizedConformance.swift
@@ -1,0 +1,33 @@
+import SwiftSyntax
+
+/// What the compiler conforms a type to without being asked.
+///
+/// This exists so that the two places needing the answer give the same one. The candidate gate
+/// (`EquatableConformanceCollector`) already knew that a payload-free enum is `Equatable`
+/// whether or not it says so; `MissingEquatableOnStateTypeVisitor` did not, and told readers to
+/// add a conformance the language had already given them. A rule and a gate disagreeing about
+/// the same language guarantee is the kind of drift a shared helper is for.
+public enum SynthesizedConformance {
+
+    /// Whether `node` is `Equatable` and `Hashable` without declaring either.
+    ///
+    /// True for an enum whose every case is payload-free. The compiler synthesises both, and a
+    /// raw-value enum cannot carry associated values, so this covers `enum R: String` and bare
+    /// `enum C { case a, b }` alike.
+    ///
+    /// An enum *with* associated values is `Equatable` only when it declares it — and only if
+    /// every payload is itself `Equatable`, which the compiler checks — so those stay gated on
+    /// the declared conformance.
+    ///
+    /// This is a language guarantee rather than a heuristic, so it cannot admit a type that is
+    /// not really `Equatable`.
+    public static func isImplicitlyEquatable(_ node: EnumDeclSyntax) -> Bool {
+        for member in node.memberBlock.members {
+            guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else { continue }
+            for element in caseDecl.elements where element.parameterClause != nil {
+                return false
+            }
+        }
+        return true
+    }
+}

--- a/Tests/CoreTests/CrossFileAnalysis/MissingEquatableOnStateTypeVisitorTests.swift
+++ b/Tests/CoreTests/CrossFileAnalysis/MissingEquatableOnStateTypeVisitorTests.swift
@@ -111,11 +111,15 @@ struct MissingEquatableOnStateTypeVisitorTests {
 
     @Test
     func flagsPublishedAndEnumStateTypes() {
+        // The enum carries a payload. It used to be `case idle, loading`, which is payload-free
+        // and therefore `Equatable` by synthesis — so this test asserted a false positive and
+        // was the reason the bug had a test defending it. The `@Published` coverage it was
+        // written for is unchanged; only the premise is.
         let issues = analyze(files: [
             "Source.swift": """
             enum LoadState {
                 case idle
-                case loading
+                case failed(Error)
             }
             class ViewModel {
                 @Published var state: LoadState = .idle
@@ -196,4 +200,79 @@ struct MissingEquatableOnStateTypeVisitorTests {
         ])
         #expect(issues.count == 1)
     }
+
+    // MARK: - Conformances the compiler supplies
+
+    // A payload-free enum is `Equatable` and `Hashable` without saying so. Telling a reader to
+    // add a conformance the language already gave them is advice they cannot act on, and it was
+    // the commonest shape this rule fired on: five of six findings in SwiftLintRuleStudioTeam,
+    // every one of them a state enum.
+    //
+    // `EquatableConformanceCollector` has always known this — the candidate gate was correct
+    // while the nag was not, so the two disagreed about the same language guarantee.
+
+    @Test
+    func ignoresPayloadFreeEnumWithNoDeclaredConformance() {
+        let issues = analyze(files: [
+            "Source.swift": """
+            enum AppSection { case fleet, standards, compare }
+            struct RootView {
+                @State private var section: AppSection
+            }
+            """
+        ])
+        #expect(issues.isEmpty)
+    }
+
+    @Test
+    func ignoresRawValueEnumInState() {
+        // A raw-value enum cannot carry associated values, so the synthesis always applies.
+        let issues = analyze(files: [
+            "Source.swift": """
+            enum SortOrder: String, CaseIterable, Identifiable {
+                case health = "Health"
+                case name = "Name"
+                var id: String { rawValue }
+            }
+            struct FleetView {
+                @State private var order: SortOrder
+            }
+            """
+        ])
+        #expect(issues.isEmpty)
+    }
+
+    @Test
+    func flagsEnumWithAssociatedValues() {
+        // The control that keeps the fix honest. An enum WITH a payload is `Equatable` only when
+        // it declares it — the compiler checks every payload is itself `Equatable` — so this one
+        // must still be reported.
+        let issues = analyze(files: [
+            "Source.swift": """
+            enum LoadState { case idle, failed(Error) }
+            struct StatusView {
+                @State private var state: LoadState
+            }
+            """
+        ])
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("'LoadState'") == true)
+    }
+
+    @Test
+    func stillFlagsAStructInState() {
+        // The other control: a struct gets no free conformance, and this is the shape the rule
+        // exists for. In the repo that prompted the fix it was the single true positive.
+        let issues = analyze(files: [
+            "Source.swift": """
+            struct AnnotationTarget: Identifiable { let id: String }
+            struct DetailView {
+                @State private var target: AnnotationTarget
+            }
+            """
+        ])
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("'AnnotationTarget'") == true)
+    }
+
 }


### PR DESCRIPTION
## What changed

`Missing Equatable on State Type` no longer fires on a payload-free enum, which is `Equatable` and `Hashable` by synthesis. `SynthesizedConformance` is a new shared helper; `EquatableConformanceCollector` now uses it instead of its own private copy.

## The measurement

Across the eight repositories carrying findings for this rule:

| repo | before | after |
|---|---|---|
| SwiftLintRuleStudio | 9 | 2 |
| SwiftLintRuleStudioTeam | 6 | 1 |
| SwiftUMLStudio | 3 | 0 |
| SwiftFormatRuleStudio | 2 | 1 |
| SwiftProjectLint | 2 | 0 |
| SwiftMarkdownWiki | 1 | 0 |
| MacCloud_client_iOS | 1 | 1 |
| SwiftAssist | 1 | 1 |
| **total** | **25** | **6** |

**19 of 25 were false positives.** In SwiftLintRuleStudioTeam five of six were state enums; the survivor is a `struct`, which gets no free conformance and is the shape the rule exists for.

## What a reviewer should scrutinise

**The knowledge was already here, one module away.** `EquatableConformanceCollector` has always treated a payload-free enum as `Equatable`, with a comment explaining that recording only *declared* conformances silently refused pure functions returning such an enum as candidates. So the candidate gate was right and the nag was wrong — the two disagreed about the same language guarantee. That is why this is a shared helper rather than a second copy of the check.

**The candidate count did not move**, and that is the result worth knowing. Because the collector already knew, nothing was being blocked: these findings were noise, not a barrier. The natural assumption about a testability rule is that clearing it unlocks something, and here it does not.

**An existing test was defending the bug.** `flagsPublishedAndEnumStateTypes` used `enum LoadState { case idle, loading }` — payload-free, already `Equatable` — so it asserted the false positive. Its premise now carries an associated value, preserving what the test was written for (`@Published` recognition, and that an enum *can* be flagged) while making the case real.

**The control is the associated-value enum.** An enum with a payload is `Equatable` only when it declares it, and only if every payload is itself `Equatable`, which the compiler checks. `flagsEnumWithAssociatedValues` and `stillFlagsAStructInState` are what stop this fix from silencing the rule outright.

## Verification

`swift package clean && swift test`: **3372 tests in 409 suites pass** (4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUiBG9dnCecA2iYHPBAFNb