### PR TITLE
Stop reporting a view property that supplies a dialog's buttons

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift
@@ -113,34 +113,111 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
     /// exactly when its parent does, so a child struct changes nothing; a type with no stored
     /// properties at all has nothing to narrow, and yields nothing.
     static func propertiesWorthExtracting(in memberBlock: MemberBlockSyntax) -> Set<String> {
+        let members = properties(of: memberBlock)
+        guard !members.stored.isEmpty else { return [] }
+
+        let buttonCollections = namesUsedAsButtonCollections(in: memberBlock)
+
+        return members.viewProperties.filter { name in
+            guard !buttonCollections.contains(name) else { return false }
+            let depends = resolvedDependencies(
+                of: name, computed: members.computedReferences, stored: members.stored
+            )
+            return depends.isSubset(of: members.stored) && depends.count < members.stored.count
+        }
+    }
+
+    private struct TypeProperties {
         var stored: Set<String> = []
         var computedReferences: [String: Set<String>] = [:]
         var viewProperties: Set<String> = []
+    }
 
+    /// The type's stored inputs, what each computed property references, and which of them return
+    /// `some View`.
+    private static func properties(of memberBlock: MemberBlockSyntax) -> TypeProperties {
+        var result = TypeProperties()
         for member in memberBlock.members {
             guard let varDecl = member.decl.as(VariableDeclSyntax.self) else { continue }
             let isStatic = varDecl.modifiers.contains { $0.name.tokenKind == .keyword(.static) }
             for binding in varDecl.bindings {
-                guard let name = binding.pattern.as(IdentifierPatternSyntax.self)?
-                    .identifier.text else { continue }
-                guard let accessor = binding.accessorBlock else {
-                    // A stored property. `static let` is a constant, not an input the view
-                    // re-renders on, so it is not part of the surface.
-                    if !isStatic { stored.insert(name) }
-                    continue
-                }
-                computedReferences[name] = referencedNames(in: Syntax(accessor))
-                if name != "body", returnsSomeViewType(binding.typeAnnotation) {
-                    viewProperties.insert(name)
-                }
+                record(binding, isStatic: isStatic, into: &result)
             }
         }
-        guard !stored.isEmpty else { return [] }
+        return result
+    }
 
-        return viewProperties.filter { name in
-            let depends = resolvedDependencies(of: name, computed: computedReferences, stored: stored)
-            return depends.isSubset(of: stored) && depends.count < stored.count
+    private static func record(
+        _ binding: PatternBindingSyntax, isStatic: Bool, into result: inout TypeProperties
+    ) {
+        guard let name = binding.pattern.as(IdentifierPatternSyntax.self)?
+            .identifier.text else { return }
+        guard let accessor = binding.accessorBlock else {
+            // A stored property. `static let` is a constant, not an input the view re-renders on,
+            // so it is not part of the surface.
+            if !isStatic { result.stored.insert(name) }
+            return
         }
+        result.computedReferences[name] = referencedNames(in: Syntax(accessor))
+        if name != "body", returnsSomeViewType(binding.typeAnnotation) {
+            result.viewProperties.insert(name)
+        }
+    }
+
+    /// APIs whose closure is a **collection of buttons**, not an arbitrary view.
+    ///
+    /// `confirmationDialog(actions:)`, `alert(actions:)`, `Menu(content:)` and `contextMenu` read
+    /// the buttons out of the builder they are handed. A `View` struct wrapping those buttons is a
+    /// container these APIs are not specified to accept, so "extract this into its own View" is not
+    /// behaviour-preserving here — it is the one place where following this rule can change what
+    /// the app does rather than only how it redraws.
+    ///
+    /// Found on MacCloud_client_iOS, where `FileListView` had three such properties and the rule
+    /// reported all three. It marked them `info` for carrying `@ViewBuilder`, which is not the same
+    /// thing as declining to report them.
+    private static let buttonCollectionBuilders: Set<String> = [
+        "confirmationDialog", "alert", "actionSheet", "Menu", "contextMenu"
+    ]
+
+    /// Property names referenced inside one of those builders.
+    ///
+    /// Only the *arguments and trailing closures* are searched, never the called expression. For a
+    /// modifier the called expression holds the receiver — the entire view it is applied to — and
+    /// walking it would sweep up every name in `body`.
+    ///
+    /// Deliberately coarse in one direction: a name appearing in `alert`'s `message:` closure is
+    /// spared along with the ones in `actions:`. Sparing a property costs a finding; reporting one
+    /// whose extraction breaks a dialog costs a working app, so the imprecision is pointed the safe
+    /// way.
+    private static func namesUsedAsButtonCollections(in memberBlock: MemberBlockSyntax) -> Set<String> {
+        var found: Set<String> = []
+        collectButtonCollectionNames(in: Syntax(memberBlock), into: &found)
+        return found
+    }
+
+    private static func collectButtonCollectionNames(in node: Syntax, into found: inout Set<String>) {
+        for child in node.children(viewMode: .sourceAccurate) {
+            if let call = child.as(FunctionCallExprSyntax.self), isButtonCollection(call) {
+                found.formUnion(referencedNames(in: Syntax(call.arguments)))
+                if let trailing = call.trailingClosure {
+                    found.formUnion(referencedNames(in: Syntax(trailing)))
+                }
+                for extra in call.additionalTrailingClosures {
+                    found.formUnion(referencedNames(in: Syntax(extra.closure)))
+                }
+            }
+            collectButtonCollectionNames(in: child, into: &found)
+        }
+    }
+
+    private static func isButtonCollection(_ call: FunctionCallExprSyntax) -> Bool {
+        if let member = call.calledExpression.as(MemberAccessExprSyntax.self) {
+            return buttonCollectionBuilders.contains(member.declName.baseName.text)
+        }
+        if let reference = call.calledExpression.as(DeclReferenceExprSyntax.self) {
+            return buttonCollectionBuilders.contains(reference.baseName.text)
+        }
+        return false
     }
 
     /// The stored properties a computed property reaches, following the type's other computed

--- a/Tests/CoreTests/Architecture/ArchitectureComputedPropertyViewTests.swift
+++ b/Tests/CoreTests/Architecture/ArchitectureComputedPropertyViewTests.swift
@@ -293,3 +293,164 @@ struct ComputedPropertyViewSubsetGateTests {
         #expect(issues.first?.message.contains("fewer of this view's inputs") == true)
     }
 }
