### PR TITLE
A clock read is not an extractable pure kernel

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ExtractablePureKernelVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ExtractablePureKernelVisitor.swift
@@ -449,6 +449,16 @@ private struct Collector {
                   let name = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text else {
                 continue
             }
+            // A binding that reads ambient state is not a kernel, whichever shape it has below:
+            // this rule's own message claims the bindings "depend only on its parameters and
+            // locals", and a clock read makes that claim false.
+            //
+            // `onlyPureCalls` cannot catch it. That walk visits `FunctionCallExprSyntax`, and
+            // `ContinuousClock.now` is a member access with no call in it. `Date()` was already
+            // refused because it *is* a call whose callee is not a pure conversion — which is why
+            // only the clock-property spelling ever got through, and why the gap went unnoticed.
+            guard !AmbientStateReads.occur(in: value) else { continue }
+
             if isVar, !value.is(IntegerLiteralExprSyntax.self) {
                 externallySeededVars.insert(name)
             }

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/AmbientStateReads.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/AmbientStateReads.swift
@@ -1,0 +1,49 @@
+import SwiftEffectInference
+import SwiftSyntax
+
+/// Whether an expression reaches ambient state — a clock, a random source, the process
+/// environment.
+///
+/// A Visitors-package forwarder onto `SwiftEffectInference.NondeterminismSources`, for the same
+/// reason `PurityInferrer` next door is one: `MemberImportVisibility` requires the *using* module
+/// to import the member's defining module, so exposing SEI's classifier directly would force every
+/// consumer package to take a direct SEI dependency edge. Forwarding keeps that edge here.
+///
+/// The classifier is consulted rather than re-derived. `NondeterminismSources` is the single
+/// implementation of "does this reach for ambient time", and a second copy living in a rule is
+/// exactly the drift that extracting it was meant to prevent.
+public enum AmbientStateReads {
+
+    /// True when any subexpression reads a clock, draws from the system RNG, or reads the ambient
+    /// environment.
+    ///
+    /// Precise in both directions that matter to a caller deciding whether something is a pure
+    /// kernel. `ContinuousClock.Instant` is not a read — the member must be `now`. `clock.now` on
+    /// an injected parameter is not a read either — the base must be a bare type name — because
+    /// reading a clock you were handed is reproducible, and that is the seam an extraction rule
+    /// wants people to build rather than something to punish.
+    public static func occur(in node: some SyntaxProtocol) -> Bool {
+        let checker = Checker(viewMode: .sourceAccurate)
+        checker.walk(node)
+        return checker.sawSource
+    }
+
+    /// Both overloads are needed. The call form catches `ContinuousClock()`, `Date()`,
+    /// `mach_absolute_time()` and `DispatchTime.now()`; the member form catches the property
+    /// spellings — `ContinuousClock.now`, `SuspendingClock.now`, `Locale.current` — which are not
+    /// calls at all and which a call-only walk misses entirely.
+    private final class Checker: SyntaxVisitor {
+
+        private(set) var sawSource = false
+
+        override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+            if NondeterminismSources.source(of: node) != nil { sawSource = true }
+            return .visitChildren
+        }
+
+        override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
+            if NondeterminismSources.source(of: node) != nil { sawSource = true }
+            return .visitChildren
+        }
+    }
+}

