### PR TITLE
Report a view property only when extracting it would narrow its inputs

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift
@@ -3,14 +3,34 @@ import SwiftProjectLintModels
 import SwiftProjectLintVisitors
 import SwiftSyntax
 
-/// Detects computed properties that return `some View` inside View-conforming types.
+/// Detects computed properties returning `some View` whose extraction would actually buy something.
 ///
-/// Computed properties returning `some View` defeat SwiftUI's structural identity — they are
-/// re-evaluated on every parent update with no diffing. Extracting them into separate `View`
-/// structs gives SwiftUI a stable identity boundary and lets the child hold its own `@State`.
+/// The mechanism is real: a computed property returning `some View` is inlined into the parent's
+/// `body` and has no node of its own in the view graph, so it re-evaluates whenever the parent
+/// does. A child `View` struct gets an identity, can skip its `body` when its inputs compare equal,
+/// and can hold its own `@State`.
+///
+/// **The benefit is conditional, and the rule used to report it unconditionally.** A child only
+/// skips an update when its inputs are narrower than its parent's. Extract `SummaryRow(issue:)` out
+/// of a view that re-renders whenever `issue` changes and the child re-renders in lockstep — the
+/// same work, one more type. Measured on this project's own app, seven of the eighteen findings had
+/// exactly that shape.
+///
+/// So the property must depend on a **strict subset** of the enclosing type's stored inputs. That
+/// is a necessary condition for the diffing benefit, not a sufficient one — a two-line `Text` gains
+/// little either way — but it is the condition the rule can actually check, and it is what
+/// separates a property that can skip an update from one that never will.
+///
+/// Dependencies are followed **transitively** through the type's other computed properties: a
+/// property that reads nothing itself but calls one that reads `isExpanded` depends on
+/// `isExpanded`. Without that, every wrapper property looks input-free and every one of them fires.
 class ComputedPropertyViewVisitor: BasePatternVisitor {
     private var currentFilePath: String = ""
     private var isInsideViewType = false
+
+    /// Names of the view properties in the type currently being visited that pass the subset gate.
+    /// Computed once per type, because the answer depends on the type's other members.
+    private var firingNames: Set<String> = []
 
     required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
         super.init(pattern: pattern, viewMode: viewMode)
@@ -25,23 +45,27 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
     override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
         if conformsToView(node.inheritanceClause) || hasBodySomeView(node.memberBlock) {
             isInsideViewType = true
+            firingNames = Self.propertiesWorthExtracting(in: node.memberBlock)
         }
         return .visitChildren
     }
 
     override func visitPost(_ _: StructDeclSyntax) {
         isInsideViewType = false
+        firingNames = []
     }
 
     override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
         if conformsToView(node.inheritanceClause) || hasBodySomeView(node.memberBlock) {
             isInsideViewType = true
+            firingNames = Self.propertiesWorthExtracting(in: node.memberBlock)
         }
         return .visitChildren
     }
 
     override func visitPost(_ _: ClassDeclSyntax) {
         isInsideViewType = false
+        firingNames = []
     }
 
     // MARK: - Detect computed properties returning some View
@@ -53,7 +77,8 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
             guard let name = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
                   name != "body",
                   returnsSomeView(binding.typeAnnotation),
-                  binding.accessorBlock != nil else {
+                  binding.accessorBlock != nil,
+                  firingNames.contains(name) else {
                 continue
             }
 
@@ -67,8 +92,9 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
 
             addIssue(
                 severity: severity,
-                message: "Computed\(qualifier) property '\(name)' returns 'some View' — "
-                    + "extract into a separate View struct for better SwiftUI diffing",
+                message: "Computed\(qualifier) property '\(name)' returns 'some View' and depends "
+                    + "on fewer of this view's inputs than the view itself — extract it into a "
+                    + "separate View struct so SwiftUI can skip it when the inputs it ignores change",
                 filePath: currentFilePath,
                 lineNumber: getLineNumber(for: Syntax(node)),
                 suggestion: "Move '\(name)' into its own struct conforming to View",
@@ -76,6 +102,97 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
             )
         }
         return .skipChildren
