### PR TITLE
Stop calling a value written back a fabrication

### DIFF
--- a/Docs/rules/non-injected-nondeterminism.md
+++ b/Docs/rules/non-injected-nondeterminism.md
@@ -66,6 +66,24 @@ The fabrication check runs *before* the `Identifiable` identity exemption, and t
 `struct Response: Identifiable { let id = model.id ?? UUID() }` satisfies the exemption exactly, and
 is also the shape of the four DTO defects that motivated the split.
 
+#### Creating a value is not fabricating one
+
+```swift
+let sessionID = currentSessionID ?? UUID()   // no session yet, so make one
+…
+currentSessionID = sessionID                 // and it is now the session
+```
+
+What makes a fabrication a defect is that the invented value stands in for a **real one that exists
+somewhere else** — a row's id, a file's modification date — so the two can disagree. When the value
+is written back into the thing that was missing, there is no counterpart left to disagree with: it
+*becomes* the answer. The one-statement form `current = current ?? UUID()` is the same thing.
+
+These are **reclassified, not silenced.** They fall through to the rule's ordinary message, which is
+true of them — a test still cannot pin the id — so the gate moves the corpus count by zero. The
+gate stays shut when the `??` falls back from a call or a literal, because there is no storage a
+later statement could be matched against.
+
 ### What this rule deliberately does not flag
 
 `ContinuousClock()`, `SuspendingClock()`, `Task.sleep(for:)`, `DispatchTime.now()`, the monotonic C functions (`mach_absolute_time`, `clock_gettime`), and `Date(timeIntervalSinceNow:)` all read a clock, and none of them are reported here.

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
@@ -89,6 +89,14 @@ import SwiftSyntax
 /// than promoted to its own, because every one of these sites was already being
 /// reported here and moving them would hand new findings to anyone who had
 /// disabled this rule.
+///
+/// **What separates the two is the value's counterpart, not its shape.** A
+/// fabrication stands in for a real value that exists somewhere else — a row's
+/// id, a file's modification date — so the two can disagree, and that
+/// disagreement is the whole defect. `let id = current ?? UUID()` followed by
+/// `current = id` has no counterpart to disagree with: the invented value
+/// *becomes* the answer. `isLazyCreation` is that distinction, and the sweep
+/// left one finding standing that needed it.
 final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
 
     private var fileIsTestOrFixture = false
@@ -145,7 +153,7 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
         guard let source, Self.reportedKinds.contains(source.kind) else { return }
         guard !fileIsTestOrFixture, !isParameterDefaultValue(node) else { return }
 
-        if isNilCoalescingFallback(node) {
+        if let fallback = nilCoalescingFallback(containing: node), !isLazyCreation(fallback) {
             flagFabrication(source.marker, at: node)
             return
         }
@@ -193,8 +201,24 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
         )
     }
 
-    /// True when `node` **is** the right-hand side of a `??` — the value used
-    /// when the real one was absent.
+    /// A nondeterministic source sitting as the fallback of a `??`, together
+    /// with the expression whose absence it stands in for.
+    ///
+    /// `missing` is what makes the lazy-creation gate possible: knowing *which*
+    /// value was nil is what lets a later statement be recognised as putting
+    /// the invented one back where it belongs. It is empty when the left
+    /// operand is not a plain reference, because a call or a literal is not
+    /// something a later statement can write into.
+    private struct Fallback {
+        let missing: String
+        /// The `??` chain's element list when the tree is unfolded; `nil` for a
+        /// folded tree, where the self-assignment form cannot be read off a
+        /// sibling list.
+        let elements: ExprListSyntax?
+        let expression: Syntax
+    }
+
+    /// The `??` fallback `node` **is**, or `nil` when it is not one.
     ///
     /// Handles both spellings because the tree shape depends on who parsed it.
     /// `SwiftParser` leaves `a ?? b` as a `SequenceExprSyntax` of three
@@ -223,22 +247,29 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
     /// same shape and now falls out of the same check rather than needing the
     /// closure stop to catch it. That stop is kept anyway: it is cheap, and it
     /// states the intent at the boundary a reader looks for it.
