### PR TITLE
Report a fabrication only when the source IS the fallback

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
@@ -193,8 +193,8 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
         )
     }
 
-    /// True when `node` is the right-hand side of a `??` — the value used when
-    /// the real one was absent.
+    /// True when `node` **is** the right-hand side of a `??` — the value used
+    /// when the real one was absent.
     ///
     /// Handles both spellings because the tree shape depends on who parsed it.
     /// `SwiftParser` leaves `a ?? b` as a `SequenceExprSyntax` of three
@@ -202,10 +202,27 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
     /// `InfixOperatorExprSyntax`. Reading only the folded form would make this
     /// silently report nothing under the parser the tests and the CLI both use.
     ///
-    /// Stops at a closure or code block for the same reason
-    /// `isParameterDefaultValue` does: `cached ?? recompute { Date() }` has a
-    /// clock read *inside* the fallback rather than *as* it, and that is the
-    /// first fault, not this one.
+    /// ## Being the fallback, not sitting inside one
+    ///
+    /// The walk climbs only through *transparent* wrappers — parentheses,
+    /// `try`, `await` — and stops at anything else. That distinction is the
+    /// whole rule, and the first version of this got it wrong: an unrestricted
+    /// walk reported the `UUID()` in
+    ///
+    /// ```swift
+    /// userDefaults ?? UserDefaults(suiteName: "test.\(UUID().uuidString)") ?? .standard
+    /// ```
+    ///
+    /// as a fabrication, because a `??` sits somewhere above it. Nothing is
+    /// fabricated there: the fallback is a fresh isolated suite, and the UUID
+    /// is a genuine identity doing its job. Caught by running the corpus rather
+    /// than by the unit tests, which had only covered the closure form of the
+    /// same mistake.
+    ///
+    /// The reachable-source case — `cached ?? recompute { Date() }` — is the
+    /// same shape and now falls out of the same check rather than needing the
+    /// closure stop to catch it. That stop is kept anyway: it is cheap, and it
+    /// states the intent at the boundary a reader looks for it.
     private func isNilCoalescingFallback(_ node: Syntax) -> Bool {
         var current = node
         while let parent = current.parent {
@@ -218,7 +235,27 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
                elements.parent?.is(SequenceExprSyntax.self) == true {
                 return isFallbackElement(current, in: elements)
             }
+            guard isTransparentWrapper(parent) else { return false }
             current = parent
+        }
+        return false
+    }
+
+    /// True when `syntax` wraps an expression without changing which expression
+    /// it *is* — parentheses, `try`, `await`.
+    ///
+    /// A parenthesised expression parses as a one-element `TupleExprSyntax`, so
+    /// the arity and label checks are what separate `(Date())` from
+    /// `f(at: Date())`. Without them this would re-admit every call argument and
+    /// the walk would be unrestricted again.
+    private func isTransparentWrapper(_ syntax: Syntax) -> Bool {
+        if syntax.is(TryExprSyntax.self) || syntax.is(AwaitExprSyntax.self) { return true }
+        if let tuple = syntax.as(TupleExprSyntax.self) { return tuple.elements.count == 1 }
+        if let element = syntax.as(LabeledExprSyntax.self) {
+            return element.label == nil && element.parent?.parent?.is(TupleExprSyntax.self) == true
+        }
+        if let list = syntax.as(LabeledExprListSyntax.self) {
+            return list.parent?.is(TupleExprSyntax.self) == true
         }
         return false
     }

--- a/Tests/CoreTests/Testability/NonInjectedNondeterminismVisitorTests.swift
+++ b/Tests/CoreTests/Testability/NonInjectedNondeterminismVisitorTests.swift
@@ -370,4 +370,34 @@ struct NonInjectedNondeterminismFabricationTests {
     func parameterDefaultStaysExempt() {
         #expect(analyze("func make(at date: Date = stored ?? Date()) {}").isEmpty)
     }
+
+    /// Verbatim from `SwiftLintRuleStudioCoreTestSupport`, and the reason this gate exists.
+    ///
+    /// The first version of `isNilCoalescingFallback` walked to any `??` above the node, so it
+    /// called this `UUID()` a fabrication. Nothing is fabricated: the fallback is a fresh isolated
+    /// `UserDefaults` suite, and the UUID inside it is a genuine identity doing its job. Being the
+    /// fallback and sitting somewhere inside one are different facts.
+    @Test("a source inside the fallback's arguments is not a fabrication")
+    func aSourceInsideTheFallbacksArgumentsIsNotAFabrication() {
+        // A raw literal, so the `\(` reaches the parser instead of interpolating into this
+        // test file — which is what makes `UUID()` an expression in the analysed source.
+        let issues = analyze(#"""
+        func make(_ userDefaults: UserDefaults?) -> UserDefaults {
+            userDefaults
+                ?? UserDefaults(suiteName: "test.Container.\(UUID().uuidString)")
+                ?? .standard
+        }
+        """#)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Non-injected nondeterminism") == true)
+    }
+
+    @Test("parentheses around the fallback do not hide it")
+    func parenthesesAroundTheFallbackDoNotHideIt() {
+        // The other half of the gate: `(Date())` is still the fallback, so the walk has to climb
+        // through parentheses while refusing call arguments — both parse as a `TupleExpr`.
+        let issues = analyze("func stamp(_ recorded: Date?) -> Date { recorded ?? (Date()) }")
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Fabricated fallback") == true)
+    }
 }


### PR DESCRIPTION
Follow-up to #139, found by running the new gate over the corpus rather than by the unit tests.

## The false positive

```swift
let testUserDefaults = userDefaults
    ?? UserDefaults(suiteName: "test.DependencyContainer.\(UUID().uuidString)")
    ?? .standard
```

`SwiftLintRuleStudioCoreTestSupport/TestIsolationHelpers.swift:152`. The `UUID()` was reported as a fabrication because a `??` sits somewhere above it. Nothing is fabricated here — the fallback is a fresh isolated `UserDefaults` suite, and the UUID inside it is a genuine identity doing its job.

## The fix

`isNilCoalescingFallback` walked up to any `??` ancestor. It now climbs only through **transparent wrappers** — parentheses, `try`, `await` — and stops at anything else, so *being* the fallback and *sitting inside* one stay different facts.

The closure form of the same mistake, `cached ?? recompute { Date() }`, now falls out of this check rather than depending on the closure stop. That stop is kept anyway: it is cheap and it states the intent at the boundary a reader looks for it.

## What a reviewer should scrutinise

A parenthesised expression and a call argument **both parse as a `TupleExprSyntax`**, so the arity and label checks in `isTransparentWrapper` are the entire distinction. Get them wrong in one direction and `(Date())` stops being reported; get them wrong in the other and every call argument is re-admitted and the walk is unrestricted again. Both directions are pinned:

- `aSourceInsideTheFallbacksArgumentsIsNotAFabrication` — the real `TestIsolationHelpers` shape, verbatim, written as a raw literal so the `\(` reaches the parser instead of interpolating into the test file.
- `parenthesesAroundTheFallbackDoNotHideIt` — `recorded ?? (Date())` is still a fabrication.

## Verification

3441 tests in 417 suites, passing. Re-scanned the corpus: SwiftLintRuleStudio 1 → 0, and the four true positives are unchanged — SwiftMarkdownWiki `VaultManager.swift:136`, SwiftAssist `CIAdapter.swift:134` and `ChatViewModel.swift:80`, MacCloud_client_MacOS `MacCloudSyncManager+Sync.swift:239-240`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4RHsdMsmwJRsc2Va7a3JR