### PR TITLE
Stop reporting an Identifiable type's id, and say when injection is worth it

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
@@ -92,7 +92,8 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
     /// this rule's contract rather than of the expression.
     private func report(_ source: NondeterminismSources.Source?, at node: Syntax) {
         guard let source, Self.reportedKinds.contains(source.kind) else { return }
-        guard !fileIsTestOrFixture, !isParameterDefaultValue(node) else { return }
+        guard !fileIsTestOrFixture, !isParameterDefaultValue(node),
+              !isIdentifiableIdentity(node) else { return }
         flag(source.marker, at: node)
     }
 
@@ -104,9 +105,58 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
             filePath: getFilePath(for: node),
             lineNumber: getLineNumber(for: node),
             suggestion: "Inject the source (a clock `() -> Date`, a `RandomNumberGenerator`, a UUID "
-                + "provider) so tests can control it.",
+                + "provider) so tests can control it. Worth doing where the value feeds a DECISION — "
+                + "a name, a bound, a branch, a retry window. A value that is only stored and shown "
+                + "needs no seam: a test can construct the record with whatever value it wants.",
             ruleName: .nonInjectedNondeterminism
         )
+    }
+
+    /// True when `node` is the `id` of an `Identifiable` type — `let id = UUID()`.
+    ///
+    /// The one shape where the marker is real and injecting the source buys nothing. `Identifiable`
+    /// is a declaration that the value's whole job is to be distinct: nothing computes with it, no
+    /// law can be stated over it, and a test that needs a particular id constructs the value with
+    /// one. A UUID provider here adds a seam to thread through every call site to fix nothing.
+    ///
+    /// **The conformance is what makes this safe, and it is required rather than inferred.** A bare
+    /// `let id = UUID()` on a type that is not `Identifiable` stays reported: without the
+    /// conformance, `id` is just a name, and the value may well be compared, persisted as a key, or
+    /// sent over a wire.
+    ///
+    /// Measured across the seven-run sweep corpus: 14 of 198 findings are `let id = UUID()`, and 13
+    /// of those carry the conformance. **This is a 7% narrowing, not the wholesale one the rule
+    /// looks like it wants** — see the note on `report`.
+    private func isIdentifiableIdentity(_ node: Syntax) -> Bool {
+        var current = node.parent
+        var isStoredIDBinding = false
+
+        while let syntax = current {
+            // A local inside a function or closure is not a stored identity, whatever it is named.
+            if syntax.is(ClosureExprSyntax.self) || syntax.is(CodeBlockSyntax.self) { return false }
+
+            if let binding = syntax.as(PatternBindingSyntax.self) {
+                guard binding.accessorBlock == nil,
+                      binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text == "id"
+                else { return false }
+                isStoredIDBinding = true
+            }
+            if isStoredIDBinding, let inheritance = inheritanceClause(of: syntax) {
+                return inheritance.inheritedTypes.contains {
+                    $0.type.trimmedDescription == "Identifiable"
+                }
+            }
+            current = syntax.parent
+        }
+        return false
+    }
+
+    private func inheritanceClause(of syntax: Syntax) -> InheritanceClauseSyntax? {
+        if let decl = syntax.as(StructDeclSyntax.self) { return decl.inheritanceClause }
+        if let decl = syntax.as(ClassDeclSyntax.self) { return decl.inheritanceClause }
+        if let decl = syntax.as(ActorDeclSyntax.self) { return decl.inheritanceClause }
+        if let decl = syntax.as(EnumDeclSyntax.self) { return decl.inheritanceClause }
+        return nil
     }
 
     /// True when `node` sits in a function/initializer parameter's default

--- a/Tests/CoreTests/Testability/NonInjectedNondeterminismVisitorTests.swift
+++ b/Tests/CoreTests/Testability/NonInjectedNondeterminismVisitorTests.swift
@@ -163,3 +163,98 @@ struct NonInjectedNondeterminismVisitorTests {
         #expect(issues.first?.message.contains("Date()") == true)
     }
 }
