### PR TITLE
Report a view property only when the extracted child can actually be skipped

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift
@@ -119,7 +119,8 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
         let buttonCollections = namesUsedAsButtonCollections(in: memberBlock)
 
         return members.viewProperties.filter { name in
-            guard !buttonCollections.contains(name) else { return false }
+            guard !buttonCollections.contains(name),
+                  !requiresCapture(name, in: members) else { return false }
             let depends = resolvedDependencies(
                 of: name, computed: members.computedReferences, stored: members.stored
             )
@@ -127,10 +128,92 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
         }
     }
 
+    /// Whether extracting this property would force a `Binding` or a capturing closure across the
+    /// boundary — in which case SwiftUI cannot skip the child and the extraction buys nothing.
+    ///
+    /// **Measured, not assumed.** A harness counting `body` evaluations while changing state no
+    /// child reads (iOS 26.5, three changes): a child with no inputs, a value input, or a
+    /// *non-capturing* closure re-rendered **0** times; a child holding a `@Binding` or a
+    /// *capturing* closure re-rendered **3** — once per change, exactly as often as the inlined
+    /// property it replaced.
+    ///
+    /// The distinction is capture, not closures. `action: { }` compiles to one static function and
+    /// compares equal; `action: { showingSheet = true }` allocates a fresh context on every parent
+    /// body run, so the child value never compares equal. A `Binding` carries a getter and setter
+    /// and behaves the same way.
+    ///
+    /// Three shapes force it: reading a stored property's projected value (`$name`), assigning to
+    /// one, or calling one of the type's own methods. Followed transitively — a property composing
+    /// children that each need a binding needs to pass those bindings down.
+    private static func requiresCapture(_ name: String, in members: TypeProperties) -> Bool {
+        var seen: Set<String> = []
+        var pending = [name]
+
+        while let current = pending.popLast() {
+            guard seen.insert(current).inserted else { continue }
+            let captures = members.capturesFor[current] ?? []
+            if !captures.isDisjoint(with: members.stored) { return true }
+            let referenced = members.computedReferences[current] ?? []
+            if !referenced.isDisjoint(with: members.instanceMethods) { return true }
+            pending.append(contentsOf: referenced.filter { members.computedReferences[$0] != nil })
+        }
+        return false
+    }
+
+    /// The names on the left of the first `=` in an unfolded operator sequence.
+    private static func assignedNames(in sequence: SequenceExprSyntax) -> Set<String> {
+        var names: Set<String> = []
+        for element in sequence.elements {
+            if element.is(AssignmentExprSyntax.self) { return names }
+            names.formUnion(referencedNames(in: Syntax(element)))
+            if let reference = element.as(DeclReferenceExprSyntax.self) {
+                names.insert(stripped(reference.baseName.text))
+            }
+            if let member = element.as(MemberAccessExprSyntax.self) {
+                names.insert(member.declName.baseName.text)
+            }
+        }
+        return []
+    }
+
+    /// Names used as a projected value (`$name`) or written to.
+    ///
+    /// `referencedNames` cannot answer this: it strips the `$` so that `$isExpanded` counts as a
+    /// dependency on `isExpanded`, which is right for the narrowing gate and loses exactly the
+    /// distinction needed here.
+    private static func projectedAndAssignedNames(in node: Syntax) -> Set<String> {
+        var names: Set<String> = []
+        for child in node.children(viewMode: .sourceAccurate) {
+            if let reference = child.as(DeclReferenceExprSyntax.self),
+               reference.baseName.text.hasPrefix("$") {
+                names.insert(String(reference.baseName.text.dropFirst()))
+            }
+            // `showing = true` parses as an *unfolded* `SequenceExprSyntax` — the plain parser
+            // does not fold operators, so `InfixOperatorExprSyntax` never appears here. The names
+            // before the first `=` are the ones being written to.
+            if let sequence = child.as(SequenceExprSyntax.self) {
+                names.formUnion(assignedNames(in: sequence))
+            }
+            if let call = child.as(FunctionCallExprSyntax.self),
+               let member = call.calledExpression.as(MemberAccessExprSyntax.self),
+               member.declName.baseName.text == "toggle", let base = member.base {
+                names.formUnion(referencedNames(in: Syntax(base)))
+            }
+            names.formUnion(projectedAndAssignedNames(in: child))
+        }
+        return names
+    }
+
     private struct TypeProperties {
         var stored: Set<String> = []
         var computedReferences: [String: Set<String>] = [:]
         var viewProperties: Set<String> = []
+        /// Non-static methods of the enclosing type. Referencing one means the extracted child
+        /// would have to be handed a closure that captures the parent.
+        var instanceMethods: Set<String> = []
+        /// Per computed property: the names it uses as a projected value (`$name`) and the names
+        /// it assigns to. Both force a `Binding` or a capturing closure across the boundary.
+        var capturesFor: [String: Set<String>] = [:]
     }
 
     /// The type's stored inputs, what each computed property references, and which of them return