+    }
+
+    // MARK: - The subset gate
+
+    /// Which `some View` properties in a type would gain a narrower input surface by extraction.
+    ///
+    /// Returns the properties whose transitive dependency on the type's stored properties is a
+    /// *strict* subset of those stored properties. A property depending on all of them re-renders
+    /// exactly when its parent does, so a child struct changes nothing; a type with no stored
+    /// properties at all has nothing to narrow, and yields nothing.
+    static func propertiesWorthExtracting(in memberBlock: MemberBlockSyntax) -> Set<String> {
+        var stored: Set<String> = []
+        var computedReferences: [String: Set<String>] = [:]
+        var viewProperties: Set<String> = []
+
+        for member in memberBlock.members {
+            guard let varDecl = member.decl.as(VariableDeclSyntax.self) else { continue }
+            let isStatic = varDecl.modifiers.contains { $0.name.tokenKind == .keyword(.static) }
+            for binding in varDecl.bindings {
+                guard let name = binding.pattern.as(IdentifierPatternSyntax.self)?
+                    .identifier.text else { continue }
+                guard let accessor = binding.accessorBlock else {
+                    // A stored property. `static let` is a constant, not an input the view
+                    // re-renders on, so it is not part of the surface.
+                    if !isStatic { stored.insert(name) }
+                    continue
+                }
+                computedReferences[name] = referencedNames(in: Syntax(accessor))
+                if name != "body", returnsSomeViewType(binding.typeAnnotation) {
+                    viewProperties.insert(name)
+                }
+            }
+        }
+        guard !stored.isEmpty else { return [] }
+
+        return viewProperties.filter { name in
+            let depends = resolvedDependencies(of: name, computed: computedReferences, stored: stored)
+            return depends.isSubset(of: stored) && depends.count < stored.count
+        }
+    }
+
+    /// The stored properties a computed property reaches, following the type's other computed
+    /// properties. A wrapper that reads nothing itself still depends on whatever it calls.
+    private static func resolvedDependencies(
+        of name: String,
+        computed: [String: Set<String>],
+        stored: Set<String>
+    ) -> Set<String> {
+        var seen: Set<String> = [name]
+        var pending = Array(computed[name] ?? [])
+        var result: Set<String> = []
+
+        while let next = pending.popLast() {
+            if stored.contains(next) { result.insert(next) }
+            guard !seen.contains(next) else { continue }
+            seen.insert(next)
+            if let further = computed[next] { pending.append(contentsOf: further) }
+        }
+        return result
+    }
+
+    private static func referencedNames(in node: Syntax) -> Set<String> {
+        var names: Set<String> = []
+        for child in node.children(viewMode: .sourceAccurate) {
+            if let reference = child.as(DeclReferenceExprSyntax.self) {
+                names.insert(stripped(reference.baseName.text))
+            }
+            if let member = child.as(MemberAccessExprSyntax.self),
+               member.base?.as(DeclReferenceExprSyntax.self)?.baseName.tokenKind
+                == .keyword(.self) {
+                names.insert(member.declName.baseName.text)
+            }
+            names.formUnion(referencedNames(in: child))
+        }
+        return names
+    }
+
+    /// `$isExpanded` and `isExpanded` are the same input.
+    ///
+    /// The projected value of a `@State` or `@Binding` parses as its own identifier, so a property
+    /// that writes through `$isExpanded` reads as depending on nothing. That is not academic: a
+    /// `Toggle(_:isOn:)` is the ordinary way to touch that state, and without this every wrapper
+    /// around one looked input-free and fired.
+    private static func stripped(_ name: String) -> String {
+        name.hasPrefix("$") ? String(name.dropFirst()) : name
+    }
+
+    private static func returnsSomeViewType(_ annotation: TypeAnnotationSyntax?) -> Bool {
+        guard let annotation,
+              let someType = annotation.type.as(SomeOrAnyTypeSyntax.self) else { return false }
+        return someType.constraint.trimmedDescription == "View"
     }
 
     // MARK: - Helpers

--- a/Tests/CoreTests/Architecture/ArchitectureComputedPropertyViewTests.swift
+++ b/Tests/CoreTests/Architecture/ArchitectureComputedPropertyViewTests.swift
@@ -28,15 +28,22 @@ struct ArchitectureComputedPropertyViewTests {
     }
 
     // MARK: - Positive: flags computed properties returning some View