-    private func isNilCoalescingFallback(_ node: Syntax) -> Bool {
+    private func nilCoalescingFallback(containing node: Syntax) -> Fallback? {
         var current = node
         while let parent = current.parent {
-            if parent.is(ClosureExprSyntax.self) || parent.is(CodeBlockSyntax.self) { return false }
+            if parent.is(ClosureExprSyntax.self) || parent.is(CodeBlockSyntax.self) { return nil }
 
             if let infix = parent.as(InfixOperatorExprSyntax.self) {
-                return isNilCoalescing(infix.operator) && Syntax(infix.rightOperand).id == current.id
+                guard isNilCoalescing(infix.operator),
+                      Syntax(infix.rightOperand).id == current.id else { return nil }
+                return Fallback(
+                    missing: reference(infix.leftOperand), elements: nil, expression: Syntax(infix)
+                )
             }
             if let elements = parent.as(ExprListSyntax.self),
-               elements.parent?.is(SequenceExprSyntax.self) == true {
-                return isFallbackElement(current, in: elements)
+               let sequence = elements.parent?.as(SequenceExprSyntax.self) {
+                guard let missing = missingOperand(before: current, in: elements) else { return nil }
+                return Fallback(
+                    missing: missing, elements: elements, expression: Syntax(sequence)
+                )
             }
-            guard isTransparentWrapper(parent) else { return false }
+            guard isTransparentWrapper(parent) else { return nil }
             current = parent
         }
-        return false
+        return nil
     }
 
     /// True when `syntax` wraps an expression without changing which expression
@@ -260,24 +291,147 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
         return false
     }
 
-    /// True when `element` is preceded by a `??` in an unfolded sequence.
+    /// The operand immediately left of the `??` that `element` follows, or
+    /// `nil` when `element` is not a fallback at all.
     ///
-    /// The predecessor rather than the position, so `a ?? b ?? c` reports both
-    /// `b` and `c` — each is the value used when everything to its left was
-    /// absent.
-    private func isFallbackElement(_ element: Syntax, in elements: ExprListSyntax) -> Bool {
+    /// The predecessor rather than the position, so `a ?? b ?? c` treats both
+    /// `b` and `c` as fallbacks — each is the value used when everything to its
+    /// left was absent — and each gets the operand it actually stands in for.
+    private func missingOperand(before element: Syntax, in elements: ExprListSyntax) -> String? {
         var previous: ExprSyntax?
+        var beforePrevious: ExprSyntax?
         for expression in elements {
             if Syntax(expression).id == element.id {
-                return previous.map(isNilCoalescing) ?? false
+                guard let previous, isNilCoalescing(previous) else { return nil }
+                return reference(beforePrevious)
+            }
+            beforePrevious = previous
+            previous = expression
+        }
+        return nil
+    }
+
+    private func isNilCoalescing(_ expression: ExprSyntax) -> Bool {
+        expression.as(BinaryOperatorExprSyntax.self)?.operator.text == "??"
+    }
+
+    /// `expression` as a plain reference — an identifier or member chain, with a
+    /// leading `self.` stripped so `self.x` and `x` are the same storage — or
+    /// `""` for anything else.
+    ///
+    /// A call, a literal or a subscript is deliberately not a reference here:
+    /// nothing a later statement writes to can be matched against it, so the
+    /// lazy-creation gate stays shut rather than guessing.
+    private func reference(_ expression: ExprSyntax?) -> String {
+        guard let expression,
+              expression.is(DeclReferenceExprSyntax.self)
+                || expression.is(MemberAccessExprSyntax.self)
+                || expression.is(OptionalChainingExprSyntax.self) else { return "" }
+        let text = expression.trimmedDescription
+        return text.hasPrefix("self.") ? String(text.dropFirst("self.".count)) : text
+    }
+
+    /// True when the invented value is written back into the thing that was
+    /// missing — which makes it a created value rather than a fabricated one.
+    ///
+    /// ```swift
+    /// let sessionID = currentSessionID ?? UUID()   // no session yet, so make one
+    /// …
+    /// currentSessionID = sessionID                 // and it is now the session
+    /// ```
+    ///
+    /// **The write-back is the whole distinction, and it is not cosmetic.** Every
+    /// fabrication defect in the corpus shares one property: the invented value
+    /// stands in for a real one that exists somewhere else, so the two can
+    /// disagree — a UUID matching no row, a date the file system has and the
+    /// record does not. When the value is stored back, there is no other value
+    /// for it to disagree with. It *becomes* the answer, and nothing downstream
+    /// can be misled about what it was.
+    ///
+    /// The direct form `current = current ?? UUID()` is the same thing said in
+    /// one statement, and is read off the sibling list because `SwiftParser`
+    /// leaves the assignment and the `??` in a single flat sequence.
+    ///
+    /// A finding suppressed here is not silenced: it falls through to the
+    /// rule's ordinary message, which is the true one. A test cannot pin the
+    /// id; it just is not being invented. That is why this gate moved the
+    /// corpus count by zero.
+    private func isLazyCreation(_ fallback: Fallback) -> Bool {
+        guard !fallback.missing.isEmpty else { return false }
+
+        if let elements = fallback.elements, assigns(to: fallback.missing, in: elements) {
+            return true
+        }
+        guard let name = boundName(of: fallback.expression),
+              let scope = enclosingBody(of: fallback.expression) else { return false }
+        return writesBack(name, to: fallback.missing, in: scope)
+    }
+
+    /// True for `target = target ?? …` — an assignment whose left-hand side is
+    /// the operand the `??` falls back from, in the same flat sequence.
+    private func assigns(to target: String, in elements: ExprListSyntax) -> Bool {
+        var previous: ExprSyntax?
+        for expression in elements {
+            if expression.is(AssignmentExprSyntax.self), reference(previous) == target {
+                return true
             }
             previous = expression
         }
         return false
     }
 
-    private func isNilCoalescing(_ expression: ExprSyntax) -> Bool {
-        expression.as(BinaryOperatorExprSyntax.self)?.operator.text == "??"
+    /// The name `expression` initialises, when it is the whole initialiser of a
+    /// simple `let`/`var` binding.
+    private func boundName(of expression: Syntax) -> String? {
+        guard let initializer = expression.parent?.as(InitializerClauseSyntax.self),
+              let binding = initializer.parent?.as(PatternBindingSyntax.self) else { return nil }
+        return binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text
+    }
+
+    /// The nearest enclosing statement body — the scope a write-back has to
+    /// live in to be this binding's.
+    private func enclosingBody(of expression: Syntax) -> Syntax? {
+        var current = expression.parent
+        while let syntax = current {
+            if syntax.is(CodeBlockSyntax.self) { return syntax }
+            current = syntax.parent
+        }
+        return nil
+    }
+
+    /// True when `scope` contains `target = name` anywhere beneath it.
+    ///
+    /// The whole subtree rather than the top-level statements, because the
+    /// write-back is as likely to sit inside an `if`, a `do` or a `defer` as it
+    /// is to sit flat in the body.
+    private func writesBack(_ name: String, to target: String, in scope: Syntax) -> Bool {
+        if let elements = scope.as(ExprListSyntax.self),
+           isWriteBack(name, to: target, in: elements) { return true }
+
+        if let infix = scope.as(InfixOperatorExprSyntax.self),
+           infix.operator.is(AssignmentExprSyntax.self),
+           reference(infix.leftOperand) == target,
+           reference(infix.rightOperand) == name { return true }
+
+        for child in scope.children(viewMode: .sourceAccurate) {
+            if writesBack(name, to: target, in: child) { return true }
+        }
+        return false
+    }
+
+    private func isWriteBack(_ name: String, to target: String, in elements: ExprListSyntax) -> Bool {
+        var previous: ExprSyntax?
+        var beforePrevious: ExprSyntax?
+        for expression in elements {
+            if previous?.is(AssignmentExprSyntax.self) == true,
+               reference(beforePrevious) == target,
+               reference(expression) == name {
+                return true
+            }
+            beforePrevious = previous
+            previous = expression
+        }
+        return false
     }
 
     /// True when `node` is the `id` of an `Identifiable` type — `let id = UUID()`.

--- a/Tests/CoreTests/Testability/NonInjectedNondeterminismVisitorTests.swift
+++ b/Tests/CoreTests/Testability/NonInjectedNondeterminismVisitorTests.swift
@@ -401,3 +401,142 @@ struct NonInjectedNondeterminismFabricationTests {
         #expect(issues.first?.message.contains("Fabricated fallback") == true)
     }
 }
+
+/// Creating a value because there is none is not fabricating one to fill a hole.
+///
+/// `ChatViewModel` writes `let sessionID = currentSessionID ?? UUID()` and then, at the end of the
+/// same method, `currentSessionID = sessionID`. The corpus sweep reported that as a fabrication and
+/// it was wrong: the invented id is not standing in for a real one that exists somewhere else, it
+/// *becomes* the session's id, and nothing downstream can be misled about what it was.
+///
+/// Every true fabrication in the corpus shares the property this one lacks — the invented value has
+/// a real counterpart it can disagree with. A write-back removes the counterpart.
+///
+/// **Suppressed here means reclassified, not silenced.** These fall through to the rule's ordinary
+/// message, which is true of them: a test still cannot pin the id. That is why this gate moves the
+/// corpus count by zero.
+@Suite("A value written back is created, not fabricated")
+struct NonInjectedNondeterminismLazyCreationTests {
+
+    private func analyze(_ source: String) -> [LintIssue] {
+        let visitor = NonInjectedNondeterminismVisitor(patternCategory: .testability)
+        let syntax = Parser.parse(source: source)
+        visitor.setSourceLocationConverter(
+            SourceLocationConverter(fileName: "Logic.swift", tree: syntax)
+        )
+        visitor.setFilePath("Logic.swift")
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == RuleIdentifier.nonInjectedNondeterminism }
+    }
+
+    /// The `ChatViewModel` shape, reduced. This is the finding the fifteenth sweep left standing.
+    @Test("a binding written back later is not a fabrication")
+    func bindingWrittenBackIsNotAFabrication() {
+        let issues = analyze("""
+        func save() {
+            let sessionID = currentSessionID ?? UUID()
+            store.save(sessionID)
+            currentSessionID = sessionID
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Non-injected nondeterminism") == true)
+    }
+
+    /// The non-vacuity guard, and the reason the gate is the write-back rather than the binding:
+    /// delete one line and the same code is a fabrication again.
+    @Test("the same binding with no write-back is still a fabrication")
+    func bindingWithoutWriteBackIsStillAFabrication() {
+        let issues = analyze("""
+        func save() {
+            let sessionID = currentSessionID ?? UUID()
+            store.save(sessionID)
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Fabricated fallback") == true)
+    }
+
+    @Test("the one-statement form is recognised too")
+    func selfAssignmentIsNotAFabrication() {
+        let issues = analyze("""
+        func ensure() {
+            currentSessionID = currentSessionID ?? UUID()
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Non-injected nondeterminism") == true)
+    }
+
+    @Test("self. and the bare name are the same storage")
+    func selfPrefixDoesNotDefeatTheGate() {
+        let issues = analyze("""
+        func save() {
+            let sessionID = self.currentSessionID ?? UUID()
+            currentSessionID = sessionID
+        }
+        """)
+        #expect(issues.first?.message.contains("Non-injected nondeterminism") == true)
+    }
+
+    @Test("a write-back nested in a branch still counts")
+    func writeBackInsideABranchCounts() {
+        let issues = analyze("""
+        func save() {
+            let sessionID = currentSessionID ?? UUID()
+            if shouldPersist {
+                currentSessionID = sessionID
+            }
+        }
+        """)
+        #expect(issues.first?.message.contains("Non-injected nondeterminism") == true)
+    }
+
+    /// The gate must not reach the DTO defects it sits next to. `self.id = model.id ?? UUID()` has
+    /// an assignment in the very same sequence, and its left-hand side is a *different* storage
+    /// from the operand the `??` falls back from — which is exactly why those clients receive a
+    /// UUID matching no row.
+    @Test("assigning into somewhere else is still a fabrication")
+    func assigningIntoDifferentStorageIsStillAFabrication() {
+        let issues = analyze("""
+        struct Response: Identifiable {
+            let id: UUID
+            init(model: Model) {
+                self.id = model.id ?? UUID()
+            }
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Fabricated fallback") == true)
+    }
+
+    /// A write-back needs somewhere to write. `attributes.date() ?? Date()` falls back from a call,
+    /// so the gate stays shut rather than guessing what storage was meant.
+    @Test("a fallback from a call cannot be lazy creation")
+    func fallbackFromACallIsStillAFabrication() {
+        let issues = analyze("""
+        func stamp(_ attributes: Attributes) -> Date {
+            let modified = attributes.date() ?? Date()
+            return modified
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Fabricated fallback") == true)
+    }
+
+    /// Writing back a *different* value is not a write-back. Guards against matching on the target
+    /// alone and exempting anything that happens to assign to it.
+    @Test("assigning something else back is still a fabrication")
+    func assigningADifferentValueIsStillAFabrication() {
+        let issues = analyze("""
+        func save() {
+            let sessionID = currentSessionID ?? UUID()
+            currentSessionID = fallbackSessionID
+            store.save(sessionID)
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Fabricated fallback") == true)
+    }
+}
+


### PR DESCRIPTION
Closes the one false positive the fifteenth sweep left standing.

## The finding that was wrong

```swift
let sessionID = currentSessionID ?? UUID()
…
currentSessionID = sessionID
```

`SwiftAssist/Sources/SwiftAssistApp/Chat/ChatViewModel.swift:80`. The rule called this inventing a value to fill a hole. It is **creating one because there is none**.

## The distinction

What makes a fabrication a defect is that the invented value stands in for a **real one that exists somewhere else** — a row's id, a file's modification date — so the two can disagree, and the disagreement *is* the fault. Every confirmed fabrication in the corpus has that counterpart.

A write-back removes it. The invented value becomes the answer; there is nothing left for it to disagree with. Unlike the decision/record distinction the rule has never been able to make, this one is visible locally: a binding whose value is assigned back into the operand the `??` fell back from, or the one-statement form `current = current ?? UUID()`.

## Reclassified, not silenced

These fall through to the rule's ordinary message, which is true of them — a test still cannot pin the id. **Re-swept across all 26 repositories: 852 prompts and 173 nondeterminism findings, both unchanged**, with the one wrong fabrication gone. No other rule or repository moved.

## What a reviewer should scrutinise

1. **That the gate cannot reach the DTO defects it sits beside.** `self.id = model.id ?? UUID()` has an assignment in the very same flat sequence — `SwiftParser` does not nest it — and only the fact that its left-hand side is *different storage* from the `??`'s left operand keeps it reported. That is exactly why those clients received a UUID matching no row. Pinned by `assigningIntoDifferentStorageIsStillAFabrication`.
2. **`reference(_:)` returning `""` for anything that is not a plain reference.** A `??` falling back from a call has no storage a later statement could be matched against, so the gate stays shut rather than guessing. Pinned by `fallbackFromACallIsStillAFabrication`.
3. **Matching the written value, not just the target.** `currentSessionID = fallbackSessionID` after the binding is not a write-back. Pinned by `assigningADifferentValueIsStillAFabrication`.
4. **`writesBack` scans the whole subtree** of the nearest enclosing body, so a write-back inside an `if`/`do`/`defer` counts. Whether that is too permissive — a write-back on one branch only — is a fair thing to disagree with; it errs toward the ordinary message rather than the defect claim.
5. **The non-vacuity guard.** Delete the write-back line and the same code is a fabrication again: `bindingWithoutWriteBackIsStillAFabrication`.

## Verification

3449 tests in 418 suites, passing. Corpus re-swept; the remaining two fabrication findings are the MacCloud_client_MacOS upload stamps, declined in writing at the call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4RHsdMsmwJRsc2Va7a3JR