### PR TITLE
Stop asking for a protocol around a generic type

### DIFF
--- a/Docs/rules/concrete-type-usage.md
+++ b/Docs/rules/concrete-type-usage.md
@@ -79,6 +79,11 @@ class MyViewModel {
 
 ### Known Limitations
 
+- **A type written with generic arguments is never reported.** `Generator<[Element], Shrinker>`
+  is already parameterised by its use site, and the advice is not available to it in any useful
+  form — `any GeneratorProtocol` erases the element type and the shrinker, which is the whole of
+  what the type carries. A bare foreign service is different and is still reported: it takes no
+  parameters, and wrapping it behind your own protocol is the canonical advice.
 - **A `typealias` for a function type is never reported.** `typealias CommandRunner = @Sendable
   ([String]) async throws -> Data` names a closure, and a property typed with it is already
   injected — a test substitutes another closure. Asking for a protocol around it would replace a

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ConcreteTypeUsageVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ConcreteTypeUsageVisitor.swift
@@ -94,19 +94,37 @@ class ConcreteTypeUsageVisitor: BasePatternVisitor {
     private func extractServiceTypeName(from type: TypeSyntax) -> String? {
         // Direct: NetworkService
         if let identifier = type.as(IdentifierTypeSyntax.self) {
-            return qualifying(identifier.name.text)
+            return qualifying(identifier)
         }
         // Optional: NetworkService?
         if let opt = type.as(OptionalTypeSyntax.self),
            let identifier = opt.wrappedType.as(IdentifierTypeSyntax.self) {
-            return qualifying(identifier.name.text)
+            return qualifying(identifier)
         }
         // Implicitly unwrapped: NetworkService!
         if let iuo = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self),
            let identifier = iuo.wrappedType.as(IdentifierTypeSyntax.self) {
-            return qualifying(identifier.name.text)
+            return qualifying(identifier)
         }
         return nil
+    }
+
+    /// A type written with generic arguments is already parameterised by its use site, and
+    /// "prefer a protocol abstraction" is not available to it in any useful form: replacing
+    /// `Generator<[Element], Shrinker>` with `any GeneratorProtocol` erases the element type and
+    /// the shrinker, which is the whole of what the type was carrying. That is a loss, not an
+    /// abstraction.
+    ///
+    /// This is what a bare foreign service does not have. `Alamofire.Session` takes no
+    /// parameters and wrapping it behind your own protocol is the canonical advice; the rule
+    /// still gives it.
+    ///
+    /// Measured on SwiftPropertyLaws, whose every law takes a generator: 215 of its 218
+    /// findings named `Generator`, and 263 of the 267 uses in that package carry generic
+    /// arguments.
+    private func qualifying(_ identifier: IdentifierTypeSyntax) -> String? {
+        guard identifier.genericArgumentClause == nil else { return nil }
+        return qualifying(identifier.name.text)
     }
 
     /// Returns the name if it's service-like and not a protocol indicator, else nil.

--- a/Tests/CoreTests/Architecture/ArchitectureConcreteTypeUsageTests.swift
+++ b/Tests/CoreTests/Architecture/ArchitectureConcreteTypeUsageTests.swift
@@ -449,4 +449,53 @@ struct ArchitectureConcreteTypeUsageTests {
         #expect(issues.isEmpty == false)
     }
 
+
+    // MARK: - A generic type is already parameterised
+
+    // `Generator<[Element], Shrinker>` cannot usefully take the advice: `any GeneratorProtocol`
+    // erases the element type and the shrinker, which is the whole of what the type carries.
+    // Measured on SwiftPropertyLaws, where every law takes a generator — 215 of its 218 findings
+    // named `Generator`, and 263 of 267 uses there carry generic arguments.
+
+    @Test
+    func genericParameterIsNotFlagged() {
+        let issues = analyzeSource("""
+        func checkLaw<Element, Shrinker>(generator: Generator<[Element], Shrinker>) {}
+        """)
+        #expect(issues.isEmpty)
+    }
+
+    @Test
+    func genericPropertyIsNotFlagged() {
+        let issues = analyzeSource("""
+        struct LawRunner {
+            private let generator: Generator<Int, AnySequence<Int>>
+        }
+        """)
+        #expect(issues.isEmpty)
+    }
+
+    @Test
+    func optionalGenericIsNotFlagged() {
+        let issues = analyzeSource("""
+        struct LawRunner {
+            private let generator: Generator<Int, AnySequence<Int>>?
+        }
+        """)
+        #expect(issues.isEmpty)
+    }
+
+    @Test
+    func aBareServiceTypeIsStillFlaggedWithoutGenerics() {
+        // The control. A foreign service taking no parameters — `Alamofire.Session` in the
+        // motivating shape — can be wrapped behind your own protocol, and that is the canonical
+        // advice. Without this the exemption could be silencing the rule outright.
+        let issues = analyzeSource("""
+        struct Client {
+            private let networkService: NetworkService
+        }
+        """)
+        #expect(issues.isEmpty == false)
+    }
+
 }


### PR DESCRIPTION
## What changed

`Concrete Type Usage` no longer reports a type written with generic arguments.

## Why

It reported this, in every law in `SwiftPropertyLaws`:

```swift
func checkMergeMultiset<Element, Shrinker>(
    generator: Generator<[Element], Shrinker>,
    options: LawCheckOptions
) async -> CheckResult
```

**The advice is not available to that type.** `any GeneratorProtocol` erases the element type and the shrinker — the whole of what `Generator` carries. Taking it would lose information rather than hide it.

A type written with generic arguments is already parameterised by its use site. A bare foreign service is not, which is why the rule still reports one: `Alamofire.Session` takes no parameters, and wrapping it behind your own protocol is the canonical advice.

## Measurement

| repo | before | after |
|---|---|---|
| SwiftPropertyLaws | 218 | **3** |
| pbt-book | 4 | 0 |
| SwiftIdempotency | 2 | 0 |
| **total (13 repos)** | **255** | **34** |

**215 of SwiftPropertyLaws' 218 findings named the single type `Generator`**, and 263 of the 267 uses of it in that package carry generic arguments. That repository's report was 97% one rule firing on one type — the largest single class of false positive in this sweep.

## What a reviewer should scrutinise

**The boundary is generic arguments, not genericness in general.** `Store<AppState>` is exempt; `NetworkService` is not. If you think a generic repository should still be abstracted, this is the line to argue with — my case is that Swift gives you no way to do it that keeps the parameters.

**`aBareServiceTypeIsStillFlaggedWithoutGenerics` is the control.** Almost every other test in that suite uses a non-generic type, so an exemption that had gone too far would leave the suite green. That test is what makes the boundary explicit rather than incidental.

**Unchanged repos are the reassurance.** `SwiftAssist`, `SwiftUMLStudio`, `SwiftLintRuleStudio` and the rest show no movement at all — their findings name real, non-generic service types, so the rule keeps its value exactly where it had it.

## Verification

`swift package clean && swift test`: **3389 tests in 409 suites pass** (4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUiBG9dnCecA2iYHPBAFNb