### PR TITLE
Lift the severity-to-appearance mapping out of LintIssueRow

### DIFF
--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/IssueSeverity.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/IssueSeverity.swift
@@ -16,7 +16,10 @@
 ///   - info: Provides informational messages or suggestions for improving code quality or consistency.
 ///
 /// - SeeAlso: `LintIssue`
-public enum IssueSeverity: String, Codable, Sendable {
+/// `CaseIterable` so that presentation mappings over severity can be checked exhaustively rather
+/// than one example per case. A three-case switch is exactly where a fourth case gets folded into
+/// an existing branch, and only a test that iterates `allCases` notices.
+public enum IssueSeverity: String, Codable, Sendable, CaseIterable {
     case error
     case warning
     case info

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift
@@ -3,14 +3,34 @@ import SwiftProjectLintModels
 import SwiftProjectLintVisitors
 import SwiftSyntax
 
-/// Detects computed properties that return `some View` inside View-conforming types.
+/// Detects computed properties returning `some View` whose extraction would actually buy something.
 ///
-/// Computed properties returning `some View` defeat SwiftUI's structural identity — they are
-/// re-evaluated on every parent update with no diffing. Extracting them into separate `View`
-/// structs gives SwiftUI a stable identity boundary and lets the child hold its own `@State`.
+/// The mechanism is real: a computed property returning `some View` is inlined into the parent's
+/// `body` and has no node of its own in the view graph, so it re-evaluates whenever the parent
+/// does. A child `View` struct gets an identity, can skip its `body` when its inputs compare equal,
+/// and can hold its own `@State`.
+///
+/// **The benefit is conditional, and the rule used to report it unconditionally.** A child only
+/// skips an update when its inputs are narrower than its parent's. Extract `SummaryRow(issue:)` out
+/// of a view that re-renders whenever `issue` changes and the child re-renders in lockstep — the
+/// same work, one more type. Measured on this project's own app, seven of the eighteen findings had
+/// exactly that shape.
+///
+/// So the property must depend on a **strict subset** of the enclosing type's stored inputs. That
+/// is a necessary condition for the diffing benefit, not a sufficient one — a two-line `Text` gains
+/// little either way — but it is the condition the rule can actually check, and it is what
+/// separates a property that can skip an update from one that never will.
+///
+/// Dependencies are followed **transitively** through the type's other computed properties: a
+/// property that reads nothing itself but calls one that reads `isExpanded` depends on
+/// `isExpanded`. Without that, every wrapper property looks input-free and every one of them fires.
 class ComputedPropertyViewVisitor: BasePatternVisitor {
     private var currentFilePath: String = ""
     private var isInsideViewType = false
+
+    /// Names of the view properties in the type currently being visited that pass the subset gate.
+    /// Computed once per type, because the answer depends on the type's other members.
+    private var firingNames: Set<String> = []
 
     required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
         super.init(pattern: pattern, viewMode: viewMode)
@@ -25,23 +45,27 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
     override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
         if conformsToView(node.inheritanceClause) || hasBodySomeView(node.memberBlock) {
             isInsideViewType = true
+            firingNames = Self.propertiesWorthExtracting(in: node.memberBlock)
         }
         return .visitChildren
     }
 
     override func visitPost(_ _: StructDeclSyntax) {
         isInsideViewType = false
+        firingNames = []
     }
 
     override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
         if conformsToView(node.inheritanceClause) || hasBodySomeView(node.memberBlock) {
             isInsideViewType = true
+            firingNames = Self.propertiesWorthExtracting(in: node.memberBlock)
         }
         return .visitChildren
     }
 
     override func visitPost(_ _: ClassDeclSyntax) {
         isInsideViewType = false
+        firingNames = []
     }
 
     // MARK: - Detect computed properties returning some View
@@ -53,7 +77,8 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
             guard let name = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
                   name != "body",
                   returnsSomeView(binding.typeAnnotation),
-                  binding.accessorBlock != nil else {
+                  binding.accessorBlock != nil,
+                  firingNames.contains(name) else {
                 continue
             }
 
@@ -67,8 +92,9 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
 
             addIssue(
                 severity: severity,
-                message: "Computed\(qualifier) property '\(name)' returns 'some View' — "
-                    + "extract into a separate View struct for better SwiftUI diffing",
+                message: "Computed\(qualifier) property '\(name)' returns 'some View' and depends "
+                    + "on fewer of this view's inputs than the view itself — extract it into a "
+                    + "separate View struct so SwiftUI can skip it when the inputs it ignores change",
                 filePath: currentFilePath,
                 lineNumber: getLineNumber(for: Syntax(node)),
                 suggestion: "Move '\(name)' into its own struct conforming to View",
@@ -76,6 +102,97 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
             )
         }
         return .skipChildren
+    }
+
+    // MARK: - The subset gate
+
+    /// Which `some View` properties in a type would gain a narrower input surface by extraction.
+    ///
+    /// Returns the properties whose transitive dependency on the type's stored properties is a
+    /// *strict* subset of those stored properties. A property depending on all of them re-renders
+    /// exactly when its parent does, so a child struct changes nothing; a type with no stored
+    /// properties at all has nothing to narrow, and yields nothing.
+    static func propertiesWorthExtracting(in memberBlock: MemberBlockSyntax) -> Set<String> {
+        var stored: Set<String> = []
+        var computedReferences: [String: Set<String>] = [:]
+        var viewProperties: Set<String> = []
+
+        for member in memberBlock.members {
+            guard let varDecl = member.decl.as(VariableDeclSyntax.self) else { continue }
+            let isStatic = varDecl.modifiers.contains { $0.name.tokenKind == .keyword(.static) }
+            for binding in varDecl.bindings {
+                guard let name = binding.pattern.as(IdentifierPatternSyntax.self)?
+                    .identifier.text else { continue }
+                guard let accessor = binding.accessorBlock else {
+                    // A stored property. `static let` is a constant, not an input the view
+                    // re-renders on, so it is not part of the surface.
+                    if !isStatic { stored.insert(name) }
+                    continue
+                }
+                computedReferences[name] = referencedNames(in: Syntax(accessor))
+                if name != "body", returnsSomeViewType(binding.typeAnnotation) {
+                    viewProperties.insert(name)
+                }
+            }
+        }
+        guard !stored.isEmpty else { return [] }
+
+        return viewProperties.filter { name in
+            let depends = resolvedDependencies(of: name, computed: computedReferences, stored: stored)
+            return depends.isSubset(of: stored) && depends.count < stored.count
+        }
+    }
+
+    /// The stored properties a computed property reaches, following the type's other computed
+    /// properties. A wrapper that reads nothing itself still depends on whatever it calls.
+    private static func resolvedDependencies(
+        of name: String,
+        computed: [String: Set<String>],
+        stored: Set<String>
+    ) -> Set<String> {
+        var seen: Set<String> = [name]
+        var pending = Array(computed[name] ?? [])
+        var result: Set<String> = []
+
+        while let next = pending.popLast() {
+            if stored.contains(next) { result.insert(next) }
+            guard !seen.contains(next) else { continue }
+            seen.insert(next)
+            if let further = computed[next] { pending.append(contentsOf: further) }
+        }
+        return result
+    }
+
+    private static func referencedNames(in node: Syntax) -> Set<String> {
+        var names: Set<String> = []
+        for child in node.children(viewMode: .sourceAccurate) {
+            if let reference = child.as(DeclReferenceExprSyntax.self) {
+                names.insert(stripped(reference.baseName.text))
+            }
+            if let member = child.as(MemberAccessExprSyntax.self),
+               member.base?.as(DeclReferenceExprSyntax.self)?.baseName.tokenKind
+                == .keyword(.self) {
+                names.insert(member.declName.baseName.text)
+            }
+            names.formUnion(referencedNames(in: child))
+        }
+        return names
+    }
+
+    /// `$isExpanded` and `isExpanded` are the same input.
+    ///
+    /// The projected value of a `@State` or `@Binding` parses as its own identifier, so a property
+    /// that writes through `$isExpanded` reads as depending on nothing. That is not academic: a
+    /// `Toggle(_:isOn:)` is the ordinary way to touch that state, and without this every wrapper
+    /// around one looked input-free and fired.
+    private static func stripped(_ name: String) -> String {
+        name.hasPrefix("$") ? String(name.dropFirst()) : name
+    }
+
+    private static func returnsSomeViewType(_ annotation: TypeAnnotationSyntax?) -> Bool {
+        guard let annotation,
+              let someType = annotation.type.as(SomeOrAnyTypeSyntax.self) else { return false }
+        return someType.constraint.trimmedDescription == "View"
     }
 
     // MARK: - Helpers