+
+/// A property that supplies a dialog's buttons is not extractable into a `View` struct.
+///
+/// `confirmationDialog(actions:)`, `alert(actions:)`, `Menu(content:)` and `contextMenu` read the
+/// buttons out of the builder they are handed. Wrapping them in a `View` interposes a container
+/// those APIs are not specified to accept, so following the rule's advice there changes what the
+/// app does rather than only how it redraws — the one place this rule could break something.
+///
+/// Found on MacCloud_client_iOS: `FileListView` had three such properties and the rule reported
+/// all three. Lowering them to `info` for carrying `@ViewBuilder` is not the same as declining.
+@Suite("A dialog's buttons are not an extractable subview")
+struct ComputedPropertyViewButtonCollectionTests {
+
+    private func filteredIssues(_ source: String) -> [LintIssue] {
+        let visitor = ComputedPropertyViewVisitor(patternCategory: .architecture)
+        let syntax = Parser.parse(source: source)
+        visitor.setSourceLocationConverter(
+            SourceLocationConverter(fileName: "TestFile.swift", tree: syntax)
+        )
+        visitor.setFilePath("TestFile.swift")
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == RuleIdentifier.computedPropertyView }
+    }
+
+    @Test("a confirmation dialog's actions are not reported")
+    func confirmationDialogActionsAreNotReported() {
+        #expect(filteredIssues("""
+        struct Row: View {
+            let title: String
+            @State private var showing = false
+            @ViewBuilder
+            private var fileActions: some View {
+                Button("Delete", role: .destructive) { }
+                Button("Cancel", role: .cancel) { }
+            }
+            var body: some View {
+                Text(title)
+                    .confirmationDialog("Pick", isPresented: $showing) { fileActions }
+            }
+        }
+        """).isEmpty)
+    }
+
+    @Test("an alert's actions are not reported")
+    func alertActionsAreNotReported() {
+        #expect(filteredIssues("""
+        struct Row: View {
+            let title: String
+            @State private var showing = false
+            @ViewBuilder
+            private var deleteActions: some View {
+                Button("Delete", role: .destructive) { }
+            }
+            var body: some View {
+                Text(title)
+                    .alert("Sure?", isPresented: $showing) { deleteActions }
+            }
+        }
+        """).isEmpty)
+    }
+
+    @Test("a menu's content is not reported")
+    func menuContentIsNotReported() {
+        #expect(filteredIssues("""
+        struct Row: View {
+            let title: String
+            @State private var showing = false
+            @ViewBuilder
+            private var moreMenuItems: some View {
+                Button("Upload") { }
+                Button("New Folder") { }
+            }
+            var body: some View {
+                HStack {
+                    Text(title)
+                    Menu(content: { moreMenuItems }, label: { Text("More") })
+                    Toggle("", isOn: $showing)
+                }
+            }
+        }
+        """).isEmpty)
+    }
+
+    // MARK: - The controls
+
+    @Test("the same property in ordinary content is still reported")
+    func ordinaryContentIsStillReported() {
+        // The control the gate needs, and the reason it keys on the *consumer* rather than on
+        // `@ViewBuilder`: an identical property placed in a `VStack` has no dialog to break.
+        let issues = filteredIssues("""
+        struct Row: View {
+            let title: String
+            @State private var showing = false
+            @ViewBuilder
+            private var buttons: some View {
+                Button("Delete", role: .destructive) { }
+            }
+            var body: some View {
+                VStack {
+                    buttons
+                    Text(title)
+                    Toggle("", isOn: $showing)
+                }
+            }
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("buttons") == true)
+    }
+
+    @Test("a sibling not used by the dialog is still reported")
+    func siblingOutsideTheDialogIsStillReported() {
+        // The gate must spare the dialog's own builder without silencing the whole type.
+        let issues = filteredIssues("""
+        struct Row: View {
+            let title: String
+            @State private var showing = false
+            @ViewBuilder
+            private var fileActions: some View {
+                Button("Delete", role: .destructive) { }
+            }
+            private var header: some View { Text("Files") }
+            var body: some View {
+                VStack {
+                    header
+                    Text(title)
+                    Toggle("", isOn: $showing)
+                }
+                .confirmationDialog("Pick", isPresented: $showing) { fileActions }
+            }
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("header") == true)
+    }
+
+    @Test("the receiver of a dialog modifier is not swept up")
+    func modifierReceiverIsNotSweptUp() {
+        // `.confirmationDialog` is a member call whose *called expression* holds the entire view it
+        // is applied to. Searching that instead of the arguments would collect every name in
+        // `body`, and the rule would go silent on any file containing one dialog.
+        let issues = filteredIssues("""
+        struct Row: View {
+            let title: String
+            @State private var showing = false
+            private var summary: some View { Text(title) }
+            @ViewBuilder
+            private var actions: some View { Button("OK") { } }
+            var body: some View {
+                VStack {
+                    summary
+                    Toggle("", isOn: $showing)
+                }
+                .confirmationDialog("Pick", isPresented: $showing) { actions }
+            }
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("summary") == true)
+    }
+}


