### PR TITLE
Report a `??` fallback onto a nondeterministic source as a fabrication

### DIFF
--- a/Docs/rules/non-injected-nondeterminism.md
+++ b/Docs/rules/non-injected-nondeterminism.md
@@ -18,6 +18,54 @@ A property-based test re-runs logic against many randomized inputs and, when it 
 
 Uses in a parameter *default value* position are exempt (a defaulted `clock: () -> Date = { Date() }` is itself the injection seam), as are test files.
 
+### Two faults, one trigger
+
+The same marker witnesses two different problems, and only one of them is about testability. The
+rule reports both, with different messages.
+
+**Cannot control the value.** A clock or an RNG read inline, feeding a bound, a branch or a retry
+window. The value is real; a test cannot pin it. The discriminator this fault wants — does the
+value feed a *decision*, or is it only stored and shown? — is not decidable from the expression's
+own syntax (`lastRunDate = Date()` reads as a record until you find the later
+`Date().timeIntervalSince(lastRunDate)` that makes it a bound), so the message carries it as advice
+rather than applying it as a gate.
+
+**Fabricates the value.** A nondeterministic source as the fallback of `??`, standing in for a
+value that was absent:
+
+```swift
+id = model.id ?? UUID()
+modifiedDate = attributes.contentModificationDate ?? Date()
+lastOccurrence = result.finishedAt ?? Date()
+```
+
+Nothing computes with these in the sense above — they are stored and shown, exactly the shape the
+first fault's advice waves through — and that advice is wrong here. Injecting a clock makes the
+invention *reproducible*, not correct.
+
+The harm is specific. `Date()` is the largest instant in the system and `UUID()` matches no row, so
+an invented value does not merely differ from the real one: **it wins every comparison it enters.**
+Three independent instances found across the corpus, one failure mode each time:
+
+| Where | What the fabricated value did |
+| --- | --- |
+| A file whose modification date the file system did not report | Looked like the newest thing on disk, won every comparison, and silently uploaded over the server's copy |
+| A CI run with no finish time | Won `max(existing.lastOccurrence, incoming)` and pinned the anti-pattern's last occurrence to poll time |
+| A note with no recorded date | Never matched its search-index entry, so it was re-indexed on every refresh, forever |
+
+The fix is to propagate the `nil` so callers can say *unknown*, or to refuse — Fluent's
+`try requireID()` is the idiom.
+
+This fault *is* a local syntactic shape, which is the only reason it can be separated from the
+first. Measured across the sweep corpus before the split: **7 production occurrences in 23
+repositories**, 2 of them live defects and 2 more already unreachable by construction. It is kept
+inside this rule rather than promoted to its own, because every one of these sites was already
+reported here and moving them would hand new findings to anyone who had disabled the rule.
+
+The fabrication check runs *before* the `Identifiable` identity exemption, and that order matters:
+`struct Response: Identifiable { let id = model.id ?? UUID() }` satisfies the exemption exactly, and
+is also the shape of the four DTO defects that motivated the split.
+
 ### What this rule deliberately does not flag
 
 `ContinuousClock()`, `SuspendingClock()`, `Task.sleep(for:)`, `DispatchTime.now()`, the monotonic C functions (`mach_absolute_time`, `clock_gettime`), and `Date(timeIntervalSinceNow:)` all read a clock, and none of them are reported here.

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
@@ -45,6 +45,50 @@ import SwiftSyntax
 /// `reportedKinds` is where that scope lives, and it is exhaustive rather than
 /// a negative test: a kind added upstream fails to compile until someone says
 /// which side of the line it falls on.
