### PR TITLE
Gate two measured declines, and say why bare `.now` stays unflagged

### DIFF
--- a/Docs/rules/non-injected-nondeterminism.md
+++ b/Docs/rules/non-injected-nondeterminism.md
@@ -84,6 +84,57 @@ true of them — a test still cannot pin the id — so the gate moves the corpus
 gate stays shut when the `??` falls back from a call or a literal, because there is no storage a
 later statement could be matched against.
 
+### Two gates on the declines
+
+Both were measured against the 26-repository sweep before being written, and together they remove
+**21 of 164 findings**.
+
+**A scratch path's name** (14 findings, eight repositories):
+
+```swift
+FileManager.default.temporaryDirectory
+    .appendingPathComponent("import-\(UUID().uuidString)", isDirectory: true)
+```
+
+The uniqueness *is* the point — two concurrent callers handed the same name would collide — and
+every one of these sites creates the directory, uses it, and deletes it on the way out. Nothing
+compares the name, stores it, or sends it anywhere, so there is no second value for it to disagree
+with, which is the same test the fabrication branch applies.
+
+**Only an identity source**, and the first draft got that wrong: it exempted anything
+nondeterministic in a temporary path name, which would have silenced `"run-\(Date())"` — and a
+clock read used to make a name unique is the shape that produced a real defect in SwiftMarkdownWiki's
+snapshot collision loop, which terminated *only* because the format carried milliseconds. A UUID is
+a name that cannot collide; a timestamp is a name that usually does not, which is a different claim.
+
+**A test-support target** (7 findings, one directory). `isTestOrFixtureFile()` already matched
+`Tests/` and `FooTests/` folders; it now also matches folders ending `TestSupport`, `TestHelpers`,
+`TestKit` and `TestFixtures`. Those are shipped library products rather than test targets, so
+nothing about the path said "test" — but every symbol in them exists to be called from a test, and
+their helpers are *deliberately* nondeterministic: a per-test `UserDefaults` suite name, a
+per-process scratch root, a unique directory per call.
+
+That check is shared with other rules, so the change was scoped by measurement rather than by
+argument: across the corpus it matches four directories and 39 files, and it removed exactly seven
+findings (all this rule's) and three candidate-census entries. No other rule moved.
+
+### Why bare `.now` is not flagged
+
+`Date.now` is reported; a leading-dot `.now` is not, and that is a decision rather than a gap.
+
+Without type resolution the base is unknown, and the corpus contains
+`ContinuousClock.Instant = .now` — a monotonic read this rule
+[deliberately excludes](contradicted-clock-determinism.md). Classifying bare `.now` as a wall-clock
+read would trade a false negative for a false positive of exactly the kind the scope note refuses.
+
+`TupleEqualityWithUnstableComponentsVisitor` reached the same conclusion independently: *"Un-based
+`.now` (leading-dot syntax with inferred base) is NOT flagged — without type resolution the base is
+unknown."*
+
+The practical consequence is worth stating, because it can be mistaken for progress: writing
+`generatedAt: .now` instead of `Date.now` moves a clock read somewhere the tool cannot see, and the
+rule's count falls. **A read the tool reports where it belongs is better than one it cannot find.**
+
 ### What this rule deliberately does not flag
 
 `ContinuousClock()`, `SuspendingClock()`, `Task.sleep(for:)`, `DispatchTime.now()`, the monotonic C functions (`mach_absolute_time`, `clock_gettime`), and `Date(timeIntervalSinceNow:)` all read a clock, and none of them are reported here.

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
@@ -158,7 +158,8 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
             return
         }
 
-        guard !isIdentifiableIdentity(node) else { return }
+        guard !isIdentifiableIdentity(node),
+              !isScratchDirectoryName(node, kind: source.kind) else { return }
         flag(source.marker, at: node)
     }
 
@@ -433,6 +434,79 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
         }
         return false
     }