--- a/Sources/App/Views/IssueSeverityStyle.swift
+++ b/Sources/App/Views/IssueSeverityStyle.swift
@@ -1,0 +1,43 @@
+import Core
+import SwiftUI
+
+/// How a severity is drawn: an icon, a colour, and the label VoiceOver reads.
+///
+/// Lifted out of `LintIssueRow`, where the three mappings lived as `private var`s returning
+/// `String` and `Color`. They were reachable only by constructing the whole row and inspecting it,
+/// which is what `LintIssueRowTests` does — one example test per severity, three views built to
+/// check three constants.
+///
+/// The reason to lift them is not to save those three tests. It is that the laws worth stating
+/// about this mapping are about the severities *as a set*, and no per-case example can express
+/// them: that every case has a style at all, and that no two cases share an icon or a colour. A
+/// severity row whose error and warning look identical is unreadable, and nothing in the code said
+/// they had to differ.
+/// `nonisolated` because the App target defaults to `MainActor` isolation and this is pure data
+/// derived from an enum. Binding it to the main actor would mean a test could not build one off it,
+/// which is the whole reason it was lifted out of the view.
+nonisolated struct IssueSeverityStyle: Equatable {
+
+    let iconName: String
+    let color: Color
+    let accessibilityLabel: String
+
+    init(_ severity: IssueSeverity) {
+        switch severity {
+        case .error:
+            self.iconName = "xmark.circle.fill"
+            self.color = .red
+            self.accessibilityLabel = "Error"
+
+        case .warning:
+            self.iconName = "exclamationmark.triangle.fill"
+            self.color = .orange
+            self.accessibilityLabel = "Warning"
+
+        case .info:
+            self.iconName = "info.circle.fill"
+            self.color = .blue
+            self.accessibilityLabel = "Info"
+        }
+    }
+}