+///
+/// ## Two faults, one trigger
+///
+/// The same marker witnesses two different problems, and only one of them is
+/// about testability.
+///
+/// **Cannot control the value.** A clock or an RNG read inline, feeding a bound,
+/// a branch or a retry window. The value is real; the test cannot pin it. This
+/// is the rule's original subject, and the discriminator it wants — does the
+/// value feed a *decision*, or is it only stored and shown? — is not decidable
+/// from the expression's own syntax, so the message carries it as advice rather
+/// than applying it as a gate.
+///
+/// **Fabricates the value.** A nondeterministic source as the fallback of `??`,
+/// standing in for a value that was absent: `id = model.id ?? UUID()`,
+/// `modifiedDate = attributes.contentModificationDate ?? Date()`. Nothing
+/// computes with it in the sense above — it is stored and shown, exactly the
+/// shape the first fault's advice waves through — and that advice is *wrong*
+/// here, which is why the shape gets its own message.
+///
+/// The harm is specific, and the corpus named it. `Date()` is the largest
+/// instant in the system and `UUID()` matches no row, so an invented value does
+/// not merely differ from the real one: it wins every comparison it enters.
+/// Three independent instances, three repositories, one failure mode — a file
+/// whose modification date the file system did not report looked like the
+/// newest thing on disk and silently uploaded over the server's copy; a CI run
+/// with no finish time won a `max(existing, incoming)` and pinned an
+/// anti-pattern's last occurrence to poll time; a note with no recorded date
+/// never matched its search-index entry and was re-indexed on every refresh
+/// forever.
+///
+/// Injecting a source does not fix any of those. It makes the invention
+/// reproducible. The fix is to propagate the `nil` or to refuse — Fluent's
+/// `try requireID()` is the idiom — so this is reported as a defect rather than
+/// as a missing seam.
+///
+/// Unlike the first fault, this one *is* a local syntactic shape, which is the
+/// whole reason it can be separated. Measured across the sweep corpus before
+/// the split: 7 production occurrences in 23 repositories, of which 2 were
+/// live defects and 2 more were fallbacks the surrounding code had already made
+/// unreachable. It is a small, precise subset — kept inside this rule rather
+/// than promoted to its own, because every one of these sites was already being
+/// reported here and moving them would hand new findings to anyone who had
+/// disabled this rule.
 final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
 
     private var fileIsTestOrFixture = false
@@ -90,10 +134,23 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
     /// The exemptions are checked here rather than in the classifier because
     /// both are facts about *where* the expression sits, which is a property of
     /// this rule's contract rather than of the expression.
+    /// The fabrication branch is taken **before** the `Identifiable` exemption,
+    /// and the order is load-bearing rather than incidental.
+    /// `struct Response: Identifiable { let id = model.id ?? UUID() }` satisfies
+    /// that exemption exactly — a stored binding named `id` on a type declaring
+    /// that its whole job is to be distinct — and it is also the precise shape
+    /// of the four DTO defects that motivated this split. Checking identity
+    /// first would silence them.
     private func report(_ source: NondeterminismSources.Source?, at node: Syntax) {
         guard let source, Self.reportedKinds.contains(source.kind) else { return }
-        guard !fileIsTestOrFixture, !isParameterDefaultValue(node),
-              !isIdentifiableIdentity(node) else { return }
+        guard !fileIsTestOrFixture, !isParameterDefaultValue(node) else { return }
+
+        if isNilCoalescingFallback(node) {
+            flagFabrication(source.marker, at: node)
+            return
+        }
+
+        guard !isIdentifiableIdentity(node) else { return }
         flag(source.marker, at: node)
     }
 
@@ -110,6 +167,80 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
                 + "needs no seam: a test can construct the record with whatever value it wants.",
             ruleName: .nonInjectedNondeterminism
         )