--- a/Tests/CoreTests/Testability/ExtractablePureKernelVisitorTests.swift
+++ b/Tests/CoreTests/Testability/ExtractablePureKernelVisitorTests.swift
@@ -398,3 +398,119 @@ struct ExtractablePureKernelVisitorTests {
         """).isEmpty)
     }
 }
+
+/// A clock read is not a pure kernel, and the rule used to say it was.
+///
+/// Found by running the rule over SwiftAssist: `WorkloadTracker.isIdle(forAtLeast:)` and
+/// `ResourceGovernor.isStale(_:)` both compute `let elapsed = ContinuousClock.now - instant` and
+/// then compare it, which satisfies both halves of the arithmetic gate — a derived binding, and a
+/// comparison that references it. The finding then told the author that `elapsed` "depends only on
+/// its parameters and locals", which is false: it depends on the host clock.
+///
+/// `onlyPureCalls` could never have caught it. That walk visits `FunctionCallExprSyntax`, and
+/// `ContinuousClock.now` is a member access containing no call. `Date()` *is* a call, and its
+/// callee is not one of the pure conversions, so the wall-clock spelling was refused all along —
+/// which is why the gap survived: the obvious probe passes.
+@Suite("A clock read is not a kernel")
+struct ExtractablePureKernelAmbientStateTests {
+
+    private func analyze(_ source: String) -> [LintIssue] {
+        let visitor = ExtractablePureKernelVisitor(patternCategory: .testability)
+        let syntax = Parser.parse(source: source)
+        visitor.setSourceLocationConverter(
+            SourceLocationConverter(fileName: "Service.swift", tree: syntax)
+        )
+        visitor.setFilePath("Service.swift")
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == .extractablePureKernel }
+    }
+
+    // MARK: - The false positives this closes
+
+    @Test("an idle check against the monotonic clock is not a kernel")
+    func continuousClockElapsedIsNotAKernel() {
+        // SwiftAssist's `WorkloadTracker.isIdle(forAtLeast:)`, verbatim in shape.
+        #expect(analyze("""
+        func isIdle(forAtLeast duration: Duration) async -> Bool {
+            guard activeCount == 0 else { return false }
+            let elapsed = ContinuousClock.now - lastActivityAt
+            return elapsed >= duration
+        }
+        """).isEmpty)
+    }
+
+    @Test("a staleness check against the monotonic clock is not a kernel")
+    func staleCheckIsNotAKernel() {
+        // SwiftAssist's `ResourceGovernor.isStale(_:)`. Here the other operand *is* a parameter,
+        // so the only impurity is the clock — which makes it the cleaner witness of the two.
+        #expect(analyze("""
+        func isStale(_ evaluatedAt: ContinuousClock.Instant) async -> Bool {
+            await warmUp()
+            let elapsed = ContinuousClock.now - evaluatedAt
+            return elapsed > .seconds(ttl)
+        }
+        """).isEmpty)
+    }
+
+    @Test("the other ambient spellings are refused too")
+    func otherAmbientSourcesAreRefused() {
+        // The member form is what a call-only walk misses, so each spelling gets its own witness
+        // rather than trusting that one clock stands in for all of them.
+        for source in ["SuspendingClock.now", "DispatchTime.now()", "Date.now"] {
+            #expect(analyze("""
+            func drifted(since mark: Instant, limit: Int) async -> Bool {
+                await warmUp()
+                let elapsed = \(source) - mark
+                return elapsed > limit
+            }
+            """).isEmpty, "\(source) should not read as a kernel")
+        }
+    }
+
+    // MARK: - The controls, which are what keep the fix from over-reaching
+
+    @Test("an injected clock still yields a kernel")
+    func injectedClockIsStillAKernel() {
+        // The case the fix must not punish. Reading a clock handed to you is reproducible, and it
+        // is precisely the seam this rule wants people to build — refusing it would mean the rule
+        // stops rewarding the refactor it recommends.
+        #expect(!analyze("""
+        func isIdle(clock: any Clock, since mark: Instant, chunkSize: Int, total: Int) async -> Bool {
+            await warmUp()
+            let elapsed = clock.now - mark
+            let chunks = (total + chunkSize - 1) / chunkSize
+            return elapsed > chunks
+        }
+        """).isEmpty)
+    }
+
+    @Test("naming a clock type without reading it is not an ambient read")
+    func clockTypeInAnAnnotationIsNotARead() {
+        // `ContinuousClock.Instant` is a type, not a clock read. The classifier requires the member
+        // to be `now`, and this is the witness for that.
+        #expect(!analyze("""
+        func plan(from mark: ContinuousClock.Instant, total: Int, size: Int) async -> Int {
+            await warmUp()
+            let chunks = (total + size - 1) / size
+            let index = chunks - 1
+            return index < chunks ? index : 0
+        }
+        """).isEmpty)
+    }
+
+    @Test("ordinary arithmetic kernels still fire")
+    func ordinaryKernelStillFires() {
+        // The blunt control: the motivating case from the suite above must be unaffected.
+        #expect(!analyze("""
+        func upload(of data: Data, from queued: Int, chunkSize: Int) async throws {
+            let totalChunks = (data.count + chunkSize - 1) / chunkSize
+            var index = queued
+            while index < totalChunks {
+                let chunk = Data(data.dropFirst(index * chunkSize).prefix(chunkSize))
+                _ = try await send(chunk)
+                index += 1
+            }
+        }
+        """).isEmpty)
+    }
+}


### PR DESCRIPTION
Found by running the rule over SwiftAssist in the refactoring experiment. Three findings there told the author to lift a clock read into a pure kernel.

## The bug

`ExtractablePureKernelVisitor` gates on shape: a derived binding, plus a use that governs something. This satisfies both halves —

```swift
let elapsed = ContinuousClock.now - lastActivityAt
return elapsed >= duration
```

— so the rule fired, and the message it printed said `elapsed` *"depends only on its parameters and locals, and nothing else in the method reaches them."* That is false twice over: it depends on the host clock, and in `WorkloadTracker` the other operand is a stored property.

**Why it survived.** `onlyPureCalls` walks `FunctionCallExprSyntax`. `ContinuousClock.now` is a member access with no call in it, so that walk never sees it. Meanwhile `Date()` *is* a call whose callee is not a pure conversion, so the wall-clock spelling was refused all along — the obvious probe passes, and the gap stays hidden behind it.

## The fix

Consult `NondeterminismSources`, the classifier SwiftEffectInference extracted precisely so that "does this reach for ambient time" has one implementation. A second copy living inside a rule is the drift that extraction exists to prevent.

`AmbientStateReads` is a Visitors-package forwarder for the same reason `PurityInferrer` next door is one, and its doc says so: `MemberImportVisibility` requires the using module to import the member's defining module, so exposing SEI's classifier directly would force `SwiftProjectLintRules` to take a direct SEI dependency edge. Forwarding keeps that edge in Visitors.

## What a reviewer should scrutinise

**The three controls, more than the three fires.** This rule's worth is its precision, and a nondeterminism guard is exactly the kind of fix that quietly over-reaches:

- **An injected clock still yields a kernel.** `clock.now` on a parameter is reproducible, and dependency-injecting the clock is the seam this rule exists to recommend. A fix that refused it would mean the rule stopped rewarding its own advice — that would be worse than the bug.
- **`ContinuousClock.Instant` in a signature is a type, not a read.** The classifier requires the member to be `now`, and this test is the witness for that.
- **The suite's motivating chunking kernel still fires.**

Also worth checking: the guard sits before the `externallySeededVars` insert in `record(_:)`, so a `var` seeded from a clock is not recorded as an externally-seeded index either. I believe that is right — it is not a resume point worth lifting — but it is a second effect of a one-line guard and deserves a look.

## Measured

On SwiftAssist: Extractable Pure Kernel **18 → 15**. All three removed findings are clock reads — `WorkloadTracker.isIdle`, `ResourceGovernor.isStale`, and `EditorCommandHandler`'s `let deadline = ContinuousClock.now + timeout` (that third one I had not predicted; I diffed the findings rather than assuming the count matched my guess). Nothing was added, and nothing else moved.

Three of the six new tests fail against the unguarded rule; the three controls pass either way, which is what makes them controls. 3,395 tests pass, SwiftLint clean.