--- a/Sources/App/Views/LintIssueRow.swift
+++ b/Sources/App/Views/LintIssueRow.swift
@@ -89,44 +89,11 @@ struct LintIssueRow: View {
     }
 
     private var severityIcon: some View {
-        Image(systemName: severityIconName)
-            .foregroundStyle(severityColor)
+        let style = IssueSeverityStyle(issue.severity)
+        return Image(systemName: style.iconName)
+            .foregroundStyle(style.color)
             .font(.title2)
-            .accessibilityLabel(severityAccessibilityLabel)
-    }
-
-    private var severityAccessibilityLabel: String {
-        switch issue.severity {
-        case .error: return "Error"
-        case .warning: return "Warning"
-        case .info: return "Info"
-        }
-    }
-
-    private var severityIconName: String {
-        switch issue.severity {
-        case .error:
-            return "xmark.circle.fill"
-
-        case .warning:
-            return "exclamationmark.triangle.fill"
-
-        case .info:
-            return "info.circle.fill"
-        }
-    }
-
-    private var severityColor: Color {
-        switch issue.severity {
-        case .error:
-            return .red
-
-        case .warning:
-            return .orange
-
-        case .info:
-            return .blue
-        }
+            .accessibilityLabel(style.accessibilityLabel)
     }
 }
 

