### PR TITLE
Repair two stale kernel mutants and add one for the clock-read guard

### DIFF
--- a/mutants/README.md
+++ b/mutants/README.md
@@ -21,8 +21,8 @@ Requires a clean working tree.
 
 ## The corpus (`manifest.json`)
 
-All three target the `ExtractableTotalKernelVisitor` — the §15.2.5 "a total kernel is
-trapped in this impure method; lift it" rule — one on each side of the
+All four target the `ExtractableTotalKernelVisitor` — the §15.2.5 "a total kernel is
+trapped in this impure method; lift it" rule — on both sides of the
 precision/recall line:
 
 | id | shape | expected | killer |
@@ -30,15 +30,30 @@ precision/recall line:
 | `kernel-governs-always-false` | detector-recall | killed | `chunkingKernelIsCandidate` |
 | `kernel-scans-pure-functions` | detector-precision | killed | `pureFunctionIsNotReported` |
 | `kernel-worth-extracting-always-true` | detector-precision | killed | `arithmeticWithoutAGoverningUseIsNotReported` |
+| `kernel-ignores-ambient-state` | detector-precision | killed | `continuousClockElapsedIsNotAKernel` |
 
 Forcing `governs` false makes the rule miss a real kernel (recall); inverting the
 purity guard makes it scan pure functions that are already candidates elsewhere;
-making `isWorthExtracting` always true makes it flag merely-stored arithmetic (both
-precision). All three verified killed.
+making `isWorthExtracting` always true makes it flag merely-stored arithmetic;
+removing the ambient-state guard makes it report `ContinuousClock.now - lastActivityAt`
+as a kernel that "depends only on its parameters and locals", which is false (all
+precision). All four verified killed.
 
 (An earlier pair of threshold/conjunction off-by-one mutants *survived* — the test
 kernels sit clear of those boundaries, so no test pinned them; they were replaced
 with the decisive mutations above rather than shipped as false guards.)
+
+**A patch can go stale, and two of these did.** `isWorthExtracting` was later split
+into `isArithmeticKernel || isPathKernel`, and both `kernel-governs-always-false` and
+`kernel-worth-extracting-always-true` stopped applying. That is a *structural* drift,
+not a line-number one: regenerating `kernel-worth-extracting-always-true` at the old
+site would have forced only the arithmetic half true and quietly tested less than its
+label claims. When a patch fails to apply, re-read what the mutant is supposed to say
+and re-express it against the current shape — do not just re-anchor it.
+
+The runner is loud about this rather than silent: an apply failure is reported as
+`APPLY FAILED`, recorded with outcome `apply-failed`, and exits non-zero. A stale
+corpus shows up as a failing run, never as a passing one.
 
 ## Adding a mutant
 

--- a/mutants/manifest.json
+++ b/mutants/manifest.json
@@ -25,6 +25,14 @@
       "expected": "killed",
       "test": "arithmeticWithoutAGoverningUseIsNotReported",
       "label": "isWorthExtracting returns true unconditionally — merely-stored arithmetic (assigned, not governing) is falsely flagged"
+    },
+    {
+      "id": "kernel-ignores-ambient-state",
+      "patch": "patches/kernel-ignores-ambient-state.patch",
+      "shape": "detector-precision",
+      "expected": "killed",
+      "test": "continuousClockElapsedIsNotAKernel",
+      "label": "the ambient-state guard is removed — a clock read (`ContinuousClock.now - lastActivityAt`) is reported as a kernel that 'depends only on its parameters and locals'"
     }
   ]
 }

--- a/mutants/patches/kernel-governs-always-false.patch
+++ b/mutants/patches/kernel-governs-always-false.patch
@@ -1,10 +1,10 @@
 diff --git a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ExtractableTotalKernelVisitor.swift b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ExtractableTotalKernelVisitor.swift
-index db7997e..d8eb87a 100644
+index 30583e3..78fa9f8 100644
 --- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ExtractableTotalKernelVisitor.swift
 +++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ExtractableTotalKernelVisitor.swift