+
+    /// True when `node` names a scratch path under the temporary directory —
+    /// `tmp.appendingPathComponent("import-\(UUID().uuidString)")`.
+    ///
+    /// The uniqueness *is* the point, and it is the one shape where a deterministic source would be
+    /// actively wrong: two concurrent imports handed the same name would collide, and every one of
+    /// these sites creates the directory, uses it, and deletes it on the way out. Nothing compares
+    /// the name, stores it, or sends it anywhere, so there is no second value for it to disagree
+    /// with — the test the fabrication branch applies, reached here from the other direction.
+    ///
+    /// Measured before the gate: 14 of 164 findings across the corpus, in eight repositories. That
+    /// is the whole of what this buys, and it is worth having because a reader triaging the rest
+    /// should not be shown fourteen findings the rule could have known were fine.
+    ///
+    /// **Only an identity source, and the first draft of this got that wrong.** It exempted
+    /// anything nondeterministic in a temporary path name, which would have silenced
+    /// `"run-\(Date())"` — and a clock read used to make a name unique is the shape that produced a
+    /// real defect in SwiftMarkdownWiki's snapshot collision loop, which terminated *only* because
+    /// the format carried milliseconds. A UUID is a name that cannot collide; a timestamp is a name
+    /// that usually does not, which is a different claim.
+    ///
+    /// **Deliberately not `NSTemporaryDirectory()` or a hard-coded `/tmp`.** Neither appears in the
+    /// corpus, and a gate is worth exactly the shapes it was measured against.
+    private func isScratchDirectoryName(_ node: Syntax, kind: NondeterminismSources.Kind) -> Bool {
+        guard kind == .identity else { return false }
+        var current = node
+        while let parent = current.parent {
+            if parent.is(ClosureExprSyntax.self) || parent.is(CodeBlockSyntax.self) { return false }
+            // The *first* enclosing call decides. Walking past it would exempt a `UUID()` that
+            // merely shares a statement with a path append, which is a different expression.
+            if let call = parent.as(FunctionCallExprSyntax.self) {
+                return Self.appendsToTemporaryDirectory(call)
+            }
+            current = parent
+        }
+        return false
+    }
+
+    /// True when `call` appends a path component to a chain rooted at a temporary directory.
+    private static func appendsToTemporaryDirectory(_ call: FunctionCallExprSyntax) -> Bool {
+        guard let callee = call.calledExpression.as(MemberAccessExprSyntax.self),
+              pathAppendingMethods.contains(callee.declName.baseName.text),
+              let base = callee.base else {
+            return false
+        }
+        return rootsAtTemporaryDirectory(base)
+    }
+
+    /// Walks a receiver chain looking for a `temporaryDirectory` member.
+    ///
+    /// Descends through further calls as well as member accesses, so a chain that appends twice —
+    /// `tmp.appendingPathComponent("A").appendingPathComponent(id)` — still finds its root.
+    private static func rootsAtTemporaryDirectory(_ expression: ExprSyntax) -> Bool {
+        var current: ExprSyntax? = expression
+        while let node = current {
+            if let member = node.as(MemberAccessExprSyntax.self) {
+                if member.declName.baseName.text == "temporaryDirectory" { return true }
+                current = member.base
+                continue
+            }
+            if let call = node.as(FunctionCallExprSyntax.self) {
+                current = call.calledExpression
+                continue
+            }
+            return false
+        }
+        return false
+    }
+
+    /// The `URL` members that build a child path from a parent.
+    private static let pathAppendingMethods: Set<String> = [
+        "appendingPathComponent", "appending", "appendingPathExtension"
+    ]
 
     /// True when `node` is the `id` of an `Identifiable` type — `let id = UUID()`.
     ///

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/BasePatternVisitor.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/BasePatternVisitor.swift
@@ -276,6 +276,9 @@ open class BasePatternVisitor: SyntaxVisitor, PatternVisitorProtocol {
             if component == "Tests" || component.hasSuffix("Tests") {
                 return true // SPM `Tests/` and Xcode `FooTests/` target folders
             }
+            if Self.testSupportDirectorySuffixes.contains(where: component.hasSuffix) {
+                return true
+            }
             if Self.fixtureDirectoryNames.contains(component) {
                 return true
             }
@@ -304,6 +307,23 @@ open class BasePatternVisitor: SyntaxVisitor, PatternVisitorProtocol {
             return next.isUppercase
         }
     }
+
+    /// Suffixes of folder names whose whole contents exist to serve tests, even
+    /// though the folder is a shipped target rather than a test target.
+    ///
+    /// `SwiftLintRuleStudioCoreTestSupport` is a library product — it compiles into
+    /// the app graph and is not a `Tests/` folder — but every symbol in it exists
+    /// to be called from a test, and its helpers are *deliberately* nondeterministic:
+    /// a per-test `UserDefaults` suite name, a per-process scratch root, a unique
+    /// directory per call. Reporting those is the tool failing to read an intent the
+    /// author stated in the target's name.
+    ///
+    /// Suffix-matched rather than exact, so `FooTestSupport` and `TestSupport` both
+    /// count, and split from `fixtureDirectoryNames` because that set is exact-match
+    /// and adding open-ended names to it would widen every entry.
+    private static let testSupportDirectorySuffixes = [
+        "TestSupport", "TestHelpers", "TestKit", "TestFixtures"
+    ]
 
     /// Folder names whose contents are test fixtures, samples, or doubles rather
     /// than production code. Matched against whole path components.