--- a/Tests/AppTests/IssueSeverityStyleTests.swift
+++ b/Tests/AppTests/IssueSeverityStyleTests.swift
@@ -1,0 +1,73 @@
+@testable import App
+@testable import Core
+import SwiftUI
+import Testing
+
+/// Laws over the severity-to-appearance mapping, which could not be stated while it lived as three
+/// `private var`s inside `LintIssueRow`.
+///
+/// `LintIssueRowTests` already covers this mapping — `errorSeverityIcon`, `warningSeverityIcon`,
+/// `infoSeverityIcon` — by building a whole row and inspecting it, one example per severity. Those
+/// stay; they check that the row actually *uses* the style. What they cannot express is anything
+/// about the severities as a set, because each of them looks at one case in isolation.
+///
+/// Both laws below are of that kind, and both are the sort a fourth severity would break silently.
+@Suite("Severity appearance")
+struct IssueSeverityStyleTests {
+
+    // MARK: - Totality
+
+    @Test("every severity has a style")
+    func everySeverityHasAStyle() {
+        // Vacuous today, and worth being honest that it is: the switch is exhaustive with no
+        // `default:`, so it cannot fail to produce a style, and adding a case is a compile error
+        // until every arm is written. That was checked by adding a fourth case — the build stopped
+        // in `LintConfigurationWriter` before any test ran. It stays as the statement of the
+        // property, not as the thing catching it.
+        for severity in IssueSeverity.allCases {
+            let style = IssueSeverityStyle(severity)
+            #expect(!style.iconName.isEmpty, "\(severity) has no icon")
+            #expect(!style.accessibilityLabel.isEmpty, "\(severity) has no label")
+        }
+    }
+
+    @Test("the accessibility label names the severity")
+    func labelNamesTheSeverity() {
+        // Ties the label to the enum rather than to a string literal typed three times. A new case
+        // whose label was copy-pasted from its neighbour fails here.
+        for severity in IssueSeverity.allCases {
+            #expect(IssueSeverityStyle(severity).accessibilityLabel == severity.rawValue.capitalized)
+        }
+    }
+
+    // MARK: - Distinctness, which is the law nobody had written
+
+    @Test("no two severities share an icon")
+    func iconsAreDistinct() {
+        // What the compiler cannot enforce. It makes you write an arm for a new severity; nothing
+        // makes that arm *differ* from its neighbours, and a copy-pasted arm is how a new case ends
+        // up drawn exactly like an old one. A severity row is read at a glance, so two identical
+        // ones are unreadable.
+        //
+        // For today's three cases this is not stronger than the example tests in
+        // `LintIssueRowTests` — duplicating warning's icon fails there too, because someone wrote
+        // an example naming `exclamationmark.triangle.fill`. It becomes stronger for the case
+        // nobody has written an example for yet, which is every case added after this one.
+        let icons = IssueSeverity.allCases.map { IssueSeverityStyle($0).iconName }
+        #expect(Set(icons).count == icons.count, "duplicate icon among \(icons)")
+    }
+
+    @Test("no two severities share a colour")
+    func coloursAreDistinct() {
+        let colours = IssueSeverity.allCases.map { IssueSeverityStyle($0).color }
+        #expect(Set(colours).count == colours.count, "duplicate colour among \(colours)")
+    }
+
+    @Test("no two severities share an accessibility label")
+    func labelsAreDistinct() {
+        // The one that matters most to a VoiceOver user: two severities read aloud identically is
+        // the same defect as two drawn identically, and less likely to be noticed by eye.
+        let labels = IssueSeverity.allCases.map { IssueSeverityStyle($0).accessibilityLabel }
+        #expect(Set(labels).count == labels.count, "duplicate label among \(labels)")
+    }
+}

--- a/Tests/CoreTests/Architecture/ArchitectureComputedPropertyViewTests.swift
+++ b/Tests/CoreTests/Architecture/ArchitectureComputedPropertyViewTests.swift
@@ -28,15 +28,22 @@ struct ArchitectureComputedPropertyViewTests {
     }
 
     // MARK: - Positive: flags computed properties returning some View