### PR DESCRIPTION
The second gate for **Computed Property View**, found while working the rule on MacCloud_client_iOS.

## Why this one matters more than the input-narrowing gate

`confirmationDialog(actions:)`, `alert(actions:)`, `Menu(content:)` and `contextMenu` read the *buttons* out of the builder they are handed. Wrapping those buttons in a `View` struct interposes a container the APIs are not specified to accept.

Every other finding this rule produces is at worst useless — a refactor that buys nothing. **This is the one shape where following its advice can change what the app does**, not just how it redraws.

`FileListView` had three of them (`moreMenuItems`, `fileActions`, `deleteConfirmationActions`) and the rule reported all three. It marked them `info` for carrying `@ViewBuilder`, which is not the same as declining.

## The gate

Keys on the **consumer**, not on `@ViewBuilder`. An identical property placed in a `VStack` has no dialog to break and is still reported — that control is in the suite, and it is why the attribute is the wrong thing to gate on.

Only the arguments and trailing closures of such a call are searched, never the called expression. For a modifier the called expression holds the receiver, i.e. the entire view it is applied to; walking it would collect every name in `body` and silence the rule on any file containing a single dialog. There is a test named for exactly that.

## Measured

Gate off against gate on, over identical code, across the nine repositories where the rule fires: **230 → 224**.

All six suppressions were checked by hand and all six are genuine:

| finding | consumer |
|---|---|
| `moreMenuItems`, `fileActions`, `deleteConfirmationActions` | `Menu`, `confirmationDialog`, `alert` |
| `errorAlertActions` | an alert |
| `contextMenuItems` | a context menu |
| `browserEntry` | sits inside `Menu { }` in `RulePresetPicker` |

`browserEntry` is the one I would have guessed wrong from its name; it is a menu item.

## What a reviewer should scrutinise

- **The deliberate over-suppression.** A name appearing in `alert`'s `message:` closure is spared along with the ones in `actions:`, because the search is per-call rather than per-argument-label. Sparing a property costs a finding; reporting one whose extraction breaks a dialog costs a working app. If you would rather have the precision, keying on the `actions:`/`content:` labels specifically is the change to ask for.
- **I did not demonstrate the breakage.** The claim that a wrapped `View` loses its dialog buttons is reasoned from the APIs' contracts, not from a failing UI test. It is the same caveat I flagged on the MacCloud PR.
- **A measurement correction.** An earlier diff of mine appeared to show five suppressions in SwiftLintRuleStudio. Two were code drift — that repo's `main` had moved since my baseline was captured — and I only caught it because two of the five had names that did not sound like menu items. The 230 → 224 above is a clean A/B on identical code.

3,412 tests pass; SwiftLint clean. `propertiesWorthExtracting` is split to keep cyclomatic complexity under the limit the extra guard pushed it over.