--- a/Tests/CoreTests/Testability/NonInjectedNondeterminismVisitorTests.swift
+++ b/Tests/CoreTests/Testability/NonInjectedNondeterminismVisitorTests.swift
@@ -73,6 +73,26 @@ struct NonInjectedNondeterminismVisitorTests {
         #expect(analyze(source, filePath: "RollTests.swift").isEmpty)
     }
 
+    /// A shipped target whose whole job is to serve tests.
+    ///
+    /// `SwiftLintRuleStudioCoreTestSupport` is a library product, not a `Tests/` folder, so the
+    /// filename and folder checks both passed it through — and its helpers are *deliberately*
+    /// nondeterministic: a per-test `UserDefaults` suite name, a per-process scratch root. Seven of
+    /// the corpus's 164 findings were that one directory. The name is a stated intent.
+    @Test func ignoresTestSupportTargets() {
+        let source = "func make() -> UUID { UUID() }"
+        #expect(analyze(source, filePath: "Sources/FooCoreTestSupport/Helpers.swift").isEmpty)
+        #expect(analyze(source, filePath: "Sources/TestHelpers/Isolation.swift").isEmpty)
+    }
+
+    /// Non-vacuity for the above, and the line the suffix match has to hold: a folder that merely
+    /// *starts* with the marker is production.
+    @Test func stillFlagsProductionNearTestSupport() {
+        let source = "func make() -> UUID { UUID() }"
+        #expect(analyze(source, filePath: "Sources/FooCore/Helpers.swift").count == 1)
+        #expect(analyze(source, filePath: "Sources/TestSupportRunner/Run.swift").count == 1)
+    }
+
     // MARK: - Injected RNG via `using:` is the testable form, not a finding
 
     @Test func ignoresRandomWithInjectedRNG() {
@@ -537,6 +557,100 @@ struct NonInjectedNondeterminismLazyCreationTests {
         """)
         #expect(issues.count == 1)
         #expect(issues.first?.message.contains("Fabricated fallback") == true)
+    }
+}
+
+/// A scratch path under the temporary directory is named uniquely on purpose.
+///
+/// Fourteen of the corpus's 164 findings were this one shape, in eight repositories: build a child
+/// of `temporaryDirectory` with a `UUID()` in its name, create it, use it, delete it on the way
+/// out. The uniqueness *is* the point — two concurrent callers handed the same name would collide —
+/// and nothing compares the name, stores it, or sends it anywhere.
+@Suite("A temporary directory's name is not an injectable dependency")
+struct NonInjectedNondeterminismScratchDirectoryTests {
+
+    private func analyze(_ source: String) -> [LintIssue] {
+        let visitor = NonInjectedNondeterminismVisitor(patternCategory: .testability)
+        let syntax = Parser.parse(source: source)
+        visitor.setSourceLocationConverter(
+            SourceLocationConverter(fileName: "Logic.swift", tree: syntax)
+        )
+        visitor.setFilePath("Logic.swift")
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == RuleIdentifier.nonInjectedNondeterminism }
+    }
+
+    @Test("a uuid inside a temporary path component is not reported")
+    func scratchDirectoryIsExempt() {
+        #expect(analyze(#"""
+        func scratch() -> URL {
+            FileManager.default.temporaryDirectory
+                .appendingPathComponent("import-\(UUID().uuidString)", isDirectory: true)
+        }
+        """#).isEmpty)
+    }
+
+    @Test("the uuid as the whole component is exempt too")
+    func bareComponentIsExempt() {
+        #expect(analyze("""
+        func scratch() -> URL {
+            fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        }
+        """).isEmpty)
+    }
+
+    /// A chain that appends twice still roots at the temporary directory.
+    @Test("a nested append still finds its root")
+    func nestedAppendIsExempt() {
+        #expect(analyze("""
+        func scratch() -> URL {
+            fileManager.temporaryDirectory
+                .appendingPathComponent("Studio", isDirectory: true)
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        }
+        """).isEmpty)
+    }
+
+    // MARK: - What the gate must not reach
+
+    /// The non-vacuity guard. Change the receiver and the same expression is reported again, so the
+    /// gate is keyed on the temporary directory rather than on "appends a path component".
+    @Test("appending a uuid to somewhere else is still reported")
+    func appendingElsewhereIsStillReported() {
+        let issues = analyze(#"""
+        func output(_ root: URL) -> URL {
+            root.appendingPathComponent("stderr-\(UUID().uuidString).txt")
+        }
+        """#)
+        #expect(issues.count == 1)
+    }
+
+    /// A `UUID()` that merely shares a statement with a path append is a different expression, so
+    /// the walk stops at the first enclosing call rather than hunting for a reason to exempt.
+    @Test("a uuid beside a temporary path is still reported")
+    func uuidBesideAScratchPathIsStillReported() {
+        let issues = analyze("""
+        func record(_ store: Store) {
+            store.write(
+                identifier: UUID(),
+                to: FileManager.default.temporaryDirectory.appendingPathComponent("out")
+            )
+        }
+        """)
+        #expect(issues.count == 1)
+    }
+
+    @Test("a clock read in a temporary path name is still reported")
+    func clockReadInAScratchNameIsStillReported() {
+        // The gate is about a name that must not collide. A date is a poor way to get one, and it
+        // is the shape that produced a real defect in SwiftMarkdownWiki's snapshot collision loop.
+        let issues = analyze(#"""
+        func scratch() -> URL {
+            FileManager.default.temporaryDirectory
+                .appendingPathComponent("run-\(Date())", isDirectory: true)
+        }
+        """#)
+        #expect(issues.count == 1)
     }
 }
 


### PR DESCRIPTION
Both gates were measured against the 26-repository sweep **before** being written. Together they remove **21 of 164** findings.

## 1. A scratch path's name — 14 findings, eight repositories

```swift
FileManager.default.temporaryDirectory
    .appendingPathComponent("import-\(UUID().uuidString)", isDirectory: true)
```

The uniqueness *is* the point — two concurrent callers handed the same name would collide — and every one of these sites creates the directory, uses it, and deletes it on the way out. Nothing compares the name, stores it, or sends it anywhere, so there is no second value for it to disagree with, which is the same test the fabrication branch applies.

**The gate is identity-only, and the first draft got that wrong.** It exempted anything nondeterministic in a temporary path name — which would have silenced `"run-\(Date())"`, the shape that produced a real defect in SwiftMarkdownWiki's snapshot collision loop, terminating *only* because the format carried milliseconds. A UUID is a name that cannot collide; a timestamp is a name that usually does not. **The test written from that corpus case is what caught it, before the gate shipped** — the unit tests around it were happy.

## 2. A test-support target — 7 findings, one directory

`isTestOrFixtureFile()` already matched `Tests/` and `FooTests/`; it now also matches folders ending `TestSupport`, `TestHelpers`, `TestKit`, `TestFixtures`. Those are shipped library products, so nothing about the path said "test" — but every symbol in them exists to be called from a test, and their helpers are *deliberately* nondeterministic: a per-test `UserDefaults` suite name, a per-process scratch root, a unique directory per call.

**That check is shared with other rules, so the blast radius was measured, not argued.** Across the corpus it matches four directories and 39 files, and it removed **exactly seven findings — all this rule's — and three candidate-census entries. No other rule moved.** (The sweep also shows Extractable Total Kernel −2, Law of Demeter −2 and Concrete Type Usage +2 in the same window; those are repository work that landed alongside, not this change, which is why they were checked separately.)

## 3. Bare `.now` stays unflagged — and the measurement turned this around

This was on the list as a false negative worth closing. It should not be closed:

- without type resolution the base of a leading-dot `.now` is unknown;
- the corpus contains `ContinuousClock.Instant = .now`, a **monotonic** read this rule deliberately excludes;
- so classifying bare `.now` as wall-clock trades a false negative for a false positive of exactly the kind the scope note refuses.

`TupleEqualityWithUnstableComponentsVisitor` had already reached that conclusion in this repository — *"Un-based `.now` … is NOT flagged — without type resolution the base is unknown."* Documented in the rule doc rather than changed, with the consequence named: writing `.now` instead of `Date.now` moves a read somewhere the tool cannot see and the count falls as if that were progress.

## What a reviewer should scrutinise

- **`isScratchDirectoryName` stops at the first enclosing call.** Walking past it would exempt a `UUID()` that merely shares a statement with a path append; `uuidBesideAScratchPathIsStillReported` pins that.
- **The receiver check, not the method.** `root.appendingPathComponent("stderr-\(UUID().uuidString).txt")` — a unique filename in a working directory, which does occur in the corpus — is still reported. Keyed on `temporaryDirectory`, not on "appends a path component".
- **`NSTemporaryDirectory()` and a hard-coded `/tmp` are deliberately not covered.** Neither appears in the corpus, and a gate is worth exactly the shapes it was measured against.
- **The suffix match on directories.** `TestSupportRunner` is production and stays reported; `FooCoreTestSupport` does not.

## Verification

3457 tests in 419 suites. Corpus re-swept: the rule goes **153 → 132**, matching the 14 + 7 predicted from the buckets exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4RHsdMsmwJRsc2Va7a3JR