+    }
+
+    /// Reports the fabrication fault: a nondeterministic source standing in for
+    /// a value that was absent.
+    ///
+    /// Deliberately does not mention injection. Injecting a clock here would
+    /// make the invented instant reproducible without making it true, and a
+    /// reader who takes this rule's usual advice on this shape ends up with a
+    /// seam threaded through every call site and the defect still in place.
+    private func flagFabrication(_ source: String, at node: Syntax) {
+        addIssue(
+            severity: .warning,
+            message: "Fabricated fallback: `\(source)` invents a value where one was missing, and "
+                + "nothing downstream can tell the invented value from a recorded one",
+            filePath: getFilePath(for: node),
+            lineNumber: getLineNumber(for: node),
+            suggestion: "This is not the testability fault the rest of this rule reports, and "
+                + "injecting a source will not fix it — it makes the invention reproducible. "
+                + "`Date()` is the largest instant in the system and `UUID()` matches no row, so a "
+                + "fabricated value wins every comparison it enters: a `max`, a `>`, a `newest` "
+                + "sort, an is-this-stale check. Propagate the `nil` so callers can say `unknown`, "
+                + "or refuse outright the way `try requireID()` does.",
+            ruleName: .nonInjectedNondeterminism
+        )
+    }
+
+    /// True when `node` is the right-hand side of a `??` — the value used when
+    /// the real one was absent.
+    ///
+    /// Handles both spellings because the tree shape depends on who parsed it.
+    /// `SwiftParser` leaves `a ?? b` as a `SequenceExprSyntax` of three
+    /// elements; a caller that has folded operators hands over an
+    /// `InfixOperatorExprSyntax`. Reading only the folded form would make this
+    /// silently report nothing under the parser the tests and the CLI both use.
+    ///
+    /// Stops at a closure or code block for the same reason
+    /// `isParameterDefaultValue` does: `cached ?? recompute { Date() }` has a
+    /// clock read *inside* the fallback rather than *as* it, and that is the
+    /// first fault, not this one.
+    private func isNilCoalescingFallback(_ node: Syntax) -> Bool {
+        var current = node
+        while let parent = current.parent {
+            if parent.is(ClosureExprSyntax.self) || parent.is(CodeBlockSyntax.self) { return false }
+
+            if let infix = parent.as(InfixOperatorExprSyntax.self) {
+                return isNilCoalescing(infix.operator) && Syntax(infix.rightOperand).id == current.id
+            }
+            if let elements = parent.as(ExprListSyntax.self),
+               elements.parent?.is(SequenceExprSyntax.self) == true {
+                return isFallbackElement(current, in: elements)
+            }
+            current = parent
+        }
+        return false
+    }
+
+    /// True when `element` is preceded by a `??` in an unfolded sequence.
+    ///
+    /// The predecessor rather than the position, so `a ?? b ?? c` reports both
+    /// `b` and `c` — each is the value used when everything to its left was
+    /// absent.
+    private func isFallbackElement(_ element: Syntax, in elements: ExprListSyntax) -> Bool {
+        var previous: ExprSyntax?
+        for expression in elements {
+            if Syntax(expression).id == element.id {
+                return previous.map(isNilCoalescing) ?? false
+            }
+            previous = expression
+        }
+        return false
+    }
+
+    private func isNilCoalescing(_ expression: ExprSyntax) -> Bool {
+        expression.as(BinaryOperatorExprSyntax.self)?.operator.text == "??"
     }
 
     /// True when `node` is the `id` of an `Identifiable` type — `let id = UUID()`.

--- a/Tests/CoreTests/Testability/NonInjectedNondeterminismVisitorTests.swift
+++ b/Tests/CoreTests/Testability/NonInjectedNondeterminismVisitorTests.swift
@@ -258,3 +258,116 @@ struct NonInjectedNondeterminismIdentityTests {
         #expect(issues.first?.suggestion?.contains("DECISION") == true)
     }
 }
