### PR TITLE
Count Law of Demeter reach-throughs, not occurrences

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/LawOfDemeterVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/LawOfDemeterVisitor.swift
@@ -11,6 +11,27 @@ import SwiftSyntax
 class LawOfDemeterVisitor: BasePatternVisitor {
     private var currentFilePath: String = ""
 
+    /// One finding per *reach-through*, not per occurrence.
+    ///
+    /// Keyed by the enclosing declaration and the penultimate component — the thing being reached
+    /// into. Measured on two repositories before this existed: five sort comparators in
+    /// SwiftInferProperties produced **48 findings for one missing `Comparable` conformance**, and
+    /// eleven DTO-flattening constructors in SwiftAssist produced eleven for zero problems. The
+    /// number never described anything a reader would act on that many times, and the largest
+    /// cluster was the *easiest* fix — so counting occurrences inverted the priority.
+    ///
+    /// The key is the penultimate component rather than the root because that is what the
+    /// encapsulation goes on: `lhs.member.location.file` and `rhs.member.location.line` are the same
+    /// problem with `location`, and reporting them under `lhs` and `rhs` would split one fix in two.
+    private var reportedReachThroughs: Set<ReachThrough> = []
+
+    private struct ReachThrough: Hashable {
+        /// Byte offset of the enclosing declaration, or 0 at file scope.
+        let declarationPosition: Int
+        /// The component being reached into — the penultimate hop.
+        let target: String
+    }
+
     /// Minimum number of dots to trigger a warning. 3 means a.b.c.d is flagged.
     private static let minChainDepth = 3
 
@@ -103,6 +124,32 @@ class LawOfDemeterVisitor: BasePatternVisitor {
         self.currentFilePath = filePath
     }
 
+    override func reset() {
+        super.reset()
+        reportedReachThroughs = []
+    }
+
+    /// The declaration a node sits in, identified by position. Chains in different functions are
+    /// different problems even when they name the same target; chains in one function are one.
+    private func enclosingDeclarationPosition(of node: Syntax) -> Int {
+        var current: Syntax? = node.parent
+        while let syntax = current {
+            if Self.isDeclarationBoundary(syntax) {
+                return syntax.positionAfterSkippingLeadingTrivia.utf8Offset
+            }
+            current = syntax.parent
+        }
+        return 0
+    }
+
+    /// The declarations a reach-through is scoped to. Split out from the walk above so the walk
+    /// stays under the cyclomatic-complexity limit these five `is` checks pushed it over.
+    private static func isDeclarationBoundary(_ syntax: Syntax) -> Bool {
+        syntax.is(FunctionDeclSyntax.self) || syntax.is(InitializerDeclSyntax.self)
+            || syntax.is(AccessorDeclSyntax.self) || syntax.is(VariableDeclSyntax.self)
+            || syntax.is(SubscriptDeclSyntax.self)
+    }
+
     override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
         // Only report from the outermost MemberAccessExpr to avoid duplicates.
         if node.parent?.is(MemberAccessExprSyntax.self) == true {
@@ -113,7 +160,46 @@ class LawOfDemeterVisitor: BasePatternVisitor {
             return .visitChildren
         }
 
-        // Walk down the chain to measure depth and collect components
+        guard let (orderedComponents, dotCount) = qualifyingChain(from: node) else {
+            return .visitChildren
+        }
+        guard dotCount >= Self.minChainDepth else { return .visitChildren }
+
+        let chain = orderedComponents.joined(separator: ".")
+        let rootDesc = orderedComponents.first ?? "unknown"
+        let target = orderedComponents.count >= 2
+            ? orderedComponents[orderedComponents.count - 2]
+            : rootDesc
+
+        // One finding per reach-through. A second chain into the same target from the same
+        // declaration is the same problem and the same fix.
+        let key = ReachThrough(
+            declarationPosition: enclosingDeclarationPosition(of: Syntax(node)),
+            target: target
+        )
+        guard reportedReachThroughs.insert(key).inserted else { return .visitChildren }
+
+        addIssue(
+            severity: .info,
+            message: "Chain '\(chain)' has \(dotCount) levels of nesting — " +
+                "code knows too much about '\(target)'s internal structure. Reported once per "
+                + "declaration that reaches into '\(target)', however many times it does so",
+            filePath: currentFilePath,
+            lineNumber: getLineNumber(for: Syntax(node)),
+            suggestion: "Ask only immediate collaborators; add a method or conformance to "
+                + "'\(target)' that encapsulates this access",
+            ruleName: .lawOfDemeter
+        )
+        return .visitChildren
+    }
+
+    /// The chain's components root-first and its depth, or `nil` when it is exempt or too shallow.
+    ///
+    /// Split out of `visit` so that walk stays under the cyclomatic-complexity limit once the
+    /// reach-through key was added to it.
+    private func qualifyingChain(
+        from node: MemberAccessExprSyntax
+    ) -> (components: [String], dotCount: Int)? {
         var components: [String] = [node.declName.baseName.text]
         var current: ExprSyntax? = node.base
         while let member = current?.as(MemberAccessExprSyntax.self) {
@@ -121,8 +207,7 @@ class LawOfDemeterVisitor: BasePatternVisitor {
             current = member.base
         }
 
-        guard let root = current else { return .visitChildren }
-        guard isNonExemptRoot(root) else { return .visitChildren }
+        guard let root = current, isNonExemptRoot(root) else { return nil }
 
         if let rootRef = root.as(DeclReferenceExprSyntax.self) {
             components.append(rootRef.baseName.text)
@@ -131,25 +216,11 @@ class LawOfDemeterVisitor: BasePatternVisitor {
         }
 
         let dotCount = components.count - 1
-        guard dotCount >= Self.minChainDepth else { return .visitChildren }
+        guard dotCount >= Self.minChainDepth else { return nil }
 
-        let orderedComponents = Array(components.reversed())
-        guard isNonExemptChain(orderedComponents, dotCount: dotCount) else {
-            return .visitChildren
-        }
-
-        let chain = orderedComponents.joined(separator: ".")
-        let rootDesc = orderedComponents.first ?? "unknown"
-        addIssue(
-            severity: .info,
-            message: "Chain '\(chain)' has \(dotCount) levels of nesting — " +
-                "code knows too much about '\(rootDesc)'s internal structure",
-            filePath: currentFilePath,
-            lineNumber: getLineNumber(for: Syntax(node)),
-            suggestion: "Ask only immediate collaborators; add a method to '\(rootDesc)' that encapsulates this access",
-            ruleName: .lawOfDemeter
-        )
-        return .visitChildren
+        let ordered = Array(components.reversed())
+        guard isNonExemptChain(ordered, dotCount: dotCount) else { return nil }
+        return (ordered, dotCount)
     }
 
     private func isNonExemptRoot(_ root: ExprSyntax) -> Bool {

--- a/Tests/CoreTests/Architecture/ArchitectureLawOfDemeterTests.swift
+++ b/Tests/CoreTests/Architecture/ArchitectureLawOfDemeterTests.swift
@@ -364,3 +364,95 @@ struct ArchitectureLawOfDemeterTests {
         #expect(issues.contains { $0.ruleName == .lawOfDemeter } == false)
     }
 }
+
+/// One finding per reach-through, not per occurrence.
+///
+/// Measured before this existed: five sort comparators in SwiftInferProperties produced **48
+/// findings for one missing `Comparable` conformance**, and eleven DTO-flattening constructors in
+/// SwiftAssist produced eleven for zero problems. Re-run over that same pre-refactor source with
+/// collapsing, the repository reports **40 instead of 90**.
+///
+/// The count was never describing something a reader would act on that many times, and it inverted
+/// the priority: the largest cluster was the easiest fix — one conformance — while the smallest
+/// findings were the ones that needed judgement.
+@Suite("Law of Demeter counts reach-throughs, not occurrences")
+struct LawOfDemeterCollapsingTests {
+    private func analyze(_ source: String) -> [LintIssue] {
+        let visitor = LawOfDemeterVisitor(patternCategory: .architecture)
+        let syntax = Parser.parse(source: source)
+        visitor.setSourceLocationConverter(
+            SourceLocationConverter(fileName: "TestFile.swift", tree: syntax)
+        )
+        visitor.setFilePath("TestFile.swift")
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == RuleIdentifier.lawOfDemeter }
+    }
+
+    @Test("a comparator reaching into one target four times reports once")
+    func repeatedReachIntoOneTargetCollapses() {
+        // The shape that produced 48 findings for one conformance. All four chains reach into
+        // `location`, and the fix is a single `Comparable` on its type.
+        let issues = analyze("""
+        func lessThan(_ lhs: Pair, _ rhs: Pair) -> Bool {
+            if lhs.member.location.file != rhs.member.location.file {
+                return lhs.member.location.file < rhs.member.location.file
+            }
+            return lhs.member.location.line < rhs.member.location.line
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("location") == true)
+    }
+
+    @Test("the same target in a different declaration is a different problem")
+    func separateDeclarationsReportSeparately() {
+        // Two functions each need their own fix applied, even when the target is the same, so
+        // collapsing is per declaration rather than per file.
+        #expect(analyze("""
+        func first(_ lhs: Pair, _ rhs: Pair) -> Bool {
+            lhs.member.location.file < rhs.member.location.file
+        }
+        func second(_ lhs: Pair, _ rhs: Pair) -> Bool {
+            lhs.member.location.line < rhs.member.location.line
+        }
+        """).count == 2)
+    }
+
+    @Test("different targets in one declaration report separately")
+    func distinctTargetsAreNotMerged() {
+        // Collapsing must not hide a second, unrelated reach-through: `location` and `owner` are
+        // different encapsulations on different types. (`signature` would not do here — it is on
+        // the framework-API exemption list and never fires, which is how the first draft of this
+        // test passed for the wrong reason.)
+        let issues = analyze("""
+        func describe(_ item: Item) -> String {
+            let a = item.member.location.file
+            let b = item.member.owner.name
+            return a + b
+        }
+        """)
+        #expect(issues.count == 2)
+    }
+
+    @Test("chains reached through different roots into one target still collapse")
+    func lhsAndRhsAreOneProblem() {
+        // `lhs` and `rhs` are the same shape. Keying on the root would split one fix in two, which
+        // is what made the comparator clusters look like eight problems instead of one.
+        #expect(analyze("""
+        func compare(_ lhs: Pair, _ rhs: Pair) -> Bool {
+            lhs.member.location.file < rhs.member.location.file
+        }
+        """).count == 1)
+    }
+
+    @Test("the message names the target, not the root")
+    func messageNamesTheEncapsulationTarget() {
+        // The fix goes on the penultimate hop's type. Naming the root sent the reader to `lhs`.
+        let issues = analyze("""
+        func compare(_ lhs: Pair, _ rhs: Pair) -> Bool {
+            lhs.member.location.file < rhs.member.location.file
+        }
+        """)
+        #expect(issues.first?.suggestion?.contains("'location'") == true)
+    }
+}


### PR DESCRIPTION
Five sort comparators in SwiftInferProperties produced **48 findings for one missing `Comparable` conformance**. Eleven DTO-flattening constructors in SwiftAssist produced eleven for **zero** problems.

The number was never describing something a reader would act on that many times.

## The priority was inverted, which is worse than the noise

The largest cluster on the sweep page was the **easiest** fix — one conformance, one line — while the single-digit findings were the ones needing judgement. Ranking by occurrence sent a reader to the cheapest work first and called it the biggest thing on the page.

## What changed

A finding is reported once per **(enclosing declaration, reach-through target)**.

The key is the *penultimate* component, not the root, because that is where the encapsulation goes. `lhs.member.location.file` and `rhs.member.location.line` are one problem with `location`; keying on the root would have split one fix into `lhs` and `rhs` — which is exactly what made those comparators look like eight problems instead of one. The message and suggestion now name the target rather than the root, which is where they had been sending people.

## Measured against the corpus where the clusters existed

Today's numbers understate this, because those clusters are already fixed. So I checked SwiftInferProperties out at the commit *before* the `Comparable` conformance and ran both versions over it:

| | findings |
|---|---|
| occurrences | **90** |
| reach-throughs | **40** |

Across all 26 repositories as they stand now: Law of Demeter **86 → 73**, total prompts **878 → 865**.

## This makes my own recent work look smaller, correctly

Those two conformances read as **−54** under occurrence counting and **−7** under reach-through counting. Seven distinct reach-throughs is the truthful number; 54 was counting lines. Future reductions on this rule will look smaller and mean more, and the sweep page will need that said plainly.

## What a reviewer should scrutinise

- **Collapsing is per declaration, not per file or per type.** Two functions each reaching into `location` report twice, because each needs the fix applied at its own call site even when one conformance serves both. If you think that should collapse further, the argument is that the *fix* is shared — but then a file with forty such functions reports one finding and the scale is invisible.
- **The count is not in the message.** It says "reported once per declaration that reaches into `location`, however many times it does so" rather than "8 chains". Emitting the count needs deferred reporting, which this visitor has no hook for; I judged the honesty of the wording worth more than the number.
- **One new test passed for the wrong reason on first draft.** Its second target was `signature`, which is on the framework-API exemption list and never fires, so "two distinct targets report separately" was really "one target reports once". The fixture now uses a non-exempt member and the comment records the trap.

3,430 tests pass; SwiftLint clean. `visit` and the declaration-boundary check were split out to stay under the cyclomatic-complexity limit the new key pushed them over.