+
+/// `let id = UUID()` on an `Identifiable` type is an identity, not a testability problem.
+///
+/// The marker is real — the value is unpredictable — but injecting a UUID provider for it enables
+/// no law. `Identifiable` is a declaration that the value's whole job is to be distinct: nothing
+/// computes with it, and a test that needs a particular id constructs the value with one.
+///
+/// **This is a narrow gate on purpose.** Measured across the sweep corpus, 14 of 198 findings are
+/// `let id = UUID()` and 13 carry the conformance — a 7% narrowing. The rule looks like it wants a
+/// much bigger one, separating values that feed a *decision* from values that are merely recorded,
+/// and that turns out not to be decidable from the expression's own syntax: `lastRunDate = Date()`
+/// reads as a record until you find the later `Date().timeIntervalSince(lastRunDate)` that makes it
+/// a bound. Suppressing that shape would hide half of a real defect, so it is left reported.
+@Suite("An Identifiable id is not injectable nondeterminism")
+struct NonInjectedNondeterminismIdentityTests {
+
+    private func analyze(_ source: String) -> [LintIssue] {
+        let visitor = NonInjectedNondeterminismVisitor(patternCategory: .testability)
+        let syntax = Parser.parse(source: source)
+        visitor.setSourceLocationConverter(
+            SourceLocationConverter(fileName: "Logic.swift", tree: syntax)
+        )
+        visitor.setFilePath("Logic.swift")
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == RuleIdentifier.nonInjectedNondeterminism }
+    }
+
+    @Test("an Identifiable id is not reported")
+    func identifiableIDIsNotReported() {
+        #expect(analyze("""
+        struct Issue: Identifiable {
+            let id = UUID()
+            let message: String
+        }
+        """).isEmpty)
+    }
+
+    @Test("the conformance is required, not the name")
+    func plainTypeWithAnIDIsStillReported() {
+        // Without `Identifiable`, `id` is just a name. The value may be compared, persisted as a
+        // key, or sent over a wire, and nothing here says otherwise.
+        #expect(analyze("""
+        struct Record {
+            let id = UUID()
+            let message: String
+        }
+        """).count == 1)
+    }
+
+    @Test("another Identifiable property is still reported")
+    func nonIDPropertyIsStillReported() {
+        // The gate is about the identity, not about the type. A timestamp on the same struct is a
+        // different question and stays open.
+        #expect(analyze("""
+        struct Issue: Identifiable {
+            let id = UUID()
+            let createdAt = Date()
+        }
+        """).count == 1)
+    }
+
+    @Test("a local named id inside a function is still reported")
+    func localIDIsStillReported() {
+        // A local is not a stored identity whatever it is called, and this one could feed anything.
+        #expect(analyze("""
+        struct Maker: Identifiable {
+            let id = UUID()
+            func make() -> String {
+                let id = UUID()
+                return id.uuidString
+            }
+        }
+        """).count == 1)
+    }
+
+    @Test("a computed id is still reported")
+    func computedIDIsStillReported() {
+        // A fresh UUID on every read is not an identity — two reads disagree, which is a defect in
+        // its own right rather than something to exempt.
+        #expect(analyze("""
+        struct Issue: Identifiable {
+            var id: UUID { UUID() }
+            let message: String
+        }
+        """).count == 1)
+    }
+
+    @Test("the suggestion names the discriminator")
+    func suggestionExplainsWhenToInject() {
+        // 198 findings with roughly a 1-in-10 hit rate means the message has to help someone
+        // triage, since the rule cannot do it for them.
+        let issues = analyze("struct Record { let stamp = Date() }")
+        #expect(issues.first?.suggestion?.contains("DECISION") == true)
+    }
+}


### PR DESCRIPTION
**198 → 185, a 7% narrowing — and the small size is the finding.**

I went looking for the treatment Computed Property View got (341 → 140). It is not available here, and I would rather say so than ship a heuristic that guesses.

## What the gate does

`let id = UUID()` on an `Identifiable` type is the one shape where the marker is real and injecting the source buys nothing. The conformance is a *declaration* that the value's whole job is to be distinct: nothing computes with it, no law can be stated over it, and a test needing a particular id constructs the value with one. A UUID provider there threads a seam through every call site to fix nothing.

**The conformance is required, not inferred from the name.** A bare `let id = UUID()` on a type that is not `Identifiable` stays reported — without it, `id` is just a name, and the value may be compared, persisted as a key, or sent over a wire. Locals named `id` stay reported. So does a computed `var id: UUID { UUID() }`, which is a defect in its own right since two reads disagree.

## Why it is not bigger

The obvious larger gate is to separate values that feed a **decision** from values that are merely **recorded**. I classified all 198 findings by shape to see how much that would cut. It is not decidable from the expression's own syntax:

```swift
lastRunDate = Date()                              // reads as a record…
…
Date().timeIntervalSince(lastRunDate) > interval  // …until this makes it a bound
```

The JWT defect fixed in MacCloud_server earlier in this work was exactly that shape — `issuedAt: Date()` looked like a plain stamp, and the bug was that it and the expiry came from *independent* clock reads. A gate that suppressed the stamp-looking half would have hidden it.

Deciding this properly needs dataflow across types and files, which is the boundary this linter is documented as blind at. So the message carries the discriminator instead, since the rule cannot apply it:

> Worth doing where the value feeds a **DECISION** — a name, a bound, a branch, a retry window. A value that is only stored and shown needs no seam: a test can construct the record with whatever value it wants.

At 185 findings with roughly a 1-in-10 hit rate, helping someone triage is worth more than a heuristic that triages wrongly for them.

## Where the hit rate comes from

One repository has been worked: **SwiftMarkdownWiki**, 21 findings, **2 acted on and 19 declined**. The two that paid were in `SnapshotManager` — a collision loop that terminates only because a 1 ms bump changes the formatted name, and a `list()` that silently drops any snapshot whose name does not round-trip.

**One repository is a thin basis for a 1-in-10 claim**, and I have already been wrong three times this week by generalising from a small sample of a rule's findings. Treat it as an estimate.

## What a reviewer should scrutinise

- **Whether `Identifiable` really licenses the exemption.** A type can conform and still persist its `id` as a database key, where reproducibility might matter for a migration test. I think constructing the value with a chosen id covers that; if you disagree, this is the gate to argue with.
- **The measurement is a subset run.** 190 → 177 across the 13 repositories where this rule fires; 198 → 185 is the same delta against the full 26-repo total. No repo lost more than 5.
- **The probe method.** I verified the gate is load-bearing by making `isIdentifiableIdentity` return false — not by disabling the guard clause, which I tried first and which silently disabled the whole rule and made the *control* tests fail instead. Same mistake I made on the capture gate; worth naming so the next probe starts from the predicate.

3,425 tests pass; SwiftLint clean.