### PR TITLE
Stop asking for a protocol around a closure

### DIFF
--- a/Docs/rules/concrete-type-usage.md
+++ b/Docs/rules/concrete-type-usage.md
@@ -77,4 +77,19 @@ class MyViewModel {
 }
 ```
 
+### Known Limitations
+
+- **A `typealias` for a function type is never reported.** `typealias CommandRunner = @Sendable
+  ([String]) async throws -> Data` names a closure, and a property typed with it is already
+  injected — a test substitutes another closure. Asking for a protocol around it would replace a
+  working seam with a heavier one.
+- **…but only when the alias is declared in the analyzed sources.** The exemption comes from a
+  project-wide prescan, so a property typed with an alias published by *another* package is still
+  reported: the declaration that would exempt it is out of scope. Measured — `CLIToolCommandRunner`
+  is exempt inside LintStudioUI, which declares it, and still flagged in SwiftLintRuleStudio, which
+  imports it. Same boundary as `unused-protocol-abstraction`'s, for the same reason.
+- **A value type used as a seam still reads as concrete.** A `struct DateProvider` wrapping a
+  closure is an injection point, but the rule sees a concrete nominal type and asks for a protocol.
+  That is advice worth refusing rather than a defect the rule can detect.
+
 ---

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
@@ -149,6 +149,7 @@ extension ProjectLinter {
         let identifiableTypes: Set<String>
         /// `View` names reading `@Environment(SomeType.self)`; `nil` when no pre-scan ran.
         let observableEnvironmentViews: Set<String>?
+        let functionTypeAliases: Set<String>
         let enumTypes: Set<String>
         let actorTypes: Set<String>
         let localTypes: Set<String>
@@ -182,6 +183,7 @@ extension ProjectLinter {
             ruleIdentifiers: env.ruleIdentifiers,
             identifiableTypes: env.identifiableTypes,
             observableEnvironmentViews: env.observableEnvironmentViews,
+            functionTypeAliases: env.functionTypeAliases,
             enumTypes: env.enumTypes,
             actorTypes: env.actorTypes,
             localTypes: env.localTypes,
@@ -205,6 +207,7 @@ extension ProjectLinter {
         ruleIdentifiers: [RuleIdentifier]?,
         identifiableTypes: Set<String> = [],
         observableEnvironmentViews: Set<String>? = nil,
+        functionTypeAliases: Set<String> = [],
         enumTypes: Set<String> = [],
         actorTypes: Set<String> = [],
         localTypes: Set<String> = [],
@@ -231,6 +234,7 @@ extension ProjectLinter {
         let det = SourcePatternDetector(registry: registry)
         det.knownIdentifiableTypes = identifiableTypes
         det.knownObservableEnvironmentViews = observableEnvironmentViews
+        det.knownFunctionTypeAliases = functionTypeAliases
         det.knownEnumTypes = enumTypes
         det.knownActorTypes = actorTypes
         det.knownLocalTypeNames = localTypes

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
@@ -234,6 +234,8 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         /// `View` names reading `@Environment(SomeType.self)`. See
         /// `ObservableEnvironmentViewCollector` for why the keypath form is excluded.
         let observableEnvironmentViews: Set<String>
+        /// `typealias` names whose underlying type is a function type.
+        let functionTypeAliases: Set<String>
         /// Per type, the sibling methods that are themselves functions of their inputs. Unlike the
         /// name sets above this needs the parsed bodies, not just declarations, so it is resolved
         /// by its own fixpoint rather than by `collectTypes`.
@@ -273,6 +275,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
                 observableEnvironmentViews: collectTypes(
                     ObservableEnvironmentViewCollector.self, from: filePaths
                 ),
+                functionTypeAliases: collectTypes(FunctionTypeAliasCollector.self, from: filePaths),
                 cleanInstanceMethods: CleanInstanceMethodCatalog.build(from: parsed),
                 impurePackageFunctions: PackagePurityJoin(sources: parsed).settledImpureNames
             )
@@ -292,6 +295,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         resolved.knownLocalTypeNames = collected.local
         resolved.knownObservableTypes = collected.observable
         resolved.knownObservableEnvironmentViews = collected.observableEnvironmentViews
+        resolved.knownFunctionTypeAliases = collected.functionTypeAliases
         resolved.knownProtocolTypes = collected.protocols
         resolved.knownEquatableTypes = collected.equatable
         resolved.knownValueTypes = collected.values
@@ -320,6 +324,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
             ruleIdentifiers: ruleIdentifiers,
             identifiableTypes: collected.identifiable,
             observableEnvironmentViews: collected.observableEnvironmentViews,
+            functionTypeAliases: collected.functionTypeAliases,
             enumTypes: collected.enums,
             actorTypes: collected.actors,
             localTypes: collected.local,

--- a/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetector.swift
+++ b/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetector.swift
@@ -33,6 +33,9 @@ public final class SourcePatternDetector: SourcePatternDetectorProtocol, @unchec
     /// `View` names reading `@Environment(SomeType.self)`; `nil` when no pre-scan ran.
     public var knownObservableEnvironmentViews: Set<String>?
 
+    /// `typealias` names whose underlying type is a function type.
+    public var knownFunctionTypeAliases: Set<String> = []
+
     public var knownProtocolTypes: Set<String> = []
 
     /// Type names known to be `Equatable` across the project. Set by
@@ -193,6 +196,7 @@ public final class SourcePatternDetector: SourcePatternDetectorProtocol, @unchec
             let visitor = entry.type.init(pattern: entry.patterns[0])
             visitor.setSourceLocationConverter(converter)
             visitor.knownObservableEnvironmentViews = knownObservableEnvironmentViews
+            visitor.knownFunctionTypeAliases = knownFunctionTypeAliases
             visitor.knownIdentifiableTypes = knownIdentifiableTypes
             visitor.knownEnumTypes = knownEnumTypes
             visitor.knownActorTypes = knownActorTypes

--- a/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetectorProtocol.swift
+++ b/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetectorProtocol.swift
@@ -36,6 +36,8 @@ public protocol SourcePatternDetectorProtocol {
     /// `View` names reading `@Environment(SomeType.self)`; `nil` when no pre-scan ran.
     var knownObservableEnvironmentViews: Set<String>? { get set }
 
+    var knownFunctionTypeAliases: Set<String> { get set }
+
     var knownProtocolTypes: Set<String> { get set }
 
     /// Type names known to be `Equatable` across the project (Equatable /

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ConcreteTypeUsageVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ConcreteTypeUsageVisitor.swift
@@ -118,6 +118,13 @@ class ConcreteTypeUsageVisitor: BasePatternVisitor {
               !name.hasSuffix("Interface")
         else { return nil }
 
+        // A `typealias` for a function type is already the seam. `CLIToolCommandRunner =
+        // @Sendable ([String], Data?) async throws -> (Data, Data, Int32)` is a closure: a
+        // property typed with it is injected by handing in another closure, which is what a
+        // test does. Asking for a protocol around it replaces a working seam with a heavier
+        // one. Requires the project-wide typealias prescan.
+        if knownFunctionTypeAliases.contains(name) { return nil }
+
         // System types that are concrete by design
         if Self.systemConcreteTypes.contains(name) { return nil }
 

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/BasePatternVisitor.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/BasePatternVisitor.swift
@@ -107,6 +107,10 @@ open class BasePatternVisitor: SyntaxVisitor, PatternVisitorProtocol {
     /// quiet in exactly the single-file case where it has no way to know better.
     public var knownObservableEnvironmentViews: Set<String>?
 
+    /// `typealias` names whose underlying type is a function type. A property typed with one
+    /// is already injected — the closure is the seam.
+    public var knownFunctionTypeAliases: Set<String> = []
+
     public var knownProjectFunctions: Set<String> = []
 
     /// Types whose initialiser has DEFAULTED parameters — built by `DefaultedInitializerCollector`.

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FunctionTypeAliasCollector.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FunctionTypeAliasCollector.swift
@@ -1,0 +1,45 @@
+import SwiftSyntax
+
+/// Collects the names of `typealias` declarations whose underlying type is a *function* type —
+/// `typealias CommandRunner = @Sendable ([String]) async throws -> Data`.
+///
+/// Used as a project-wide pre-scan so `ConcreteTypeUsageVisitor` can tell a service class from
+/// a closure. A property typed with one of these is already injected: a function value is the
+/// seam, handed in at the call site and substituted in a test by writing another closure.
+/// Asking for "a protocol abstraction" around it replaces a working seam with a heavier one
+/// and buys nothing.
+///
+/// Only the alias is recorded, not the signature. Whether the closure is `@Sendable`, `async`
+/// or throwing makes no difference to the question being asked.
+public final class FunctionTypeAliasCollector: SyntaxVisitor, TypeCollectorProtocol {
+    public var collectedTypes: Set<String> { aliasNames }
+
+    private(set) var aliasNames: Set<String> = []
+
+    public init() {
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override public func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
+        if Self.resolvesToFunctionType(node.initializer.value) {
+            aliasNames.insert(node.name.text)
+        }
+        return .visitChildren
+    }
+
+    /// Whether `type` is a function type, seeing through the wrappers an alias commonly uses.
+    ///
+    /// `@Sendable (Int) -> Void` arrives as an `AttributedTypeSyntax`, and a parenthesised
+    /// signature — the form an optional alias needs — as a `TupleTypeSyntax` of one element.
+    private static func resolvesToFunctionType(_ type: TypeSyntax) -> Bool {
+        if type.is(FunctionTypeSyntax.self) { return true }
+        if let attributed = type.as(AttributedTypeSyntax.self) {
+            return resolvesToFunctionType(attributed.baseType)
+        }
+        if let tuple = type.as(TupleTypeSyntax.self), tuple.elements.count == 1,
+           let only = tuple.elements.first {
+            return resolvesToFunctionType(only.type)
+        }
+        return false
+    }
+}

--- a/Tests/CoreTests/Architecture/ArchitectureConcreteTypeUsageTests.swift
+++ b/Tests/CoreTests/Architecture/ArchitectureConcreteTypeUsageTests.swift
@@ -19,11 +19,13 @@ private func analyzeSource(
     _ source: String,
     observableTypes: Set<String> = [],
     protocolTypes: Set<String> = [],
+    functionTypeAliases: Set<String> = [],
     filePath: String = "SourceFile.swift"
 ) -> [LintIssue] {
     let visitor = ConcreteTypeUsageVisitor(patternCategory: .architecture)
     visitor.knownObservableTypes = observableTypes
     visitor.knownProtocolTypes = protocolTypes
+    visitor.knownFunctionTypeAliases = functionTypeAliases
     let syntax = Parser.parse(source: source)
     let converter = SourceLocationConverter(fileName: filePath, tree: syntax)
     visitor.setSourceLocationConverter(converter)
@@ -407,4 +409,44 @@ struct ArchitectureConcreteTypeUsageTests {
         let issue = try #require(issues.first)
         #expect(issue.message.contains("ResourceMetricsProvider"))
     }
+
+    // MARK: - A closure typealias is already the seam
+
+    // `CLIToolCommandRunner = @Sendable ([String], Data?) async throws -> (Data, Data, Int32)`
+    // is a function type. A property typed with it is injected by handing in another closure,
+    // which is exactly what a test does — asking for "a protocol abstraction" around it swaps a
+    // working seam for a heavier one. Reported against LintStudioUI's `CLIToolActor`.
+
+    @Test
+    func closureTypeAliasPropertyIsNotFlagged() {
+        let issues = analyzeSource("""
+        final class CLIToolActor {
+            private let commandRunner: CLIToolCommandRunner?
+        }
+        """, functionTypeAliases: ["CLIToolCommandRunner"])
+        #expect(issues.isEmpty)
+    }
+
+    @Test
+    func closureTypeAliasParameterIsNotFlagged() {
+        let issues = analyzeSource("""
+        final class CLIToolActor {
+            init(commandRunner: CLIToolCommandRunner? = nil) {}
+        }
+        """, functionTypeAliases: ["CLIToolCommandRunner"])
+        #expect(issues.isEmpty)
+    }
+
+    @Test
+    func aRealServiceTypeIsStillFlagged() {
+        // The control. Without it this change could silence the rule entirely and the suite
+        // would not notice — the catalog is empty in most tests.
+        let issues = analyzeSource("""
+        final class Client {
+            private let networkService: NetworkService?
+        }
+        """, functionTypeAliases: ["CLIToolCommandRunner"])
+        #expect(issues.isEmpty == false)
+    }
+
 }


### PR DESCRIPTION
## What changed

`Concrete Type Usage` no longer reports a property or parameter typed with a `typealias` for a **function type**. New `FunctionTypeAliasCollector`, plumbed through `CollectedTypes` beside the enum and actor catalogs the same check already consults.

## Why

It flagged `commandRunner: CLIToolCommandRunner?` and asked for a protocol abstraction. `CLIToolCommandRunner` is:

```swift
typealias CLIToolCommandRunner = @Sendable (_ arguments: [String], _ stdin: Data?) async throws -> (Data, Data, Int32)
```

A closure — already the seam. A test substitutes it by writing another closure, which is precisely what a protocol would be introduced to allow.

The guard sits beside `knownEnumTypes` and `knownActorTypes` in `qualifying`, which are the two existing cases of "this is concrete for a reason".

## What a reviewer should scrutinise

**The collector sees through wrappers**, because an alias rarely names a bare function type: `@Sendable (Int) -> Void` arrives as an `AttributedTypeSyntax`, and a parenthesised signature — the form an optional alias needs — as a single-element `TupleTypeSyntax`.

**Measured: 30 → 25** across the repositories with findings. Two numbers in that comparison are *not* the rule, and both are documented:

- **SwiftLintRuleStudio rises by three, and all three are mine from earlier today** — `now: DateProvider` twice and `makeID: IDProvider`, the seams added when that repo's clock was made injectable. A `struct` serving as a seam still reads as concrete here. That is advice worth refusing rather than a defect the rule can detect, and it is now under Known Limitations.
- **`bridgedRunner: CLIToolCommandRunner` in SwiftLintRuleStudio is still flagged.** The alias is declared in LintStudioUI, so a prescan of *this* project cannot see it — the same one-project-at-a-time boundary that made `unused-protocol-abstraction` misfire on published API. Also documented rather than left to be rediscovered.

**The control is `aRealServiceTypeIsStillFlagged`.** The catalog is empty in almost every other test in that suite, so without a test that passes a non-empty catalog *and* still expects a finding, this change could silence the rule and the suite would not notice.

## Verification

`swift package clean && swift test`: **3380 tests in 409 suites pass** (3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUiBG9dnCecA2iYHPBAFNb