+    //
+    // Each fixture below carries a stored input the flagged property does not read. That is not
+    // decoration: the rule reports a property only when extracting it would give the child a
+    // narrower input surface than its parent, so a view with no inputs at all has nothing to
+    // narrow and is deliberately silent. The gate itself is specified in its own suite at the
+    // bottom of this file.
 
     @Test func testFlagsComputedPropertyReturningView() throws {
         let source = """
         struct ContentView: View {
+            let title: String
             var header: some View {
                 Text("Title")
             }
             var body: some View {
-                header
+                VStack { header; Text(title) }
             }
         }
         """
@@ -50,10 +57,11 @@ struct ArchitectureComputedPropertyViewTests {
     @Test func testFlagsMultipleComputedProperties() {
         let source = """
         struct MyView: View {
+            let title: String
             var header: some View { Text("H") }
             var footer: some View { Text("F") }
             var body: some View {
-                VStack { header; footer }
+                VStack { header; footer; Text(title) }
             }
         }
         """
@@ -67,11 +75,12 @@ struct ArchitectureComputedPropertyViewTests {
     @Test func testViewBuilderPropertyFlaggedAsInfo() throws {
         let source = """
         struct MyView: View {
+            let title: String
             @ViewBuilder
             var content: some View {
                 Text("Hello")
             }
-            var body: some View { content }
+            var body: some View { VStack { content; Text(title) } }
         }
         """
         let issues = filteredIssues(source)
@@ -83,8 +92,9 @@ struct ArchitectureComputedPropertyViewTests {
     @Test func testDetectsViewViaBodyHeuristic() {
         let source = """
         struct CustomView {
+            let title: String
             var body: some View {
-                Text("Body")
+                VStack { sidebar; Text(title) }
             }
             var sidebar: some View {
                 Text("Side")
@@ -138,11 +148,12 @@ struct ArchitectureComputedPropertyViewTests {
     @Test func testClassConformingToView() {
         let source = """
         class MyViewController: View {
+            let title: String
             var header: some View {
                 Text("Title")
             }
             var body: some View {
-                header
+                VStack { header; Text(title) }
             }
         }
         """
@@ -162,5 +173,123 @@ struct ArchitectureComputedPropertyViewTests {
         """
         let issues = filteredIssues(source)
         #expect(issues.isEmpty)
+    }
+}
+
+/// The gate that decides whether extracting a `some View` property would buy anything.
+///
+/// The rule's premise is real — an inlined computed property has no node in the view graph and
+/// re-evaluates whenever its parent does, while a child `View` struct can skip its `body` when its
+/// inputs compare equal. What the rule used to omit is that the child only skips when its inputs
+/// are *narrower*. A child taking everything its parent takes re-renders in lockstep: same work,
+/// one more type.
+///
+/// Measured on this project's own app before the gate: seven of eighteen findings had exactly that
+/// shape.
+@Suite("Extracting a view property must narrow its inputs")
+struct ComputedPropertyViewSubsetGateTests {
+
+    private func filteredIssues(_ source: String) -> [LintIssue] {
+        let visitor = ComputedPropertyViewVisitor(patternCategory: .architecture)
+        let syntax = Parser.parse(source: source)
+        visitor.setSourceLocationConverter(
+            SourceLocationConverter(fileName: "TestFile.swift", tree: syntax)
+        )
+        visitor.setFilePath("TestFile.swift")
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == RuleIdentifier.computedPropertyView }
+    }
+
+    @Test("a property reading fewer inputs than the view is flagged")
+    func narrowerPropertyIsFlagged() {
+        // `summary` ignores `isExpanded`, so a child taking only `issue` skips the re-render that
+        // toggling the disclosure causes. That is the whole benefit, and here it is available.
+        let issues = filteredIssues("""
+        struct Row: View {
+            let issue: String
+            @State private var isExpanded = false
+            var summary: some View { Text(issue) }
+            var body: some View {
+                VStack { summary; Toggle("", isOn: $isExpanded) }
+            }
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("summary") == true)
+    }
+
+    @Test("a property reading every input is not flagged")
+    func propertyUsingEveryInputIsNotFlagged() {
+        // Nothing to narrow: `everything` re-renders exactly when the view does.
+        #expect(filteredIssues("""
+        struct Row: View {
+            let issue: String
+            @State private var isExpanded = false
+            var everything: some View {
+                VStack { Text(issue); Text(isExpanded ? "open" : "shut") }
+            }
+            var body: some View { everything }
+        }
+        """).isEmpty)
+    }
+
+    @Test("a dependency reached through another property still counts")
+    func transitiveDependencyIsNotFlagged() {
+        // `wrapper` reads no input directly and would look input-free to a shallow check. It calls
+        // `toggle`, which reads `isExpanded`, so extracting it narrows nothing. Without following
+        // this edge every wrapper property in a view fires.
+        #expect(filteredIssues("""
+        struct Row: View {
+            let issue: String
+            @State private var isExpanded = false
+            var toggle: some View { Toggle(issue, isOn: $isExpanded) }
+            var wrapper: some View { HStack { toggle } }
+            var body: some View { wrapper }
+        }
+        """).isEmpty)
+    }
+
+    @Test("a view with no inputs has nothing to narrow")
+    func viewWithoutInputsIsNotFlagged() {
+        // A view whose value carries no inputs already compares equal to itself, so SwiftUI can
+        // skip it without help. Extracting a constant subview out of a constant view moves work
+        // rather than saving it.
+        #expect(filteredIssues("""
+        struct Banner: View {
+            var header: some View { Text("Title") }
+            var body: some View { header }
+        }
+        """).isEmpty)
+    }
+
+    @Test("a static constant is not an input")
+    func staticConstantIsNotAnInput() {
+        // `spacing` cannot change, so it is not something the view re-renders on. Counting it as an
+        // input would make `header` look like a strict subset of {spacing, title} and fire on a
+        // view that has only one real input.
+        let issues = filteredIssues("""
+        struct Banner: View {
+            static let spacing: Double = 8
+            let title: String
+            var header: some View { Text("Title").padding(Self.spacing) }
+            var body: some View { VStack { header; Text(title) } }
+        }
+        """)
+        #expect(issues.count == 1)
+    }
+
+    @Test("the message says why extraction would help")
+    func messageExplainsTheBenefit() {
+        // The old message asserted a benefit unconditionally. Now that the finding is conditional,
+        // the message has to carry the condition, or a reader cannot tell it from the old one.
+        let issues = filteredIssues("""
+        struct Row: View {
+            let issue: String
+            @State private var isExpanded = false
+            var summary: some View { Text(issue) }
+            var body: some View { VStack { summary; Toggle("", isOn: $isExpanded) } }
+        }
+        """)
+        #expect(issues.first?.message.contains("fewer of this view's inputs") == true)
     }
 }


### PR DESCRIPTION
Follows the Computed Property View experiment. **341 → 251 findings across nine repositories, so 73% survive** — I had predicted most would not, and that prediction was wrong.

## The rule was right about the mechanism and silent about the condition

A computed property returning `some View` is inlined into the parent's `body` with no node of its own in the view graph, so it re-evaluates whenever the parent does. A child `View` struct gets an identity, can skip its `body` when its inputs compare equal, and can hold its own `@State`. That is real, and the rule stays.

What it never checked is whether any of it applies. **A child only skips an update when its inputs are narrower than its parent's.** Extract `SummaryRow(issue:)` from a view that re-renders whenever `issue` changes and the child re-renders in lockstep: same work, one more type. The rule fired on every `some View` property in a `View` type regardless, its only discrimination being that `@ViewBuilder` lowered the severity.

## The gate

A property is reported only when its transitive dependency on the enclosing type's stored properties is a **strict subset** of them.

- Necessary, not sufficient — a two-line `Text` gains little either way. But it is the condition that separates a property which *can* skip an update from one that never will.
- **Transitive**, through the type's other computed properties. A wrapper that reads nothing itself but calls one that reads `isExpanded` depends on `isExpanded`. Without this edge every wrapper property fires.
- A view with **no stored inputs** yields nothing: its value already compares equal to itself, so SwiftUI can skip it without help.
- `static let` is excluded — a constant is not something a view re-renders on.

## Measured

| repo | before | after |
|---|---|---|
| SwiftLintRuleStudio | 107 | 83 |
| SwiftLintRuleStudioTeam | 87 | 56 |
| SwiftAssist | 33 | 20 |
| SwiftFormatRuleStudio | 31 | 23 |
| MacCloud_client_iOS | 25 | 25 |
| SwiftMarkdownWiki | 21 | 18 |
| SwiftProjectLint | 18 | 14 |
| SwiftUMLStudio | 14 | 7 |
| MacCloud_client_MacOS | 5 | 5 |
| **total** | **341** | **251** |

Two repos lose nothing at all, one loses half. I would treat the spread as the interesting result rather than the total.

## What a reviewer should scrutinise

- **Whether 73% surviving means the gate is too weak.** This is the honest question. I expected a Concrete-Type-Usage-scale collapse and did not get one. Either the rule was less indiscriminate than one file suggested, or "strict subset" admits too much — a property depending on 4 of 5 inputs passes, and its benefit is marginal. A stricter form (say, depends on at most half) would cut deeper but I can see no principled defence of a threshold, so I did not invent one.
- **The hand check.** `LintIssueRow`'s seven findings were classified by hand *before* the gate was written. It silences exactly the three I predicted: `summaryRow`, which reads both of the view's inputs, and both properties of `ExpandedIssueContent`, whose single input each one reads. The four that remain each ignore an input the view has.
- **The five existing positive fixtures gained a stored input.** They are synthetic views with no inputs, which the gate is deliberately silent on. Rewriting a rule's tests to match a rule change is exactly how a mistake gets hidden, so: their purpose was detection, severity, `@ViewBuilder` and the body heuristic, and adding one input keeps every one of those assertions doing its original job. The gate has its own separate suite.
- **One bug the new tests caught.** `$isExpanded` parses as its own identifier, so a property writing through a `@State` projected value read as depending on nothing, and every wrapper around a `Toggle` fired. `$name` now resolves to `name`.

3,401 tests pass; SwiftLint clean.