### PR TITLE
Stop reporting a defaulted parameter as a missing injection

### DIFF
--- a/Docs/rules/direct-instantiation.md
+++ b/Docs/rules/direct-instantiation.md
@@ -10,7 +10,9 @@
 Creating a service, manager, repository, or similar object directly at its point of use — rather than receiving it through an initializer or environment — makes code hard to test and creates hidden coupling between consumer and implementation.
 
 ### Discussion
-`DirectInstantiationVisitor` identifies calls to constructors of types whose names end with service-like suffixes: `Manager`, `Service`, `Store`, `Provider`, `Client`, `Repository`, `Handler`, `Controller`, `Factory`, `Adapter`, `ViewModel`, `Coordinator`, or `Generator`. It fires for stored property initializers, default parameter values, local variable declarations, and closure bodies. It does not fire when the variable has a SwiftUI property wrapper (`@StateObject`, `@ObservedObject`, etc.), because wrapper-decorated `@StateObject var vm = SomeViewModel()` is the correct SwiftUI pattern for owned view models.
+`DirectInstantiationVisitor` identifies calls to constructors of types whose names end with service-like suffixes: `Manager`, `Service`, `Store`, `Provider`, `Client`, `Repository`, `Handler`, `Controller`, `Factory`, `Adapter`, `ViewModel`, `Coordinator`, or `Generator`. It fires for stored property initializers, local variable declarations, and closure bodies. It does not fire when the variable has a SwiftUI property wrapper (`@StateObject`, `@ObservedObject`, etc.), because wrapper-decorated `@StateObject var vm = SomeViewModel()` is the correct SwiftUI pattern for owned view models.
+
+**A defaulted parameter is not flagged, and used to be.** `init(svc: NetworkService = NetworkService())` was reported with the advice "remove the default value and inject at the call site". The parameter *is* the seam: a test substitutes by passing one, which is the whole requirement, and removing the default only makes every caller construct one for no testability gain. The rule was also inconsistent about it — `= .shared` and `= .default` hard-wire production in exactly the same way and were never reported, so the line was drawn on whether the default was spelled as a constructor call rather than on whether a seam existed. What remains is where the rule's value is: a stored property with an inline initializer has no parameter to pass and no seam at all.
 
 **The singleton definition site is exempt.** A type that vends an instance of *itself* as a `static` member — `static let shared = ProjectParser()` *inside* `ProjectParser` — is defining the singleton, not consuming an injectable dependency. Instantiating yourself to publish your own `.shared` is the singleton idiom (and the same shape covers namespaced constants like `static let live = Client()`); flagging it contradicts the rule's intent and double-reports the line that `Singleton Usage` already covers at the *access* sites. The visitor tracks the enclosing nominal type via a declaration stack (`class`/`struct`/`enum`/`actor`) and skips a `static` initializer whose instantiated type equals the enclosing type. The exemption is deliberately narrow: a `static` member instantiating a *different* service type, or a *non-`static`* member instantiating the enclosing type, is still flagged.
 