-@@ -151,7 +151,7 @@ private struct KernelScan {
-     /// that picks out chunking math and progress tracking and essentially nothing else.
-     var isWorthExtracting: Bool {
+@@ -207,7 +207,7 @@ private struct KernelScan {
+ 
+     private var isArithmeticKernel: Bool {
          let hasArithmetic = !derivedBindings.isEmpty || hasFraction
 -        let governs = hasGoverningComparison || hasSlicingArithmetic || hasFraction
 +        let governs = false

--- a/mutants/patches/kernel-ignores-ambient-state.patch
+++ b/mutants/patches/kernel-ignores-ambient-state.patch
@@ -1,0 +1,13 @@
+diff --git a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ExtractableTotalKernelVisitor.swift b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ExtractableTotalKernelVisitor.swift
+index 30583e3..6ebd1d7 100644
+--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ExtractableTotalKernelVisitor.swift
++++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ExtractableTotalKernelVisitor.swift
+@@ -457,7 +457,7 @@ private struct Collector {
+             // `ContinuousClock.now` is a member access with no call in it. `Date()` was already
+             // refused because it *is* a call whose callee is not a pure conversion — which is why
+             // only the clock-property spelling ever got through, and why the gap went unnoticed.
+-            guard !AmbientStateReads.occur(in: value) else { continue }
++            guard true else { continue }
+ 
+             if isVar, !value.is(IntegerLiteralExprSyntax.self) {
+                 externallySeededVars.insert(name)

--- a/mutants/patches/kernel-worth-extracting-always-true.patch
+++ b/mutants/patches/kernel-worth-extracting-always-true.patch
@@ -1,13 +1,13 @@
 diff --git a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ExtractableTotalKernelVisitor.swift b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ExtractableTotalKernelVisitor.swift
-index db7997e..11c66ea 100644
+index 30583e3..3baa0b3 100644
 --- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ExtractableTotalKernelVisitor.swift
 +++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ExtractableTotalKernelVisitor.swift
-@@ -152,7 +152,7 @@ private struct KernelScan {
-     var isWorthExtracting: Bool {
-         let hasArithmetic = !derivedBindings.isEmpty || hasFraction
-         let governs = hasGoverningComparison || hasSlicingArithmetic || hasFraction
--        return hasArithmetic && governs && signalCount >= 2
-+        return true
-     }
+@@ -203,7 +203,7 @@ private struct KernelScan {
+     /// layout constant. A governing use alone fires on every `if` in the codebase. It is the
+     /// conjunction — a value *computed* and then used as a bound, an index, a slice or a fraction —
+     /// that picks out chunking math and progress tracking and essentially nothing else.
+-    var isWorthExtracting: Bool { isArithmeticKernel || isPathKernel }
++    var isWorthExtracting: Bool { true }
  
-     private var signalCount: Int {
+     private var isArithmeticKernel: Bool {
+         let hasArithmetic = !derivedBindings.isEmpty || hasFraction


### PR DESCRIPTION
`kernel-governs-always-false` and `kernel-worth-extracting-always-true` had stopped applying, so two of the three mutants guarding `ExtractableTotalKernelVisitor` were doing nothing.

## The cause is structural, and that changes the repair

Not a line shift. `isWorthExtracting` was split into `isArithmeticKernel || isPathKernel` when the path-kernel shape was added, and both patches were written against the older single-expression body.

That distinction is the whole point of this PR. Re-anchoring `kernel-worth-extracting-always-true` at its old site — now inside `isArithmeticKernel` — would have produced a patch that applies cleanly, gets killed by its named test, and **tests less than its label claims**: it would force only the arithmetic half true, leaving the path half live. A mutant that passes while guarding half of what it says it guards is worse than one that fails loudly.

Both are re-expressed against the current shape instead:

- `kernel-governs-always-false` → `let governs = false` inside `isArithmeticKernel`
- `kernel-worth-extracting-always-true` → `var isWorthExtracting: Bool { true }` at the new top-level site

## New mutant

`kernel-ignores-ambient-state` removes the guard that stops a clock read being reported as a kernel, killed by `continuousClockElapsedIsNotAKernel`. That guard was added recently — it is the fix for the rule telling an author that `ContinuousClock.now - lastActivityAt` "depends only on its parameters and locals" — and nothing was pinning it.

## Result

```
detector-precision   3/3
detector-recall      1/1
TOTAL: 4 pass, 0 fail
```

## A correction to how I described this

I had reported that mutation coverage for the rule was "weaker than it looks". That was wrong about the mechanism. The runner reports an apply failure as `APPLY FAILED`, records outcome `apply-failed`, and exits non-zero — **a stale corpus shows up as a failing run, never as a passing one**. The corpus was broken, not silently degraded. Nobody had run it since the split.

The README now records both: that a patch can go stale structurally, and that the right response is to re-read the mutant's intent rather than re-anchor it.

## What a reviewer should scrutinise

- **Whether `kernel-governs-always-false` still earns its `detector-recall` label.** With `governs` false, `isArithmeticKernel` is false, but `isWorthExtracting` is now a disjunction — the mutant only misses the chunking kernel because `isPathKernel` is also false for that fixture. It is killed, but it is a narrower mutant than it was before the split, and a path-shaped fixture would not be caught by it.
- **The regeneration procedure.** I generated each patch with `git diff -- <file>` after a single edit, reverting between. My first attempt used bare `git diff`, which swept the previously written patch files into the next patch and produced three patches that all failed to apply. The README's "Adding a mutant" section already specifies the `-- <file>` form; I did not follow it the first time.