### PR TITLE
Stop judging a protocol this run cannot see the consumers of

### DIFF
--- a/Docs/rules/unused-protocol-abstraction.md
+++ b/Docs/rules/unused-protocol-abstraction.md
@@ -105,4 +105,13 @@ struct SettingDiff: BuildSettingIdentity { /* … */ }
 function taking `any BuildSettingIdentity` — to replace per-type duplication, or remove the
 protocol if no shared behavior is actually needed.
 
+### Known Limitations
+
+- **A `public`, `open` or `package` protocol is never reported.** Its consumers can be in
+  another module, package or repository, and this rule reads one project at a time — "conformed
+  to here, used nowhere here" is what a healthy abstraction looks like from inside the library
+  that publishes it. The rule keeps its value on `internal` protocols, whose consumers are all
+  inside the module by definition. In an app target nothing is lost either: a `public` protocol
+  there is over-exposed rather than unused, and `publicInAppTarget` is the rule that says so.
+
 ---

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/UnusedProtocolAbstractionVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/UnusedProtocolAbstractionVisitor.swift
@@ -26,6 +26,10 @@ final class UnusedProtocolAbstractionVisitor: CrossFileVisitorBase, CrossFilePat
         /// so conformers and uses are only credited from that same file. This avoids a
         /// same-named type in another file masking a genuinely dead file-scoped protocol.
         let isFileScoped: Bool
+        /// `public`, `open` and `package` protocols can be used by code this run cannot see.
+        /// The same visibility reasoning as `isFileScoped`, pointed the other way: there, the
+        /// consumers must be inside one file; here, they may be outside the project entirely.
+        let isAPI: Bool
     }
 
     private var declaredProtocols: [ProtocolDecl] = []
@@ -37,15 +41,13 @@ final class UnusedProtocolAbstractionVisitor: CrossFileVisitorBase, CrossFilePat
     // MARK: - Phase 1: collect
 
     override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
-        let isFileScoped = node.modifiers.contains { modifier in
-            let text = modifier.name.text
-            return text == "private" || text == "fileprivate"
-        }
+        let modifiers = Set(node.modifiers.map(\.name.text))
         declaredProtocols.append(ProtocolDecl(
             name: node.name.text,
             file: currentFilePath,
             line: getLineNumber(for: Syntax(node)),
-            isFileScoped: isFileScoped
+            isFileScoped: !modifiers.isDisjoint(with: ["private", "fileprivate"]),
+            isAPI: !modifiers.isDisjoint(with: ["public", "open", "package"])
         ))
         return .visitChildren
     }
@@ -91,6 +93,16 @@ final class UnusedProtocolAbstractionVisitor: CrossFileVisitorBase, CrossFilePat
                 ? referencingFiles.contains(proto.file)
                 : referencingFiles.isEmpty == false
 
