### PR TITLE
Stop reporting an SPI the author declared as one

### DIFF
--- a/Docs/rules/accessing-implementation-details.md
+++ b/Docs/rules/accessing-implementation-details.md
@@ -50,4 +50,15 @@ func hack(n: Networking) {
 }
 ```
 
+### Known Limitations
+
+- **A member published under `@_spi(...)` is never reported.** The attribute is Swift's own way
+  of saying "public symbol, deliberately not public API", and the underscore is the naming
+  convention that accompanies it. Reporting it tells the author something they already said.
+  This needs the project-wide SPI prescan, so a single-file run will still report such an access.
+- **A member the enclosing type declares itself is never reported.** `other._value` inside that
+  type's own initializer is how an `Equatable`-style comparison is written. The scope is the
+  enclosing type, not the file: two types in one file are still separate encapsulations, and one
+  reaching into the other's underscored member is the violation this rule exists for.
+
 ---

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
@@ -150,6 +150,7 @@ extension ProjectLinter {
         /// `View` names reading `@Environment(SomeType.self)`; `nil` when no pre-scan ran.
         let observableEnvironmentViews: Set<String>?
         let functionTypeAliases: Set<String>
+        let spiMembers: Set<String>
         let enumTypes: Set<String>
         let actorTypes: Set<String>
         let localTypes: Set<String>
@@ -184,6 +185,7 @@ extension ProjectLinter {
             identifiableTypes: env.identifiableTypes,
             observableEnvironmentViews: env.observableEnvironmentViews,
             functionTypeAliases: env.functionTypeAliases,
+            spiMembers: env.spiMembers,
             enumTypes: env.enumTypes,
             actorTypes: env.actorTypes,
             localTypes: env.localTypes,
@@ -208,6 +210,7 @@ extension ProjectLinter {
         identifiableTypes: Set<String> = [],
         observableEnvironmentViews: Set<String>? = nil,
         functionTypeAliases: Set<String> = [],
+        spiMembers: Set<String> = [],
         enumTypes: Set<String> = [],
         actorTypes: Set<String> = [],
         localTypes: Set<String> = [],
@@ -235,6 +238,7 @@ extension ProjectLinter {
         det.knownIdentifiableTypes = identifiableTypes
         det.knownObservableEnvironmentViews = observableEnvironmentViews
         det.knownFunctionTypeAliases = functionTypeAliases
+        det.knownSPIMembers = spiMembers
         det.knownEnumTypes = enumTypes
         det.knownActorTypes = actorTypes
         det.knownLocalTypeNames = localTypes

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
@@ -236,6 +236,8 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         let observableEnvironmentViews: Set<String>
         /// `typealias` names whose underlying type is a function type.
         let functionTypeAliases: Set<String>
+        /// Member names declared under `@_spi(...)`.
+        let spiMembers: Set<String>
         /// Per type, the sibling methods that are themselves functions of their inputs. Unlike the
         /// name sets above this needs the parsed bodies, not just declarations, so it is resolved
         /// by its own fixpoint rather than by `collectTypes`.
@@ -276,6 +278,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
                     ObservableEnvironmentViewCollector.self, from: filePaths
                 ),
                 functionTypeAliases: collectTypes(FunctionTypeAliasCollector.self, from: filePaths),
+                spiMembers: collectTypes(SPIMemberCollector.self, from: filePaths),
                 cleanInstanceMethods: CleanInstanceMethodCatalog.build(from: parsed),
                 impurePackageFunctions: PackagePurityJoin(sources: parsed).settledImpureNames
             )
@@ -295,6 +298,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         resolved.knownLocalTypeNames = collected.local
         resolved.knownObservableTypes = collected.observable
         resolved.knownObservableEnvironmentViews = collected.observableEnvironmentViews
+        resolved.knownSPIMembers = collected.spiMembers
         resolved.knownFunctionTypeAliases = collected.functionTypeAliases
         resolved.knownProtocolTypes = collected.protocols
         resolved.knownEquatableTypes = collected.equatable
@@ -325,6 +329,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
             identifiableTypes: collected.identifiable,
             observableEnvironmentViews: collected.observableEnvironmentViews,
             functionTypeAliases: collected.functionTypeAliases,
+            spiMembers: collected.spiMembers,
             enumTypes: collected.enums,
             actorTypes: collected.actors,
             localTypes: collected.local,

--- a/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetector.swift
+++ b/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetector.swift
@@ -34,6 +34,9 @@ public final class SourcePatternDetector: SourcePatternDetectorProtocol, @unchec
     public var knownObservableEnvironmentViews: Set<String>?
 
     /// `typealias` names whose underlying type is a function type.
+    /// Member names declared under `@_spi(...)`.
+    public var knownSPIMembers: Set<String> = []
+
     public var knownFunctionTypeAliases: Set<String> = []
 
     public var knownProtocolTypes: Set<String> = []
@@ -196,6 +199,7 @@ public final class SourcePatternDetector: SourcePatternDetectorProtocol, @unchec
             let visitor = entry.type.init(pattern: entry.patterns[0])
             visitor.setSourceLocationConverter(converter)
             visitor.knownObservableEnvironmentViews = knownObservableEnvironmentViews
+            visitor.knownSPIMembers = knownSPIMembers
             visitor.knownFunctionTypeAliases = knownFunctionTypeAliases
             visitor.knownIdentifiableTypes = knownIdentifiableTypes
             visitor.knownEnumTypes = knownEnumTypes

--- a/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetectorProtocol.swift
+++ b/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetectorProtocol.swift
@@ -36,6 +36,8 @@ public protocol SourcePatternDetectorProtocol {
     /// `View` names reading `@Environment(SomeType.self)`; `nil` when no pre-scan ran.
     var knownObservableEnvironmentViews: Set<String>? { get set }
 
+    var knownSPIMembers: Set<String> { get set }
+
     var knownFunctionTypeAliases: Set<String> { get set }
 
     var knownProtocolTypes: Set<String> { get set }

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/AccessingImplementationDetailsVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/AccessingImplementationDetailsVisitor.swift
@@ -18,6 +18,53 @@ class AccessingImplementationDetailsVisitor: BasePatternVisitor {
         self.currentFilePath = filePath
     }
 
+    // MARK: - Same-type declaration
+
+    /// Whether the type enclosing `node` declares `name` as one of its own members.
+    ///
+    /// Scope is the enclosing type, deliberately, and not the file. A first attempt used the
+    /// file and was wrong in a way the existing suite caught immediately: two classes in one
+    /// file, one reaching into the other's `_data`, is exactly the violation this rule is for.
+    /// Swift's `private` being file-scoped makes that access *legal*, which is not the same as
+    /// it being encapsulated.
+    private func enclosingTypeDeclares(_ name: String, from node: some SyntaxProtocol) -> Bool {
+        var current = node.parent
+        while let candidate = current {
+            if let members = Self.memberBlock(of: candidate) {
+                return Self.declaredNames(in: members).contains(name)
+            }
+            current = candidate.parent
+        }
+        return false
+    }
+
+    private static func memberBlock(of node: Syntax) -> MemberBlockSyntax? {
+        if let decl = node.as(StructDeclSyntax.self) { return decl.memberBlock }
+        if let decl = node.as(ClassDeclSyntax.self) { return decl.memberBlock }
+        if let decl = node.as(ActorDeclSyntax.self) { return decl.memberBlock }
+        if let decl = node.as(EnumDeclSyntax.self) { return decl.memberBlock }
+        if let decl = node.as(ExtensionDeclSyntax.self) { return decl.memberBlock }
+        return nil
+    }
+
+    /// The member names a type declares directly — properties and functions.
+    private static func declaredNames(in members: MemberBlockSyntax) -> Set<String> {
+        var names: Set<String> = []
+        for member in members.members {
+            if let function = member.decl.as(FunctionDeclSyntax.self) {
+                names.insert(function.name.text)
+            }
+            if let variable = member.decl.as(VariableDeclSyntax.self) {
+                for binding in variable.bindings {
+                    if let identifier = binding.pattern.as(IdentifierPatternSyntax.self) {
+                        names.insert(identifier.identifier.text)
+                    }
+                }
+            }
+        }
+        return names
+    }
+
     // MARK: - MemberAccessExprSyntax
 
     override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
@@ -46,6 +93,21 @@ class AccessingImplementationDetailsVisitor: BasePatternVisitor {
             // working as intended, and library code does it routinely.
             if let baseReference = base.as(DeclReferenceExprSyntax.self),
                baseReference.baseName.text.hasPrefix("_") {
+                return .visitChildren
+            }
+            // Skip a member the project publishes under `@_spi(...)`. That attribute is
+            // Swift's own way of saying "public symbol, deliberately not public API", and the
+            // underscore is the naming convention that accompanies it rather than an accident.
+            // Reporting it tells the author something they already said, in the language's own
+            // vocabulary. Requires the project-wide SPI prescan.
+            if knownSPIMembers.contains(memberName) {
+                return .visitChildren
+            }
+            // Skip a member the *enclosing type itself* declares. The shape is
+            // `other._value` inside that type's own initializer, which is how an
+            // `Equatable`-style comparison against another instance is written — a type
+            // reaching into its own kind, not a caller reaching past an interface.
+            if enclosingTypeDeclares(memberName, from: node) {
                 return .visitChildren
             }
             let baseDesc = base.as(DeclReferenceExprSyntax.self)?.baseName.text ?? "object"

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/BasePatternVisitor.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/BasePatternVisitor.swift
@@ -109,6 +109,9 @@ open class BasePatternVisitor: SyntaxVisitor, PatternVisitorProtocol {
 
     /// `typealias` names whose underlying type is a function type. A property typed with one
     /// is already injected — the closure is the seam.
+    /// Member names declared under `@_spi(...)` — published deliberately, not leaked.
+    public var knownSPIMembers: Set<String> = []
+
     public var knownFunctionTypeAliases: Set<String> = []
 
     public var knownProjectFunctions: Set<String> = []

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/SPIMemberCollector.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/SPIMemberCollector.swift
@@ -1,0 +1,63 @@
+import SwiftSyntax
+
+/// Collects the names of members declared under `@_spi(...)`.
+///
+/// `@_spi` is Swift's own mechanism for "public symbol, deliberately not public API": the
+/// declaration is visible to a client that opts in with a matching `@_spi` import and invisible
+/// to everyone else. A package that publishes one is entitled to use it.
+///
+/// Used as a project-wide pre-scan so `AccessingImplementationDetailsVisitor` can tell a leaked
+/// internal from a declared one. That rule reads an underscore prefix as "implementation
+/// detail", which is the right heuristic — but where the author has *also* written the
+/// attribute, the underscore is the convention that accompanies the attribute rather than a
+/// naming accident, and reporting it tells the author something they already said.
+///
+/// The attribute is honoured on the declaration itself or on an enclosing `extension`, which is
+/// where it is usually written when a whole group of members is being published as SPI.
+public final class SPIMemberCollector: SyntaxVisitor, TypeCollectorProtocol {
+    public var collectedTypes: Set<String> { memberNames }
+
+    private(set) var memberNames: Set<String> = []
+
+    public init() {
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override public func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+        if Self.isSPI(node.attributes) || Self.isInsideSPIExtension(node) {
+            memberNames.insert(node.name.text)
+        }
+        return .visitChildren
+    }
+
+    override public func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard Self.isSPI(node.attributes) || Self.isInsideSPIExtension(node) else {
+            return .visitChildren
+        }
+        for binding in node.bindings {
+            if let identifier = binding.pattern.as(IdentifierPatternSyntax.self) {
+                memberNames.insert(identifier.identifier.text)
+            }
+        }
+        return .visitChildren
+    }
+
+    private static func isSPI(_ attributes: AttributeListSyntax) -> Bool {
+        attributes.contains { element in
+            guard let attribute = element.as(AttributeSyntax.self) else { return false }
+            return attribute.attributeName.trimmedDescription == "_spi"
+        }
+    }
+
+    /// Whether the declaration sits inside an `extension` carrying the attribute.
+    private static func isInsideSPIExtension(_ node: some SyntaxProtocol) -> Bool {
+        var current = node.parent
+        while let candidate = current {
+            if let extensionDecl = candidate.as(ExtensionDeclSyntax.self) {
+                return isSPI(extensionDecl.attributes)
+            }
+            current = candidate.parent
+        }
+        return false
+    }
+}

--- a/Tests/CoreTests/ImplementationDetailNamingTests.swift
+++ b/Tests/CoreTests/ImplementationDetailNamingTests.swift
@@ -57,8 +57,9 @@ struct ImplementationDetailNamingTests {
 
     // MARK: - Accessing implementation details
 
-    private func implDetailIssues(_ source: String) -> [LintIssue] {
+    private func implDetailIssues(_ source: String, spiMembers: Set<String> = []) -> [LintIssue] {
         let visitor = AccessingImplementationDetailsVisitor(patternCategory: .architecture)
+        visitor.knownSPIMembers = spiMembers
         let syntax = Parser.parse(source: source)
         visitor.setSourceLocationConverter(
             SourceLocationConverter(fileName: "TestFile.swift", tree: syntax)
@@ -167,4 +168,61 @@ struct ImplementationDetailNamingTests {
 
         #expect(issues.contains { $0.message.contains("TabView") })
     }
+
+    // MARK: - SPI and same-file declarations
+
+    // Two shapes an underscored access takes in a library that is not a leak. Both were
+    // reported against SwiftIdempotency, whose whole snapshot mechanism is published SPI.
+
+    @Test("a member published under @_spi is not an implementation-detail access")
+    func spiMemberIsExempt() {
+        // `@_spi` is Swift's own way of saying "public symbol, deliberately not public API".
+        // The underscore is the convention accompanying the attribute, not an accident.
+        let issues = implDetailIssues("""
+        func compare(_ recorders: [any Recorder]) {
+            let boxes = recorders.map { $0._snapshotBox() }
+            _ = boxes
+        }
+        """, spiMembers: ["_snapshotBox"])
+        #expect(issues.isEmpty)
+    }
+
+    @Test("an underscored member declared in this file is not an implementation-detail access")
+    func sameFileMemberIsExempt() {
+        // `private` is file-scoped in Swift, so this is legal and idiomatic — it is how an
+        // Equatable-style comparison against another instance of the same type is written.
+        let issues = implDetailIssues("""
+        struct Box {
+            private let _value: Any
+            init<T: Equatable>(_ value: T) {
+                self._value = value
+                self.equals = { other in (other._value as? T) == value }
+            }
+        }
+        """)
+        #expect(issues.isEmpty)
+    }
+
+    @Test("an underscored member declared nowhere in this file is still reported")
+    func foreignMemberIsStillReported() {
+        // The control. Without it both guards above could be satisfied by a rule that had
+        // simply stopped firing, and the two absence assertions would still pass.
+        let issues = implDetailIssues("""
+        func peek(_ other: Widget) -> Any {
+            other._internalStorage
+        }
+        """)
+        #expect(issues.isEmpty == false)
+    }
+
+    @Test("a member outside the SPI catalog is still reported")
+    func nonSPIMemberIsStillReported() {
+        let issues = implDetailIssues("""
+        func peek(_ other: Widget) -> Any {
+            other._internalStorage
+        }
+        """, spiMembers: ["_snapshotBox"])
+        #expect(issues.isEmpty == false)
+    }
+
 }


### PR DESCRIPTION
## What changed

`Accessing Implementation Details` no longer reports two shapes of underscored access:

1. **A member published under `@_spi(...)`** — via a new project-wide `SPIMemberCollector`.
2. **A member the enclosing type declares itself.**

## Why

The underscore heuristic is right and its answer was wrong in both cases.

**SwiftIdempotency declares `_snapshotBox()` inside an `@_spi(Internals) public extension`**, with a SwiftLint suppression beside it for `identifier_name`. The author said "this is deliberate SPI" three separate ways, and the rule reported all five uses of it *inside the package that publishes it*.

**`other._value` inside a type's own initializer** is how an `Equatable`-style comparison against another instance is written — the type reaching into its own kind, not a caller reaching past an interface.

## What a reviewer should scrutinise

**The second guard's scope is the enclosing type, and my first attempt used the file.** The existing suite caught it immediately: `testDetectsUnderscoreMemberOnOtherObject` puts two classes in one file and has one reach into the other's `_data` — exactly the violation this rule exists for. Swift's `private` being file-scoped makes that access *legal*; it does not make it *encapsulated*, and the rule is about the second. **Three existing tests failed on the wide version**, which is the control doing its job, and worth knowing if the scope is ever revisited.

**Four new tests, two of them controls** — `foreignMemberIsStillReported` and `nonSPIMemberIsStillReported`. Without those, both exemptions would be equally satisfied by a rule that had simply stopped firing.

**The SPI catalog needs the project-wide prescan**, so a single-file run still reports such an access. Documented under Known Limitations, alongside the same caveat now on `concrete-type-usage` and `unused-protocol-abstraction`.

## Measurement

SwiftIdempotency: **6 → 0**, and its refactor prompts **9 → 3**. That repo is a library whose entire snapshot mechanism is published SPI, so it saw the worst of this.

## Verification

`swift package clean && swift test`: **3384 tests in 409 suites pass** (4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUiBG9dnCecA2iYHPBAFNb