+
+/// A nondeterministic source on the right of `??` is a different fault, and gets a different
+/// message.
+///
+/// The rest of this rule reports values a test cannot *control*. These are values the code
+/// *invents*: `id = model.id ?? UUID()` fires only for a record that was never saved, and when it
+/// fires it lies in a plausible shape. Nothing computes with the value in the sense the main
+/// message means, which is exactly why the main message is wrong here — its advice ("a value that
+/// is only stored and shown needs no seam") waves through every one of these.
+///
+/// Measured across the sweep corpus before this split: 7 production occurrences in 23
+/// repositories, 2 of them live defects. Small, and precise — the whole reason it is separable is
+/// that unlike the decision/record distinction, this one *is* visible in local syntax.
+@Suite("A `??` fallback onto a nondeterministic source is a fabrication, not a missing seam")
+struct NonInjectedNondeterminismFabricationTests {
+
+    private func analyze(_ source: String) -> [LintIssue] {
+        let visitor = NonInjectedNondeterminismVisitor(patternCategory: .testability)
+        let syntax = Parser.parse(source: source)
+        visitor.setSourceLocationConverter(
+            SourceLocationConverter(fileName: "Logic.swift", tree: syntax)
+        )
+        visitor.setFilePath("Logic.swift")
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == RuleIdentifier.nonInjectedNondeterminism }
+    }
+
+    @Test("the fallback is reported as a fabrication")
+    func fallbackIsReportedAsFabrication() {
+        let issues = analyze("""
+        func stamp(_ model: Model) -> Date { model.createdAt ?? Date() }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Fabricated fallback") == true)
+        #expect(issues.first?.message.contains("Date()") == true)
+    }
+
+    @Test("the fabrication message does not advise injection")
+    func fabricationMessageDoesNotAdviseASeam() {
+        // The point of the split. The main suggestion tells a reader to inject the source and says
+        // a value that is only stored and shown needs no seam; both are wrong for this shape.
+        let suggestion = analyze("""
+        func identify(_ model: Model) -> UUID { model.id ?? UUID() }
+        """).first?.suggestion
+        #expect(suggestion?.contains("will not fix it") == true)
+        #expect(suggestion?.contains("Propagate the `nil`") == true)
+    }
+
+    @Test("an inline read that is not a fallback keeps the original message")
+    func nonFallbackKeepsTheSeamMessage() {
+        let issues = analyze("func isExpired(_ token: Token) -> Bool { token.expiry < Date() }")
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Non-injected nondeterminism") == true)
+    }
+
+    /// The interaction that made the ordering in `report` load-bearing.
+    ///
+    /// This is the shape of the four MacCloud_server DTO defects: a stored `id` on an
+    /// `Identifiable` type, which is exactly what the identity exemption was written to silence.
+    /// Checking identity first would have hidden every one of them.
+    @Test("an Identifiable id built from a fallback is still reported")
+    func identifiableIDFromAFallbackIsStillReported() {
+        let issues = analyze("""
+        struct Response: Identifiable {
+            let id = model.id ?? UUID()
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Fabricated fallback") == true)
+    }
+
+    @Test("a plain Identifiable id is still exempt")
+    func plainIdentifiableIDStaysExempt() {
+        // Non-vacuity guard for the test above: the exemption still works when there is no `??`.
+        #expect(analyze("""
+        struct Response: Identifiable {
+            let id = UUID()
+        }
+        """).isEmpty)
+    }
+
+    @Test("both fallbacks in a chain are reported")
+    func everyFallbackInAChainIsReported() {
+        let issues = analyze("""
+        func stamp(_ model: Model) -> Date { model.createdAt ?? model.seenAt ?? Date() }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Fabricated fallback") == true)
+    }
+
+    @Test("a source inside the fallback expression is not a fabrication")
+    func aReadInsideTheFallbackIsTheOtherFault() {
+        // `Date()` here is *in* the recompute, not *as* the fallback — the value is computed, not
+        // invented, so it stays the seam message.
+        let issues = analyze("""
+        func value(_ cached: Date?) -> Date { cached ?? recompute { Date() } }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Non-injected nondeterminism") == true)
+    }
+
+    @Test("the left-hand side of a `??` is not a fabrication")
+    func theLeftSideKeepsTheSeamMessage() {
+        let issues = analyze("func pick(_ fallback: Int) -> Int { Int.random(in: 1...6) ?? fallback }")
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Non-injected nondeterminism") == true)
+    }
+
+    @Test("a parameter default is still exempt on either side of a `??`")
+    func parameterDefaultStaysExempt() {
+        #expect(analyze("func make(at date: Date = stored ?? Date()) {}").isEmpty)
+    }
+}


### PR DESCRIPTION
## What changed

`NonInjectedNondeterminismVisitor` now recognises one extra shape and gives it its own message: a nondeterministic source appearing as the **right-hand side of `??`**.

```swift
id          = model.id ?? UUID()                            // fabrication
modifiedDate = attributes.contentModificationDate ?? Date()  // fabrication
elapsed      = Date().timeIntervalSince(lastRun)             // unchanged — the seam message
```

Everything the rule reported before, it still reports; the count does not move. Only the message and suggestion change for the fallback shape.

## Why

The rule's existing suggestion says *"a value that is only stored and shown needs no seam"*. That is sound advice for the fault the rule was written for, and **wrong for this shape** — which is precisely the shape that produced the highest-yield findings in the sweep. The four MacCloud_server DTO defects (`id = model.id ?? UUID()`) satisfy "only stored and shown" exactly, and the rule as it stood would have talked a reader out of every one of them.

Injecting a UUID provider or a clock here does not fix anything. It makes the invention reproducible.

## The harm, named by the corpus rather than by the rule

`Date()` is the largest instant in the system and `UUID()` matches no row, so a fabricated value does not merely differ from the real one — **it wins every comparison it enters.** Three independent instances, three repositories, one failure mode:

| Where | What the fabricated value did |
| --- | --- |
| A file whose modification date the file system did not report | Looked like the newest thing on disk, won every comparison, silently uploaded over the server's copy (already fixed in MacCloud_client_MacOS) |
| A CI run with no finish time | Won `max(existing.lastOccurrence, incoming)` and pinned an anti-pattern's last occurrence to poll time |
| A note with no recorded date | Never matched its search-index entry, so it was re-indexed on every refresh, forever |

## Measurement

The sweep artifact said this was "worth measuring across the corpus before touching the rule, and has not been". It has been now: **7 production occurrences across 23 repositories** — 2 live defects, 2 fallbacks the surrounding code had already made unreachable, 1 legitimate lazy-create, 2 declined with reasoning already written beside them.

Small and precise. Precision is 2/7 here rather than the 8/8 MacCloud_server suggested, because DTOs repeat one shape and the rest of the corpus does not.

## What a reviewer should scrutinise

1. **The ordering in `report`.** The fabrication branch runs *before* the `Identifiable` identity exemption, and it has to: `struct Response: Identifiable { let id = model.id ?? UUID() }` satisfies that exemption exactly and is also the DTO defect shape. `identifiableIDFromAFallbackIsStillReported` pins it, with `plainIdentifiableIDStaysExempt` as the non-vacuity guard.
2. **`isNilCoalescingFallback` handles both tree shapes.** `SwiftParser` leaves `a ?? b` unfolded as a `SequenceExprSyntax`; a caller that folds operators hands over an `InfixOperatorExprSyntax`. Reading only the folded form would silently report nothing under the parser the tests and the CLI both use.
3. **The closure/code-block stop.** `cached ?? recompute { Date() }` has a clock read *inside* the fallback rather than *as* it — that is the first fault, and `aReadInsideTheFallbackIsTheOtherFault` keeps it there.
4. **Whether this should have been its own rule.** Argued in the type doc: it is kept inside this one because every site was already reported here, and splitting would hand new findings to anyone who had put `non-injected-nondeterminism` in `disabled_rules`.

## Verification

Full suite: 3439 tests in 417 suites, passing. Smoke-tested against the live corpus — 1 fabrication in SwiftMarkdownWiki, 2 in SwiftAssist, 2 in MacCloud_client_MacOS, matching the hand census exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4RHsdMsmwJRsc2Va7a3JR