@@ -138,6 +221,10 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
     private static func properties(of memberBlock: MemberBlockSyntax) -> TypeProperties {
         var result = TypeProperties()
         for member in memberBlock.members {
+            if let function = member.decl.as(FunctionDeclSyntax.self),
+               !function.modifiers.contains(where: { $0.name.tokenKind == .keyword(.static) }) {
+                result.instanceMethods.insert(function.name.text)
+            }
             guard let varDecl = member.decl.as(VariableDeclSyntax.self) else { continue }
             let isStatic = varDecl.modifiers.contains { $0.name.tokenKind == .keyword(.static) }
             for binding in varDecl.bindings {
@@ -159,6 +246,7 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
             return
         }
         result.computedReferences[name] = referencedNames(in: Syntax(accessor))
+        result.capturesFor[name] = projectedAndAssignedNames(in: Syntax(accessor))
         if name != "body", returnsSomeViewType(binding.typeAnnotation) {
             result.viewProperties.insert(name)
         }

--- a/Tests/CoreTests/Architecture/ArchitectureComputedPropertyViewTests.swift
+++ b/Tests/CoreTests/Architecture/ArchitectureComputedPropertyViewTests.swift
@@ -454,3 +454,153 @@ struct ComputedPropertyViewButtonCollectionTests {
         #expect(issues.first?.message.contains("summary") == true)
     }
 }
+
+/// A child that must be handed a `Binding` or a capturing closure cannot be skipped, so extracting
+/// it buys nothing.
+///
+/// **Measured rather than assumed.** A harness counting `body` evaluations while changing state no
+/// child reads (iOS 26.5, three changes): a child with no inputs, a value input, or a
+/// *non-capturing* closure re-rendered **0** times; a child holding a `@Binding` or a *capturing*
+/// closure re-rendered **3** — once per change, exactly as often as the inlined property it
+/// replaced.
+///
+/// The distinction is capture, not closures. `action: { }` compiles to one static function and
+/// compares equal; `action: { showingSheet = true }` allocates a fresh context on every parent body
+/// run. The first version of that harness used the non-capturing form and reported the opposite
+/// conclusion, which is why the shape matters more than the type.
+@Suite("A child needing a binding or a capturing closure is not worth extracting")
+struct ComputedPropertyViewCaptureTests {
+
+    private func filteredIssues(_ source: String) -> [LintIssue] {
+        let visitor = ComputedPropertyViewVisitor(patternCategory: .architecture)
+        let syntax = Parser.parse(source: source)
+        visitor.setSourceLocationConverter(
+            SourceLocationConverter(fileName: "TestFile.swift", tree: syntax)
+        )
+        visitor.setFilePath("TestFile.swift")
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == RuleIdentifier.computedPropertyView }
+    }
+
+    @Test("a property writing through a projected value is not reported")
+    func projectedValueIsNotReported() {
+        // `$draft` would have to cross the boundary as a `@Binding`, which re-renders every time.
+        #expect(filteredIssues("""
+        struct Form: View {
+            let title: String
+            @State private var draft = ""
+            @State private var other = false
+            private var field: some View { TextField("", text: $draft) }
+            var body: some View {
+                VStack { field; Text(title); Toggle("", isOn: $other) }
+            }
+        }
+        """).isEmpty)
+    }
+
+    @Test("a property assigning to state is not reported")
+    func assignmentIsNotReported() {
+        // The assignment has to become a closure the parent supplies, and it captures.
+        #expect(filteredIssues("""
+        struct Form: View {
+            let title: String
+            @State private var showing = false
+            @State private var other = false
+            private var opener: some View {
+                Button("Configure") { showing = true }
+            }
+            var body: some View {
+                VStack { opener; Text(title); Toggle("", isOn: $other) }
+            }
+        }
+        """).isEmpty)
+    }
+
+    @Test("a property calling one of the view's own methods is not reported")
+    func instanceMethodCallIsNotReported() {
+        // `submit` captures the view. This is the `Button(action: performLogin)` shape.
+        #expect(filteredIssues("""
+        struct Form: View {
+            let title: String
+            @State private var other = false
+            private var submitButton: some View {
+                Button("Submit", action: submit)
+            }
+            private func submit() { }
+            var body: some View {
+                VStack { submitButton; Text(title); Toggle("", isOn: $other) }
+            }
+        }
+        """).isEmpty)
+    }
+
+    @Test("a property composing one that needs a binding is not reported either")
+    func captureIsFollowedTransitively() {
+        // `form` reads nothing itself, but extracting it means passing `$draft` down through it.
+        #expect(filteredIssues("""
+        struct Screen: View {
+            let title: String
+            @State private var draft = ""
+            @State private var other = false
+            private var field: some View { TextField("", text: $draft) }
+            private var form: some View { VStack { field } }
+            var body: some View {
+                VStack { form; Text(title); Toggle("", isOn: $other) }
+            }
+        }
+        """).isEmpty)
+    }
+
+    // MARK: - The controls
+
+    @Test("a value-only property is still reported")
+    func valueOnlyPropertyIsStillReported() {
+        // The measured win: a child taking a `String` compares equal and is skipped. If this stops
+        // firing the rule has nothing left to say.
+        let issues = filteredIssues("""
+        struct Row: View {
+            let title: String
+            @State private var other = false
+            private var heading: some View { Text(title).font(.headline) }
+            var body: some View {
+                VStack { heading; Toggle("", isOn: $other) }
+            }
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("heading") == true)
+    }
+
+    @Test("a property with no inputs at all is still reported")
+    func inputFreePropertyIsStillReported() {
+        let issues = filteredIssues("""
+        struct Row: View {
+            let title: String
+            @State private var other = false
+            private var logo: some View { Image(systemName: "cloud") }
+            var body: some View {
+                VStack { logo; Text(title); Toggle("", isOn: $other) }
+            }
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("logo") == true)
+    }
+
+    @Test("a static method call does not count as capture")
+    func staticMethodIsNotCapture() {
+        // Only instance methods capture the view. A static helper is reachable from anywhere.
+        let issues = filteredIssues("""
+        struct Row: View {
+            let title: String
+            @State private var other = false
+            private var heading: some View { Text(Self.format(title)) }
+            private static func format(_ text: String) -> String { text }
+            var body: some View {
+                VStack { heading; Toggle("", isOn: $other) }
+            }
+        }
+        """)
+        #expect(issues.count == 1)
+    }
+}


### PR DESCRIPTION
The third and last gate on `computed-property-view`, and the first one resting on a **measurement** rather than on reasoning about SwiftUI.

Reopened from #134, which GitHub auto-closed when its base branch (#133's) was deleted on merge. Same single commit, now targeting `main`.

## The measurement

A harness in MacCloud_client_iOS (PR #4 there) counts `body` evaluations while changing state no child reads. iOS 26.5, three unrelated changes:

| child shape | re-renders | |
|---|---|---|
| no inputs | **0** | skipped |
| value input (`String`) | **0** | skipped |
| non-capturing closure `{ }` | **0** | skipped |
| `@Binding` | **3** | every time |
| capturing closure | **3** | every time |

A child holding a `Binding` or a capturing closure re-renders **exactly as often as the inlined property it replaced**. Extracting it is a new type for no benefit, and the rule was reporting those alongside the ones that pay.

**The distinction is capture, not closures.** `action: { }` compiles to one static function and compares equal; `action: { showing = true }` allocates a fresh context on every parent body run. That correction came out of the measurement — the first version of the harness used the non-capturing form and reported the opposite conclusion.

## The gate

Three shapes force a capture across the boundary: reading a stored property's projected value (`$name`), assigning to one, or calling one of the view's own **instance** methods. Followed transitively, since a property composing children that each need a binding has to pass those bindings down. A `static` helper does not count — it is reachable without the view.

## Measured

**224 → 140** across the nine repositories where the rule fires.

| repo | before | after |
|---|---|---|
| SwiftLintRuleStudio | 80 | 57 |
| SwiftLintRuleStudioTeam | 56 | 39 |
| SwiftFormatRuleStudio | 23 | 7 |
| SwiftAssist | 20 | 14 |
| SwiftMarkdownWiki | 18 | 9 |
| SwiftProjectLint | 14 | 6 |
| SwiftUMLStudio | 7 | 4 |
| MacCloud_client_MacOS | 5 | 4 |
| MacCloud_client_iOS | 1 | 0 |

A heuristic scan run *before* implementing predicted 147, so the estimate and the implementation agree to within a few findings.

Across all three gates the rule has gone **341 → 140**, and every survivor now names a child that was measured to be skippable.

## What a reviewer should scrutinise

- **A parser detail that silently broke the first version.** `showing = true` parses as an *unfolded* `SequenceExprSyntax` — the plain parser does not fold operators, so `InfixOperatorExprSyntax` never appears and my assignment check matched nothing at all. It compiled and the suite passed; only the test written for that case caught it.
- **Whether instance-method calls are too broad.** Calling `submit()` means the child needs `action: submit` passed in, which captures. But a method that only reads value inputs and returns a value — a formatter, say — would be better as a `static` helper, and the gate now quietly pushes in that direction. I think that is right; it is a judgment.
- **Hand checks at both edges.** `chooseFolderPrompt` assigns `choosingFolder = true` and is now silent; `hint` reads only value properties and static helpers and still fires. Both verified by opening the files.

3,419 tests pass; SwiftLint clean. Four suppression tests fail without the gate and the three controls pass either way, which is what makes them controls.