+    //
+    // Each fixture below carries a stored input the flagged property does not read. That is not
+    // decoration: the rule reports a property only when extracting it would give the child a
+    // narrower input surface than its parent, so a view with no inputs at all has nothing to
+    // narrow and is deliberately silent. The gate itself is specified in its own suite at the
+    // bottom of this file.
 
     @Test func testFlagsComputedPropertyReturningView() throws {
         let source = """
         struct ContentView: View {
+            let title: String
             var header: some View {
                 Text("Title")
             }
             var body: some View {
-                header
+                VStack { header; Text(title) }
             }
         }
         """
@@ -50,10 +57,11 @@ struct ArchitectureComputedPropertyViewTests {
     @Test func testFlagsMultipleComputedProperties() {
         let source = """
         struct MyView: View {
+            let title: String
             var header: some View { Text("H") }
             var footer: some View { Text("F") }
             var body: some View {
-                VStack { header; footer }
+                VStack { header; footer; Text(title) }
             }
         }
         """
@@ -67,11 +75,12 @@ struct ArchitectureComputedPropertyViewTests {
     @Test func testViewBuilderPropertyFlaggedAsInfo() throws {
         let source = """
         struct MyView: View {
+            let title: String
             @ViewBuilder
             var content: some View {
                 Text("Hello")
             }
-            var body: some View { content }
+            var body: some View { VStack { content; Text(title) } }
         }
         """
         let issues = filteredIssues(source)
@@ -83,8 +92,9 @@ struct ArchitectureComputedPropertyViewTests {
     @Test func testDetectsViewViaBodyHeuristic() {
         let source = """
         struct CustomView {
+            let title: String
             var body: some View {
-                Text("Body")
+                VStack { sidebar; Text(title) }
             }
             var sidebar: some View {
                 Text("Side")
@@ -138,11 +148,12 @@ struct ArchitectureComputedPropertyViewTests {
     @Test func testClassConformingToView() {
         let source = """
         class MyViewController: View {
+            let title: String
             var header: some View {
                 Text("Title")
             }
             var body: some View {
-                header
+                VStack { header; Text(title) }
             }
         }
         """
@@ -162,5 +173,123 @@ struct ArchitectureComputedPropertyViewTests {
         """
         let issues = filteredIssues(source)
         #expect(issues.isEmpty)
+    }
+}
+
+/// The gate that decides whether extracting a `some View` property would buy anything.
+///
+/// The rule's premise is real — an inlined computed property has no node in the view graph and
+/// re-evaluates whenever its parent does, while a child `View` struct can skip its `body` when its
+/// inputs compare equal. What the rule used to omit is that the child only skips when its inputs
+/// are *narrower*. A child taking everything its parent takes re-renders in lockstep: same work,
+/// one more type.
+///
+/// Measured on this project's own app before the gate: seven of eighteen findings had exactly that
+/// shape.
+@Suite("Extracting a view property must narrow its inputs")
+struct ComputedPropertyViewSubsetGateTests {
+
+    private func filteredIssues(_ source: String) -> [LintIssue] {
+        let visitor = ComputedPropertyViewVisitor(patternCategory: .architecture)
+        let syntax = Parser.parse(source: source)
+        visitor.setSourceLocationConverter(
+            SourceLocationConverter(fileName: "TestFile.swift", tree: syntax)
+        )
+        visitor.setFilePath("TestFile.swift")
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == RuleIdentifier.computedPropertyView }
+    }
+
+    @Test("a property reading fewer inputs than the view is flagged")
+    func narrowerPropertyIsFlagged() {
+        // `summary` ignores `isExpanded`, so a child taking only `issue` skips the re-render that
+        // toggling the disclosure causes. That is the whole benefit, and here it is available.
+        let issues = filteredIssues("""
+        struct Row: View {
+            let issue: String
+            @State private var isExpanded = false
+            var summary: some View { Text(issue) }
+            var body: some View {
+                VStack { summary; Toggle("", isOn: $isExpanded) }
+            }
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("summary") == true)
+    }
+
+    @Test("a property reading every input is not flagged")
+    func propertyUsingEveryInputIsNotFlagged() {
+        // Nothing to narrow: `everything` re-renders exactly when the view does.
+        #expect(filteredIssues("""
+        struct Row: View {
+            let issue: String
+            @State private var isExpanded = false
+            var everything: some View {
+                VStack { Text(issue); Text(isExpanded ? "open" : "shut") }
+            }
+            var body: some View { everything }
+        }
+        """).isEmpty)
+    }
+
+    @Test("a dependency reached through another property still counts")
+    func transitiveDependencyIsNotFlagged() {
+        // `wrapper` reads no input directly and would look input-free to a shallow check. It calls
+        // `toggle`, which reads `isExpanded`, so extracting it narrows nothing. Without following
+        // this edge every wrapper property in a view fires.
+        #expect(filteredIssues("""
+        struct Row: View {
+            let issue: String
+            @State private var isExpanded = false
+            var toggle: some View { Toggle(issue, isOn: $isExpanded) }
+            var wrapper: some View { HStack { toggle } }
+            var body: some View { wrapper }
+        }
+        """).isEmpty)
+    }
+
+    @Test("a view with no inputs has nothing to narrow")
+    func viewWithoutInputsIsNotFlagged() {
+        // A view whose value carries no inputs already compares equal to itself, so SwiftUI can
+        // skip it without help. Extracting a constant subview out of a constant view moves work
+        // rather than saving it.
+        #expect(filteredIssues("""
+        struct Banner: View {
+            var header: some View { Text("Title") }
+            var body: some View { header }
+        }
+        """).isEmpty)
+    }
+
+    @Test("a static constant is not an input")
+    func staticConstantIsNotAnInput() {
+        // `spacing` cannot change, so it is not something the view re-renders on. Counting it as an
+        // input would make `header` look like a strict subset of {spacing, title} and fire on a
+        // view that has only one real input.
+        let issues = filteredIssues("""
+        struct Banner: View {
+            static let spacing: Double = 8
+            let title: String
+            var header: some View { Text("Title").padding(Self.spacing) }
+            var body: some View { VStack { header; Text(title) } }
+        }
+        """)
+        #expect(issues.count == 1)
+    }
+
+    @Test("the message says why extraction would help")
+    func messageExplainsTheBenefit() {
+        // The old message asserted a benefit unconditionally. Now that the finding is conditional,
+        // the message has to carry the condition, or a reader cannot tell it from the old one.
+        let issues = filteredIssues("""
+        struct Row: View {
+            let issue: String
+            @State private var isExpanded = false
+            var summary: some View { Text(issue) }
+            var body: some View { VStack { summary; Toggle("", isOn: $isExpanded) } }
+        }
+        """)
+        #expect(issues.first?.message.contains("fewer of this view's inputs") == true)
     }
 }


### PR DESCRIPTION
An experiment with **Computed Property View**, the largest rule in the sweep — 341 findings across nine repositories, 18 of them in this repo. The result is mostly a finding about the sweep's own methodology, so the code change here is small and the reasoning is the point.

## What the rule asked for, and why I declined it

All 18 findings say the same thing: a computed property returning `some View` should become its own `View` struct, *"for better SwiftUI diffing."* Seven of them are in `LintIssueRow.swift` — `summaryRow`, `issueSummary`, `expandToggle`, `messageBody`, `locationsSection` and so on. Every one is a stack of `Text` and `Image` with no branching. Extracting them yields seven structs and changes no behaviour.

Two things worth recording:

- **The rule is category `architecture`, not `testability`.** Its stated benefit is rendering. Judging it by whether it produces property-test candidates — which is what the sweep's "which rules pay" note does — measures it against a claim it never made. That is a flaw in my framing, not in the rule.
- **In the same file, the rule is silent on the only three properties that contain logic.** `severityIconName`, `severityColor` and `severityAccessibilityLabel` return `String` and `Color`, not `some View`, so it does not see them. They are the testable content of the file.

So I did not extract the seven views. I lifted the three mappings instead.

## What changed

`IssueSeverityStyle` maps `IssueSeverity` to an icon, a colour, and a VoiceOver label. `IssueSeverity` gains `CaseIterable` so the mapping can be checked across every case.

Five tests. The two that matter are about the severities *as a set*, which no per-case example can express:

- **no two severities share an icon or a colour** — a severity row is read at a glance, and nothing in the code said error and warning had to look different
- **no two share an accessibility label** — the same defect for a VoiceOver user, and less likely to be noticed by eye

## What a reviewer should scrutinise

- **These laws are not stronger than the existing example tests today, and the tests say so.** `LintIssueRowTests` already asserts each severity's icon by name, so duplicating warning's arm fails there too — I checked. The laws become stronger for the *next* case added, which is the one nobody will write an example for. If you think that is too weak a justification for the change, that is the argument to make.
- **The compiler already covers more than I first assumed.** I tried to simulate a fourth severity to show the laws catching it; the build stopped in `LintConfigurationWriter` because the switches over `IssueSeverity` are exhaustive. So a new case cannot silently skip an arm — the residual risk is only that the arm *duplicates* an existing one, which is precisely what these laws cover and nothing else does. That narrows the claim, and I would rather state the narrow version.
- **`nonisolated` on the style.** The App target defaults to MainActor; a value type of pure data has no reason to be actor-bound, and binding it would stop a test constructing one off the main actor.
- **The three ViewInspector example tests are unchanged.** They now check that the row *uses* the style, which is a different and still worthwhile assertion.

## Measured — and it went the wrong way

- Computed Property View: **18 → 18**, as expected; I did not do what it asked.
- Prompts: **60 → 60**.
- Candidate census: **718 → 716**.

The census went **down by two**, because `severityIconName` and `severityAccessibilityLabel` were themselves counted as pure-function candidates and are now one initialiser, which the rule does not count. (`severityColor` was never counted — `Color` is not a return type it recognises.)

That is worth stating plainly: **the census counts pure declarations, not testable behaviour.** Consolidating two pure computed properties into one well-tested value type lowers it while raising what is actually under test. Any use of the census as a payoff metric rewards fragmenting logic into many small pure functions and penalises consolidating it — I will correct the sweep write-up accordingly.

3,400 tests pass; SwiftLint clean.