### PR TITLE
Lift the severity-to-appearance mapping out of LintIssueRow

### DIFF
--- a/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/IssueSeverity.swift
+++ b/Packages/SwiftProjectLintModels/Sources/SwiftProjectLintModels/IssueSeverity.swift
@@ -16,7 +16,10 @@
 ///   - info: Provides informational messages or suggestions for improving code quality or consistency.
 ///
 /// - SeeAlso: `LintIssue`
-public enum IssueSeverity: String, Codable, Sendable {
+/// `CaseIterable` so that presentation mappings over severity can be checked exhaustively rather
+/// than one example per case. A three-case switch is exactly where a fourth case gets folded into
+/// an existing branch, and only a test that iterates `allCases` notices.
+public enum IssueSeverity: String, Codable, Sendable, CaseIterable {
     case error
     case warning
     case info

--- a/Sources/App/Views/IssueSeverityStyle.swift
+++ b/Sources/App/Views/IssueSeverityStyle.swift
@@ -1,0 +1,43 @@
+import Core
+import SwiftUI
+
+/// How a severity is drawn: an icon, a colour, and the label VoiceOver reads.
+///
+/// Lifted out of `LintIssueRow`, where the three mappings lived as `private var`s returning
+/// `String` and `Color`. They were reachable only by constructing the whole row and inspecting it,
+/// which is what `LintIssueRowTests` does — one example test per severity, three views built to
+/// check three constants.
+///
+/// The reason to lift them is not to save those three tests. It is that the laws worth stating
+/// about this mapping are about the severities *as a set*, and no per-case example can express
+/// them: that every case has a style at all, and that no two cases share an icon or a colour. A
+/// severity row whose error and warning look identical is unreadable, and nothing in the code said
+/// they had to differ.
+/// `nonisolated` because the App target defaults to `MainActor` isolation and this is pure data
+/// derived from an enum. Binding it to the main actor would mean a test could not build one off it,
+/// which is the whole reason it was lifted out of the view.
+nonisolated struct IssueSeverityStyle: Equatable {
+
+    let iconName: String
+    let color: Color
+    let accessibilityLabel: String
+
+    init(_ severity: IssueSeverity) {
+        switch severity {
+        case .error:
+            self.iconName = "xmark.circle.fill"
+            self.color = .red
+            self.accessibilityLabel = "Error"
+
+        case .warning:
+            self.iconName = "exclamationmark.triangle.fill"
+            self.color = .orange
+            self.accessibilityLabel = "Warning"
+
+        case .info:
+            self.iconName = "info.circle.fill"
+            self.color = .blue
+            self.accessibilityLabel = "Info"
+        }
+    }
+}

--- a/Sources/App/Views/LintIssueRow.swift
+++ b/Sources/App/Views/LintIssueRow.swift
@@ -89,44 +89,11 @@ struct LintIssueRow: View {
     }
 
     private var severityIcon: some View {
-        Image(systemName: severityIconName)
-            .foregroundStyle(severityColor)
+        let style = IssueSeverityStyle(issue.severity)
+        return Image(systemName: style.iconName)
+            .foregroundStyle(style.color)
             .font(.title2)
-            .accessibilityLabel(severityAccessibilityLabel)
-    }
-
-    private var severityAccessibilityLabel: String {
-        switch issue.severity {
-        case .error: return "Error"
-        case .warning: return "Warning"
-        case .info: return "Info"
-        }
-    }
-
-    private var severityIconName: String {
-        switch issue.severity {
-        case .error:
-            return "xmark.circle.fill"
-
-        case .warning:
-            return "exclamationmark.triangle.fill"
-
-        case .info:
-            return "info.circle.fill"
-        }
-    }
-
-    private var severityColor: Color {
-        switch issue.severity {
-        case .error:
-            return .red
-
-        case .warning:
-            return .orange
-
-        case .info:
-            return .blue
-        }
+            .accessibilityLabel(style.accessibilityLabel)
     }
 }
 

--- a/Tests/AppTests/IssueSeverityStyleTests.swift
+++ b/Tests/AppTests/IssueSeverityStyleTests.swift
@@ -1,0 +1,73 @@
+@testable import App
+@testable import Core
+import SwiftUI
+import Testing
+
+/// Laws over the severity-to-appearance mapping, which could not be stated while it lived as three
+/// `private var`s inside `LintIssueRow`.
+///
+/// `LintIssueRowTests` already covers this mapping — `errorSeverityIcon`, `warningSeverityIcon`,
+/// `infoSeverityIcon` — by building a whole row and inspecting it, one example per severity. Those
+/// stay; they check that the row actually *uses* the style. What they cannot express is anything
+/// about the severities as a set, because each of them looks at one case in isolation.
+///
+/// Both laws below are of that kind, and both are the sort a fourth severity would break silently.
+@Suite("Severity appearance")
+struct IssueSeverityStyleTests {
+
+    // MARK: - Totality
+
+    @Test("every severity has a style")
+    func everySeverityHasAStyle() {
+        // Vacuous today, and worth being honest that it is: the switch is exhaustive with no
+        // `default:`, so it cannot fail to produce a style, and adding a case is a compile error
+        // until every arm is written. That was checked by adding a fourth case — the build stopped
+        // in `LintConfigurationWriter` before any test ran. It stays as the statement of the
+        // property, not as the thing catching it.
+        for severity in IssueSeverity.allCases {
+            let style = IssueSeverityStyle(severity)
+            #expect(!style.iconName.isEmpty, "\(severity) has no icon")
+            #expect(!style.accessibilityLabel.isEmpty, "\(severity) has no label")
+        }
+    }
+
+    @Test("the accessibility label names the severity")
+    func labelNamesTheSeverity() {
+        // Ties the label to the enum rather than to a string literal typed three times. A new case
+        // whose label was copy-pasted from its neighbour fails here.
+        for severity in IssueSeverity.allCases {
+            #expect(IssueSeverityStyle(severity).accessibilityLabel == severity.rawValue.capitalized)
+        }
+    }
+
+    // MARK: - Distinctness, which is the law nobody had written
+
+    @Test("no two severities share an icon")
+    func iconsAreDistinct() {
+        // What the compiler cannot enforce. It makes you write an arm for a new severity; nothing
+        // makes that arm *differ* from its neighbours, and a copy-pasted arm is how a new case ends
+        // up drawn exactly like an old one. A severity row is read at a glance, so two identical
+        // ones are unreadable.
+        //
+        // For today's three cases this is not stronger than the example tests in
+        // `LintIssueRowTests` — duplicating warning's icon fails there too, because someone wrote
+        // an example naming `exclamationmark.triangle.fill`. It becomes stronger for the case
+        // nobody has written an example for yet, which is every case added after this one.
+        let icons = IssueSeverity.allCases.map { IssueSeverityStyle($0).iconName }
+        #expect(Set(icons).count == icons.count, "duplicate icon among \(icons)")
+    }
+
+    @Test("no two severities share a colour")
+    func coloursAreDistinct() {
+        let colours = IssueSeverity.allCases.map { IssueSeverityStyle($0).color }
+        #expect(Set(colours).count == colours.count, "duplicate colour among \(colours)")
+    }
+
+    @Test("no two severities share an accessibility label")
+    func labelsAreDistinct() {
+        // The one that matters most to a VoiceOver user: two severities read aloud identically is
+        // the same defect as two drawn identically, and less likely to be noticed by eye.
+        let labels = IssueSeverity.allCases.map { IssueSeverityStyle($0).accessibilityLabel }
+        #expect(Set(labels).count == labels.count, "duplicate label among \(labels)")
+    }
+}


### PR DESCRIPTION
Reopened from a clean branch — the original PR #130 had the Computed Property View rule narrowing accidentally committed onto it, bundling two unrelated changes. That narrowing now lives on its own in **#131**; this PR is the two commits it should always have been.

An experiment with **Computed Property View**, the largest rule in the sweep — 341 findings across nine repositories, 18 of them in this repo.

## What the rule asked for, and why I declined it

All 18 findings say the same thing: a computed property returning `some View` should become its own `View` struct, *"for better SwiftUI diffing."* Seven are in `LintIssueRow.swift` — `summaryRow`, `issueSummary`, `expandToggle`, `messageBody`, `locationsSection`. Every one is a stack of `Text` and `Image` with no branching, taking the whole model the parent already has.

Two things worth recording:

- **The rule is category `architecture`, not `testability`.** Its stated benefit is rendering. Judging it by whether it produces property-test candidates measures it against a claim it never made — that was a flaw in how I framed the sweep, not in the rule. (The rule's real defect, that it never checked whether extraction would help, is fixed separately in #131.)
- **In the same file the rule is silent on the only three properties that contain logic.** `severityIconName`, `severityColor` and `severityAccessibilityLabel` return `String` and `Color`, not `some View`, so it passes over them.

So I did not extract the seven views. I lifted the three mappings instead.

## What changed

`IssueSeverityStyle` maps `IssueSeverity` to an icon, a colour and a VoiceOver label. `IssueSeverity` gains `CaseIterable` so the mapping can be checked across every case.

Five tests. The two that matter are about the severities *as a set*, which no per-case example can express:

- **no two severities share an icon or a colour** — a severity row is read at a glance, and nothing in the code said error and warning had to look different
- **no two share an accessibility label** — the same defect for a VoiceOver user, and less likely to be caught by eye

## What a reviewer should scrutinise

- **These laws are not stronger than the existing example tests today, and the tests say so.** `LintIssueRowTests` already asserts each severity's icon by name, so duplicating warning's arm fails there too — I checked. They become stronger for the *next* case added, which is the one nobody will write an example for. If that is too thin a justification, that is the argument to make.
- **The compiler already covers more than I assumed.** I tried to simulate a fourth severity to watch the laws catch it; the build stopped in `LintConfigurationWriter`, because the switches over `IssueSeverity` are exhaustive. A new case therefore cannot silently skip an arm — the residual risk is only that the arm *duplicates* an existing one, which is what these laws cover and nothing else does. That narrows the claim, and the narrow version is the one worth stating.
- **`nonisolated` on the style.** The App target defaults to MainActor; a value type of pure data has no reason to be actor-bound, and binding it would stop a test constructing one off the main actor — the reason it was lifted.
- **The three ViewInspector example tests are unchanged.** They now assert that the row *uses* the style, which is a different and still worthwhile thing to check.

## Measured — and it went the wrong way

- Computed Property View: **18 → 18**, as expected; I did not do what it asked.
- Prompts: **60 → 60**.
- Candidate census: **718 → 716**.

The census went **down by two**: `severityIconName` and `severityAccessibilityLabel` were themselves counted as pure-function candidates and are now one initialiser, which the rule does not count. (`severityColor` was never counted — `Color` is not a return type it recognises.)

That is worth stating plainly: **the census counts pure declarations, not testable behaviour.** Consolidating two pure computed properties into one well-tested value type lowers it while raising what is actually under test. Any use of the census as a payoff metric rewards fragmenting logic into many small pure functions and penalises consolidating it.

3,400 tests pass; SwiftLint clean.