@@ -42,11 +44,6 @@ final class ProjectParser {
 // Direct instantiation in stored property
 class MyView {
     private let svc = NetworkService()  // direct instantiation
-}
-
-// Direct instantiation as default parameter
-class MyViewModel {
-    init(svc: NetworkService = NetworkService()) { }  // default creates concrete instance
 }
 
 // Direct instantiation in function body

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/DirectInstantiationVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/DirectInstantiationVisitor.swift
@@ -98,24 +98,6 @@ class DirectInstantiationVisitor: BasePatternVisitor {
         return .visitChildren
     }
 
-    // MARK: - Constructor/function parameter defaults
-
-    override func visit(_ node: FunctionParameterSyntax) -> SyntaxVisitorContinueKind {
-        guard let defaultValue = node.defaultValue else { return .visitChildren }
-        if let typeName = isServiceLikeCall(defaultValue.value) {
-            let paramName = node.firstName.text
-            addIssue(
-                severity: .warning,
-                message: "Default parameter '\(paramName)' directly instantiates '\(typeName)' — prefer injection",
-                filePath: currentFilePath,
-                lineNumber: getLineNumber(for: Syntax(node)),
-                suggestion: "Remove the default value and inject '\(typeName)' at the call site",
-                ruleName: .directInstantiation
-            )
-        }
-        return .visitChildren
-    }
-
     // MARK: - Static-member detection
 
     private func isStatic(_ node: VariableDeclSyntax) -> Bool {

--- a/Tests/CoreTests/Architecture/ArchitectureDirectInstantiationTests.swift
+++ b/Tests/CoreTests/Architecture/ArchitectureDirectInstantiationTests.swift
@@ -39,15 +39,39 @@ struct ArchitectureDirectInstantiationTests {
 
     // MARK: - Constructor default
 
-    @Test func testDetectsDirectInstantiationInConstructorDefault() throws {
+    @Test func testDefaultedParameterIsASeamNotAViolation() {
+        // A defaulted parameter *is* the injection point: a test substitutes by passing one,
+        // which is the whole requirement. The old advice — "remove the default value and
+        // inject at the call site" — makes every caller construct one for no testability gain.
+        //
+        // The rule was also inconsistent about it. Three defaults hard-wire production
+        // identically and only the constructor spelling was reported:
+        //
+        //     init(svc: NetworkService = NetworkService())   // flagged
+        //     init(svc: NetworkService = .shared)            // silent
+        //     init(fm: FileManager = .default)               // silent
+        //
+        // If the concern is the hard-wire, `.shared` is the worse case. The line was drawn on
+        // syntax rather than substance, and `= .default` is the convention these projects use.
         let source = """
         class MyViewModel {
             init(svc: NetworkService = NetworkService()) { }
         }
         """
-        let issues = analyzeSource(source)
-        let directIssues = issues.filter { $0.ruleName == .directInstantiation }
-        let issue = try #require(directIssues.first)
+        let issues = analyzeSource(source).filter { $0.ruleName == .directInstantiation }
+        #expect(issues.isEmpty)
+    }
+
+    @Test func testStoredPropertyHardWireIsStillDetected() throws {
+        // The control, and where the rule's value actually is. A stored property with an
+        // inline initializer has no seam at all — there is no parameter to pass.
+        let source = """
+        class MyViewModel {
+            private let svc = NetworkService()
+        }
+        """
+        let issues = analyzeSource(source).filter { $0.ruleName == .directInstantiation }
+        let issue = try #require(issues.first)
         #expect(issue.message.contains("NetworkService"))
     }
 


### PR DESCRIPTION
## What changed

`Direct Instantiation` no longer fires on a default parameter value. The `FunctionParameterSyntax` branch is gone; stored properties, local variables and closure bodies are untouched.

## Why

`init(svc: NetworkService = NetworkService())` was reported with the advice *"remove the default value and inject at the call site"*. **The parameter is the seam** — a test substitutes by passing one, which is the entire requirement — and removing the default just makes every caller construct one for no testability gain.

**The inconsistency is what settles it rather than taste.** Three defaults hard-wire production identically:

```swift
init(svc: NetworkService = NetworkService())   // flagged
init(svc: NetworkService = .shared)            // silent
init(fm: FileManager = .default)               // silent
```

Only the constructor spelling was reported. If the concern is the hard-wire, `.shared` is the *worse* case — it's a singleton. If the concern is a missing seam, all three have one. The line was drawn on how the default was spelled, not on what it does.

And `= .default` is the convention these projects use throughout — including the `DateProvider = .system` seams added to SwiftLintRuleStudio this week, whose entire purpose is making a clock injectable. They would have been flagged for it had they been spelled the other way.

## What a reviewer should scrutinise

**This reverses a documented design decision.** `Docs/rules/direct-instantiation.md` listed the defaulted parameter as a violating example on purpose, so this is a disagreement with intent, not a bug fix. The doc now carries the reasoning in the same place, next to the singleton-exemption note.

**The control is `testStoredPropertyHardWireIsStillDetected`.** A stored property with an inline initializer has no parameter to pass and no seam at all — that is where the rule's value is, and without a test pinning it this change could silence the rule and the suite would still pass.

**The alternative I did not take** was making it consistent the other way: also flag `= .shared` and `= .default`. That would have been defensible and much noisier, and it would flag the Foundation-injection idiom every one of these projects relies on.

## Measurement

Across the repositories carrying findings: **123 → 82**. `SwiftLintRuleStudioTeam` goes to **zero**, so every finding it had for this rule was a defaulted parameter.

## Verification

`swift package clean && swift test`: **3385 tests in 409 suites pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUiBG9dnCecA2iYHPBAFNb