+            // A protocol that is API cannot be judged from this project's sources. Its
+            // consumers may be in another package or another repository, and "conformed to
+            // here, used nowhere here" is what a well-behaved abstraction looks like from
+            // inside the library that publishes it. Reported against LintStudioUI's
+            // `GitServiceProtocol`, which SwiftLintRuleStudio takes in two places.
+            //
+            // Nothing is lost in an app target, where a `public` protocol has no outside
+            // consumer to speak of: `publicInAppTarget` is the rule that says so, and it says
+            // it better, because over-exposure rather than disuse is the actual problem there.
+            guard !proto.isAPI else { continue }
             guard conformers >= 1, isUsed == false else { continue }
             let suffix = conformers == 1 ? "type" : "types"
             addIssue(

--- a/Tests/CoreTests/CrossFileAnalysis/UnusedProtocolAbstractionVisitorTests.swift
+++ b/Tests/CoreTests/CrossFileAnalysis/UnusedProtocolAbstractionVisitorTests.swift
@@ -148,4 +148,97 @@ struct UnusedProtocolAbstractionVisitorTests {
 
         #expect(issues.isEmpty)
     }
+
+    // MARK: - API is out of scope
+
+    // A protocol declared `public`, `open` or `package` can be used by code this run cannot
+    // see. "Conformed to here, used nowhere here" is what a well-behaved abstraction looks
+    // like from inside the library that publishes it, so the rule has no evidence either way.
+    //
+    // This was reported against LintStudioUI's `GitServiceProtocol`, which SwiftLintRuleStudio
+    // takes in two places — `DependencyContainer.gitService` and `GitBranchDiffService`.
+
+    @Test
+    func publicProtocolIsNotFlagged() {
+        let issues = analyze(files: [
+            "Service.swift": """
+            public protocol GitServiceProtocol: Sendable {
+                func currentBranch() async throws -> String
+            }
+            public actor GitServiceActor: GitServiceProtocol {
+                public func currentBranch() async throws -> String { "main" }
+            }
+            """
+        ])
+        #expect(issues.isEmpty)
+    }
+
+    @Test
+    func openProtocolIsNotFlagged() {
+        let issues = analyze(files: [
+            "Service.swift": """
+            open protocol Openable {
+                func open()
+            }
+            struct Door: Openable {
+                func open() {}
+            }
+            """
+        ])
+        #expect(issues.isEmpty)
+    }
+
+    @Test
+    func packageProtocolIsNotFlagged() {
+        // `package` reaches other modules in the same package, which a single-target run of
+        // this rule need not be able to see either.
+        let issues = analyze(files: [
+            "Service.swift": """
+            package protocol Shareable {
+                func share()
+            }
+            struct Note: Shareable {
+                func share() {}
+            }
+            """
+        ])
+        #expect(issues.isEmpty)
+    }
+
+    @Test
+    func internalProtocolIsStillFlagged() {
+        // The control, and most of the rule's value. An `internal` protocol's consumers are
+        // all inside the module, so the absence of a use here is evidence rather than a gap.
+        let issues = analyze(files: [
+            "Service.swift": """
+            protocol Formatting {
+                func format() -> String
+            }
+            struct Plain: Formatting {
+                func format() -> String { "plain" }
+            }
+            """
+        ])
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("'Formatting'") == true)
+    }
+
+    @Test
+    func publicProtocolUsedAsATypeIsStillNotFlagged() {
+        // Belt and braces: a used API protocol was never flagged and still is not, so this
+        // change cannot be masking a regression in the "is it used" logic itself.
+        let issues = analyze(files: [
+            "Service.swift": """
+            public protocol Formatting {
+                func format() -> String
+            }
+            struct Plain: Formatting {
+                func format() -> String { "plain" }
+            }
+            func render(_ formatter: any Formatting) -> String { formatter.format() }
+            """
+        ])
+        #expect(issues.isEmpty)
+    }
+
 }


### PR DESCRIPTION
## What changed

`Unused Protocol Abstraction` no longer reports a protocol declared `public`, `open` or `package`.

## Why

For an `internal` protocol, "conformed to but never used as a type" is evidence — every consumer is inside the module by definition, so their absence means something. For API it is not evidence at all: the consumers can be in another module, package or repository, and this rule reads one project at a time.

Reported against **LintStudioUI's `GitServiceProtocol`**, which `SwiftLintRuleStudio` takes in two places — `DependencyContainer.gitService` and `GitBranchDiffService`. Nothing in LintStudioUI's own sources could have shown that.

## What a reviewer should scrutinise

**There was already a partial mitigation, and why it missed matters.** `resolveConfiguration` disables this rule for a library whose *nested packages* are excluded from the run. That covers a consumer in a sibling package in the same repo. It cannot cover a consumer in a **different repo**, which is the ordinary case for a published library — and LintStudioUI has no nested packages, so it never engaged.

**The visitor already reasoned about visibility, in the other direction.** `isFileScoped` credits a `private` protocol's conformers only from its own file, because that is as far as it can be seen. `isAPI` is that same reasoning pointed outward, which is why it sits beside it rather than being a special case bolted on.

**Nothing is lost in an app target.** A `public` protocol there has no outside consumer to speak of — but the problem is over-exposure, not disuse, and `publicInAppTarget` already says so and says it better.

**The `internal` control is the point.** `internalProtocolIsStillFlagged` is what stops this from silencing the rule outright, and `publicProtocolUsedAsATypeIsStillNotFlagged` guards against the change masking a regression in the is-it-used logic itself.

## Measurement

Across the repositories carrying findings: **3 → 1**. The survivor is SwiftMarkdownWiki's, an `internal` protocol — the control arriving on its own, in the wild.

## Verification

`swift package clean && swift test`: **3377 tests in 409 suites pass** (5 new). Known Limitations documented in `Docs/rules/unused-protocol-abstraction.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUiBG9dnCecA2iYHPBAFNb