### PR TITLE
Non-Injected Nondeterminism: a closure default is a seam, and a computed property is a fresh read

### DIFF
--- a/Docs/rules/non-injected-nondeterminism.md
+++ b/Docs/rules/non-injected-nondeterminism.md
@@ -16,7 +16,8 @@ A property-based test re-runs logic against many randomized inputs and, when it 
 - The C RNG family: `arc4random`, `arc4random_uniform`, `drand48`, and `CFAbsoluteTimeGetCurrent`
 - Ambient clock/locale reads: `Date.now`, `Locale.current`, `TimeZone.current`
 
-Uses in a parameter *default value* position are exempt (a defaulted `clock: () -> Date = { Date() }` is itself the injection seam), as are test files.
+Uses in a parameter *default value* position are exempt — a defaulted `clock: () -> Date = { Date() }`
+is itself the injection seam — as are test files.
 
 ### Two faults, one trigger
 
@@ -83,6 +84,34 @@ These are **reclassified, not silenced.** They fall through to the rule's ordina
 true of them — a test still cannot pin the id — so the gate moves the corpus count by zero. The
 gate stays shut when the `??` falls back from a call or a literal, because there is no storage a
 later statement could be matched against.
+
+### A closure parameter default is a seam too
+
+The default-value exemption used to stop at any closure, so this was reported:
+
+```swift
+init(clock: @escaping @Sendable () -> Date = { Date() }) { … }
+```
+
+That is the shape this page offers as the fix, and the shape a reader who takes its advice ends up
+writing. The corpus said so plainly: **three sites across two repositories carried a hand-written
+`swiftprojectlint:disable:next` for this rule**, each with a comment beside it making the same
+point — *"The seam itself, and the one place in this type that reads a clock. The rule is right that
+this default reads ambient time — that is what a default is for."* Nobody had traced the
+suppressions back here.
+
+A default value is substitutable by construction, and it makes no difference whether what is handed
+over is the instant (`= Date()`) or the capability that reads it (`= { Date() }`). A test passes
+`{ fixedDate }` to either.
+
+**The line held is `defaultValue`, not "is a closure."** A closure argument at a call site stays
+reported: `items.map { Date() }` runs immediately, and `queue.async { stamp = Date() }` runs later
+with nothing able to replace it. Only a parameter guarantees substitutability. A provider constant
+like `DateProvider { Date() }` is outside it too — the substitutability there comes from the type
+being a provider, which this rule cannot see, and the one in the corpus stays declined in writing
+beside the code.
+
+Corpus effect: **one finding**, and three suppression comments that no longer suppress anything.
 
 ### Two gates on the declines
 

--- a/Docs/rules/non-injected-nondeterminism.md
+++ b/Docs/rules/non-injected-nondeterminism.md
@@ -19,10 +19,10 @@ A property-based test re-runs logic against many randomized inputs and, when it 
 Uses in a parameter *default value* position are exempt — a defaulted `clock: () -> Date = { Date() }`
 is itself the injection seam — as are test files.
 
-### Two faults, one trigger
+### Three faults, one trigger
 
-The same marker witnesses two different problems, and only one of them is about testability. The
-rule reports both, with different messages.
+The same marker witnesses three different problems, and only one of them is about testability. The
+rule reports all three, with different messages.
 
 **Cannot control the value.** A clock or an RNG read inline, feeding a bound, a branch or a retry
 window. The value is real; a test cannot pin it. The discriminator this fault wants — does the
@@ -84,6 +84,40 @@ These are **reclassified, not silenced.** They fall through to the rule's ordina
 true of them — a test still cannot pin the id — so the gate moves the corpus count by zero. The
 gate stays shut when the `??` falls back from a call or a literal, because there is no storage a
 later statement could be matched against.
+
+#### Fresh read per access
+
+A read that is the body of a computed property happens once per **access**, not once:
+
+```swift
+// One reference instant for every state resolution in a render pass
+private var now: Date { Date() }
+```
+
+That comment is from `WaiversView`, and the declaration under it could not deliver what it claimed.
+The view took seventeen reads of `now` in one pass — six across the summary tiles, four building
+the groups below, one per waiver inside each filter — so a waiver crossing its expiry between the
+tile count and the list underneath was counted "Active" above and shown under "Expired" below.
+
+The rule already reported that line, as a value a test could not pin. That is true and is not what
+was wrong with it: **the disagreement survives injection**, because a provider read seventeen times
+still answers seventeen times. A reader who takes the ordinary advice threads a clock through every
+call site and leaves the defect exactly where it was, which is why this shape gets its own sentence.
+
+A name promises a value. `let` delivers one and `var … { }` does not, and the gap is invisible at
+every use site — `now` reads identically either way. The fix is to read once at the top of the
+operation that needs it and pass it down: `body` computes `let now = Date()`, the helpers take
+`asOf: now`.
+
+**The getter must be a single expression**, and that requirement came from the corpus rather than
+from the tests. Without it the check reported `WaiversView` *after* the fix — `let now = Date()`
+followed by a `return` — naming the remedy as the fault. A multi-statement getter has already given
+the value a name, which is the whole repair; what is left is the shape where the property *is* the
+read. Scoped to properties, not to zero-argument functions: `now()` reads as work at every call
+site, `now` reads as a value, and only the second one misleads.
+
+Like the lazy-creation gate, this **changes what the rule says and not what it counts** — 5 sites
+across the sweep corpus, all already reported, all still reported.
 
 ### A closure parameter default is a seam too
 

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor+Messages.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor+Messages.swift
@@ -1,0 +1,102 @@
+import Foundation
+import SwiftProjectLintModels
+import SwiftProjectLintVisitors
+import SwiftSyntax
+
+/// What the rule tells the author, once per fault.
+///
+/// Three markers, three sentences, and the differences between them are the point: the same
+/// `Date()` is a missing seam, an invented value, or a value read afresh on every access depending
+/// only on where it sits. Advice written for one of them is wrong for the other two — the ordinary
+/// message's *"a value that is only stored and shown needs no seam"* waves through every
+/// fabrication, and *"inject the source"* leaves a fresh-read-per-access defect exactly where it
+/// was.
+extension NonInjectedNondeterminismVisitor {
+
+    func flag(_ source: String, at node: Syntax) {
+        addIssue(
+            severity: .warning,
+            message: "Non-injected nondeterminism: `\(source)` makes this code unpredictable, so a "
+                + "property-based test can't pin the value or reproduce a failure",
+            filePath: getFilePath(for: node),
+            lineNumber: getLineNumber(for: node),
+            suggestion: "Inject the source (a clock `() -> Date`, a `RandomNumberGenerator`, a UUID "
+                + "provider) so tests can control it. Worth doing where the value feeds a DECISION — "
+                + "a name, a bound, a branch, a retry window. A value that is only stored and shown "
+                + "needs no seam: a test can construct the record with whatever value it wants.",
+            ruleName: .nonInjectedNondeterminism
+        )
+    }
+
+    /// Reports the fabrication fault: a nondeterministic source standing in for
+    /// a value that was absent.
+    ///
+    /// Deliberately does not mention injection. Injecting a clock here would
+    /// make the invented instant reproducible without making it true, and a
+    /// reader who takes this rule's usual advice on this shape ends up with a
+    /// seam threaded through every call site and the defect still in place.
+    func flagFabrication(_ source: String, at node: Syntax) {
+        addIssue(
+            severity: .warning,
+            message: "Fabricated fallback: `\(source)` invents a value where one was missing, and "
+                + "nothing downstream can tell the invented value from a recorded one",
+            filePath: getFilePath(for: node),
+            lineNumber: getLineNumber(for: node),
+            suggestion: "This is not the testability fault the rest of this rule reports, and "
+                + "injecting a source will not fix it — it makes the invention reproducible. "
+                + "`Date()` is the largest instant in the system and `UUID()` matches no row, so a "
+                + "fabricated value wins every comparison it enters: a `max`, a `>`, a `newest` "
+                + "sort, an is-this-stale check. Propagate the `nil` so callers can say `unknown`, "
+                + "or refuse outright the way `try requireID()` does.",
+            ruleName: .nonInjectedNondeterminism
+        )
+    }
+
+    /// Reports the third fault: a read that is the body of a computed
+    /// property, so it happens once per *access* rather than once.
+    ///
+    /// This is the one shape on this rule where the corpus produced a defect
+    /// that the rule pointed at and described wrongly. `WaiversView` carried
+    ///
+    /// ```swift
+    /// // One reference instant for every state resolution in a render pass
+    /// private var now: Date { Date() }
+    /// ```
+    ///
+    /// and took seventeen reads of it in one pass — six across the summary
+    /// tiles, four building the groups below, one per waiver inside each
+    /// filter. A waiver crossing its expiry between the tile count and the list
+    /// underneath was counted "Active" above and shown under "Expired" below.
+    /// The rule reported that line as a value a test could not pin, which is
+    /// true and is not what was wrong with it: the defect is present with the
+    /// clock injected, because a provider read seventeen times still answers
+    /// seventeen times.
+    ///
+    /// A name promises a value. `let` delivers one and `var … { }` does not,
+    /// and the gap is invisible at every use site — `now` reads identically
+    /// either way. That is why this is worth its own sentence rather than the
+    /// general advice, which would send a reader to thread a clock through and
+    /// leave the disagreement exactly where it was.
+    ///
+    /// Scoped to computed properties, not to zero-argument functions. `now()`
+    /// reads as work at every call site; `now` reads as a value, and only the
+    /// second one misleads.
+    ///
+    /// This changes what the rule *says* and not what it counts — these sites
+    /// were already reported, and still are.
+    func flagFreshReadPerAccess(_ source: String, property: String, at node: Syntax) {
+        addIssue(
+            severity: .warning,
+            message: "Fresh read per access: `\(property)` is a computed property, so each `\(property)` "
+                + "in this type is a separate `\(source)` and no two of them are required to agree",
+            filePath: getFilePath(for: node),
+            lineNumber: getLineNumber(for: node),
+            suggestion: "Injecting a source does not fix this — a provider read N times still "
+                + "answers N times. Read the value once at the top of the operation that needs it "
+                + "and pass it down (`body` computes `let now = Date()`; the helpers take "
+                + "`asOf: now`). Two reads that disagree are a defect wherever a total and a list, "
+                + "a state and a countdown, or a check and the record of it are shown together.",
+            ruleName: .nonInjectedNondeterminism
+        )
+    }
+}

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor+Placement.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor+Placement.swift
@@ -1,0 +1,143 @@
+import Foundation
+import SwiftProjectLintModels
+import SwiftProjectLintVisitors
+import SwiftSyntax
+
+/// Where an expression sits, which is what separates a use from a seam.
+///
+/// These are facts about placement rather than about the expression, so they belong to this
+/// rule's contract rather than to the shared classifier. They live in an extension because the
+/// visitor's own body is at its length limit, and because they read as one group: each one
+/// answers *what is this expression to the declaration around it?*
+extension NonInjectedNondeterminismVisitor {
+
+    /// The name of the computed property whose getter `node` sits in, or `nil`.
+    ///
+    /// Both spellings count — the implicit getter `var now: Date { Date() }`
+    /// and the explicit `var now: Date { get { Date() } }` — because they are
+    /// the same declaration and the same fresh read.
+    ///
+    /// A *stored* property is not this: `let stamp = Date()` is one read at
+    /// initialisation, which is a value, and the rule's ordinary message is the
+    /// right one for it. The walk therefore looks for an accessor block and
+    /// stops at anything that introduces a body of its own — a nested function,
+    /// an initialiser, a closure — so a clock read inside a helper declared
+    /// within a getter is attributed where it is written rather than to the
+    /// property enclosing it.
+    ///
+    /// ## The read has to *be* the property
+    ///
+    /// The getter must be a single expression, and that requirement came out of
+    /// the corpus rather than out of these tests. Without it the check reported
+    ///
+    /// ```swift
+    /// var body: some View {
+    ///     let now = Date()          // ← reported as a fresh read per access
+    ///     return … summary(asOf: now) … content(asOf: now) …
+    /// }
+    /// ```
+    ///
+    /// which is `WaiversView` *after* the fix this message exists to describe:
+    /// one read, bound, threaded. Naming the enclosing property is wrong there
+    /// twice over — the read happens once per evaluation, and `body` is not
+    /// what anyone reads repeatedly.
+    ///
+    /// A multi-statement getter has already given the value a name, which is
+    /// the whole remedy. What is left is the shape where the property *is* the
+    /// read, so the name is the only thing standing between a reader and the
+    /// belief that two mentions of it agree.
+    func computedPropertyName(containing node: Syntax) -> String? {
+        var child = node
+        var current = node.parent
+        while let syntax = current {
+            if syntax.is(ClosureExprSyntax.self)
+                || syntax.is(FunctionDeclSyntax.self)
+                || syntax.is(InitializerDeclSyntax.self)
+                || syntax.is(SubscriptDeclSyntax.self) { return nil }
+
+            // Reached on the way up out of the explicit form. A `set`,
+            // `willSet` or `didSet` body runs on write, not on read, so it is
+            // not a fresh read per access and keeps the ordinary message.
+            if let accessor = syntax.as(AccessorDeclSyntax.self) {
+                guard accessor.accessorSpecifier.tokenKind == .keyword(.get) else { return nil }
+            }
+            if let accessors = syntax.as(AccessorBlockSyntax.self) {
+                guard isSingleExpressionGetter(accessors),
+                      let binding = accessors.parent?.as(PatternBindingSyntax.self),
+                      let name = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text
+                else { return nil }
+                return name
+            }
+            child = syntax
+            current = syntax.parent
+        }
+        return nil
+    }
+
+    /// True when `accessors` is a getter of exactly one statement.
+    ///
+    /// Both spellings again: `{ Date() }` carries the item list directly, and
+    /// `{ get { Date() } }` carries it in the `get` accessor's body. A getter
+    /// that reached its value in several steps has already bound it to a name,
+    /// and binding it is the fix.
+    private func isSingleExpressionGetter(_ accessors: AccessorBlockSyntax) -> Bool {
+        switch accessors.accessors {
+        case .getter(let items):
+            return items.count == 1
+
+        case .accessors(let list):
+            guard let getter = list.first(where: {
+                $0.accessorSpecifier.tokenKind == .keyword(.get)
+            }) else { return false }
+            return getter.body?.statements.count == 1
+        }
+    }
+
+    /// True when `node` sits in a function/initializer parameter's default
+    /// value — `init(id: UUID = UUID())` is the injection seam, not inline
+    /// nondeterminism.
+    ///
+    /// ## A closure default is a seam too
+    ///
+    /// This used to stop at any `ClosureExprSyntax`, so
+    /// `clock: () -> Date = { Date() }` was reported — the exact shape this
+    /// rule's own documentation offers as the fix, and the shape a reader who
+    /// takes its advice ends up writing. The corpus said so plainly: three
+    /// sites across two repositories carried a hand-written
+    /// `swiftprojectlint:disable:next` for this rule, each with a comment
+    /// saying the same thing — *"the seam itself... that is what a default is
+    /// for."* Nobody traced the suppressions back here.
+    ///
+    /// A default value is substitutable by construction, and it makes no
+    /// difference whether the value handed over is the instant (`= Date()`) or
+    /// the capability that reads it (`= { Date() }`). A test passes
+    /// `{ fixedDate }` to either. The closure is not invoked at the seam; it is
+    /// the production implementation of one.
+    ///
+    /// The distinction that is *not* generalised: a closure argument at a
+    /// call site. `items.map { Date() }` runs immediately and
+    /// `queue.async { stamp = Date() }` runs later with nothing able to replace
+    /// it, so the substitutability has to come from the parameter, which is why
+    /// this stays keyed on `defaultValue` rather than on being a closure.
+    ///
+    /// The walk requires the node to sit *inside* the parameter's default-value
+    /// clause rather than merely to have a parameter ancestor, and a function
+    /// or accessor body between the two ends it — a nested declaration's body
+    /// is code that runs, not a value being handed over.
+    func isParameterDefaultValue(_ node: Syntax) -> Bool {
+        var child = node
+        var current = node.parent
+        while let syntax = current {
+            if syntax.is(CodeBlockSyntax.self) || syntax.is(AccessorBlockSyntax.self) {
+                return false
+            }
+            if let parameter = syntax.as(FunctionParameterSyntax.self) {
+                guard let defaultValue = parameter.defaultValue else { return false }
+                return Syntax(defaultValue).id == child.id
+            }
+            child = syntax
+            current = syntax.parent
+        }
+        return false
+    }
+}

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
@@ -617,17 +617,47 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
 
     /// True when `node` sits in a function/initializer parameter's default
     /// value — `init(id: UUID = UUID())` is the injection seam, not inline
-    /// nondeterminism. Stops at a closure / code block so a call inside a
-    /// default closure body is still flagged.
+    /// nondeterminism.
+    ///
+    /// ## A closure default is a seam too
+    ///
+    /// This used to stop at any `ClosureExprSyntax`, so
+    /// `clock: () -> Date = { Date() }` was reported — the exact shape this
+    /// rule's own documentation offers as the fix, and the shape a reader who
+    /// takes its advice ends up writing. The corpus said so plainly: three
+    /// sites across two repositories carried a hand-written
+    /// `swiftprojectlint:disable:next` for this rule, each with a comment
+    /// saying the same thing — *"the seam itself... that is what a default is
+    /// for."* Nobody traced the suppressions back here.
+    ///
+    /// A default value is substitutable by construction, and it makes no
+    /// difference whether the value handed over is the instant (`= Date()`) or
+    /// the capability that reads it (`= { Date() }`). A test passes
+    /// `{ fixedDate }` to either. The closure is not invoked at the seam; it is
+    /// the production implementation of one.
+    ///
+    /// The distinction that is *not* generalised: a closure argument at a
+    /// call site. `items.map { Date() }` runs immediately and
+    /// `queue.async { stamp = Date() }` runs later with nothing able to replace
+    /// it, so the substitutability has to come from the parameter, which is why
+    /// this stays keyed on `defaultValue` rather than on being a closure.
+    ///
+    /// The walk requires the node to sit *inside* the parameter's default-value
+    /// clause rather than merely to have a parameter ancestor, and a function
+    /// or accessor body between the two ends it — a nested declaration's body
+    /// is code that runs, not a value being handed over.
     private func isParameterDefaultValue(_ node: Syntax) -> Bool {
+        var child = node
         var current = node.parent
         while let syntax = current {
-            if syntax.is(ClosureExprSyntax.self) || syntax.is(CodeBlockSyntax.self) {
+            if syntax.is(CodeBlockSyntax.self) || syntax.is(AccessorBlockSyntax.self) {
                 return false
             }
-            if syntax.is(FunctionParameterSyntax.self) {
-                return true
+            if let parameter = syntax.as(FunctionParameterSyntax.self) {
+                guard let defaultValue = parameter.defaultValue else { return false }
+                return Syntax(defaultValue).id == child.id
             }
+            child = syntax
             current = syntax.parent
         }
         return false

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
@@ -160,46 +160,12 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
 
         guard !isIdentifiableIdentity(node),
               !isScratchDirectoryName(node, kind: source.kind) else { return }
+
+        if let property = computedPropertyName(containing: node) {
+            flagFreshReadPerAccess(source.marker, property: property, at: node)
+            return
+        }
         flag(source.marker, at: node)
-    }
-
-    private func flag(_ source: String, at node: Syntax) {
-        addIssue(
-            severity: .warning,
-            message: "Non-injected nondeterminism: `\(source)` makes this code unpredictable, so a "
-                + "property-based test can't pin the value or reproduce a failure",
-            filePath: getFilePath(for: node),
-            lineNumber: getLineNumber(for: node),
-            suggestion: "Inject the source (a clock `() -> Date`, a `RandomNumberGenerator`, a UUID "
-                + "provider) so tests can control it. Worth doing where the value feeds a DECISION — "
-                + "a name, a bound, a branch, a retry window. A value that is only stored and shown "
-                + "needs no seam: a test can construct the record with whatever value it wants.",
-            ruleName: .nonInjectedNondeterminism
-        )
-    }
-
-    /// Reports the fabrication fault: a nondeterministic source standing in for
-    /// a value that was absent.
-    ///
-    /// Deliberately does not mention injection. Injecting a clock here would
-    /// make the invented instant reproducible without making it true, and a
-    /// reader who takes this rule's usual advice on this shape ends up with a
-    /// seam threaded through every call site and the defect still in place.
-    private func flagFabrication(_ source: String, at node: Syntax) {
-        addIssue(
-            severity: .warning,
-            message: "Fabricated fallback: `\(source)` invents a value where one was missing, and "
-                + "nothing downstream can tell the invented value from a recorded one",
-            filePath: getFilePath(for: node),
-            lineNumber: getLineNumber(for: node),
-            suggestion: "This is not the testability fault the rest of this rule reports, and "
-                + "injecting a source will not fix it — it makes the invention reproducible. "
-                + "`Date()` is the largest instant in the system and `UUID()` matches no row, so a "
-                + "fabricated value wins every comparison it enters: a `max`, a `>`, a `newest` "
-                + "sort, an is-this-stale check. Propagate the `nil` so callers can say `unknown`, "
-                + "or refuse outright the way `try requireID()` does.",
-            ruleName: .nonInjectedNondeterminism
-        )
     }
 
     /// A nondeterministic source sitting as the fallback of a `??`, together
@@ -613,53 +579,5 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
         if let decl = syntax.as(ActorDeclSyntax.self) { return decl.inheritanceClause }
         if let decl = syntax.as(EnumDeclSyntax.self) { return decl.inheritanceClause }
         return nil
-    }
-
-    /// True when `node` sits in a function/initializer parameter's default
-    /// value — `init(id: UUID = UUID())` is the injection seam, not inline
-    /// nondeterminism.
-    ///
-    /// ## A closure default is a seam too
-    ///
-    /// This used to stop at any `ClosureExprSyntax`, so
-    /// `clock: () -> Date = { Date() }` was reported — the exact shape this
-    /// rule's own documentation offers as the fix, and the shape a reader who
-    /// takes its advice ends up writing. The corpus said so plainly: three
-    /// sites across two repositories carried a hand-written
-    /// `swiftprojectlint:disable:next` for this rule, each with a comment
-    /// saying the same thing — *"the seam itself... that is what a default is
-    /// for."* Nobody traced the suppressions back here.
-    ///
-    /// A default value is substitutable by construction, and it makes no
-    /// difference whether the value handed over is the instant (`= Date()`) or
-    /// the capability that reads it (`= { Date() }`). A test passes
-    /// `{ fixedDate }` to either. The closure is not invoked at the seam; it is
-    /// the production implementation of one.
-    ///
-    /// The distinction that is *not* generalised: a closure argument at a
-    /// call site. `items.map { Date() }` runs immediately and
-    /// `queue.async { stamp = Date() }` runs later with nothing able to replace
-    /// it, so the substitutability has to come from the parameter, which is why
-    /// this stays keyed on `defaultValue` rather than on being a closure.
-    ///
-    /// The walk requires the node to sit *inside* the parameter's default-value
-    /// clause rather than merely to have a parameter ancestor, and a function
-    /// or accessor body between the two ends it — a nested declaration's body
-    /// is code that runs, not a value being handed over.
-    private func isParameterDefaultValue(_ node: Syntax) -> Bool {
-        var child = node
-        var current = node.parent
-        while let syntax = current {
-            if syntax.is(CodeBlockSyntax.self) || syntax.is(AccessorBlockSyntax.self) {
-                return false
-            }
-            if let parameter = syntax.as(FunctionParameterSyntax.self) {
-                guard let defaultValue = parameter.defaultValue else { return false }
-                return Syntax(defaultValue).id == child.id
-            }
-            child = syntax
-            current = syntax.parent
-        }
-        return false
     }
 }

--- a/Tests/CoreTests/Testability/NonInjectedNondeterminismClosureDefaultTests.swift
+++ b/Tests/CoreTests/Testability/NonInjectedNondeterminismClosureDefaultTests.swift
@@ -1,0 +1,78 @@
+@testable import Core
+import Foundation
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+/// A parameter default is the seam whether it hands over the value or the capability that reads it.
+///
+/// The rule used to stop the default-value walk at any closure, so `clock: () -> Date = { Date() }`
+/// was reported — the exact shape this rule's documentation offers as the fix. The corpus is what
+/// showed the cost: three sites across two repositories carried a hand-written
+/// `swiftprojectlint:disable:next` for this rule, each with a comment beside it saying the same
+/// thing, and none of them had been traced back to the rule.
+///
+/// The line held here is `defaultValue`, not "is a closure". A closure argument at a call site is
+/// still reported: `items.map { Date() }` runs immediately, and `queue.async { stamp = Date() }`
+/// runs later with nothing able to substitute it. Only a parameter guarantees substitutability.
+@Suite("A closure parameter default is an injection seam")
+struct NonInjectedNondeterminismClosureDefaultTests {
+
+    private func analyze(_ source: String) -> [LintIssue] {
+        let visitor = NonInjectedNondeterminismVisitor(patternCategory: .testability)
+        let syntax = Parser.parse(source: source)
+        visitor.setSourceLocationConverter(
+            SourceLocationConverter(fileName: "Logic.swift", tree: syntax)
+        )
+        visitor.setFilePath("Logic.swift")
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == .nonInjectedNondeterminism }
+    }
+
+    @Test("a defaulted clock closure is not reported")
+    func defaultedClockClosureIsNotReported() {
+        #expect(analyze("struct S { init(now: @Sendable () -> Date = { Date() }) {} }").isEmpty)
+    }
+
+    @Test("attributes on the parameter type do not change the answer")
+    func escapingAndSendableAreIrrelevant() {
+        // The shape found in the corpus, verbatim apart from the surrounding type.
+        #expect(analyze("""
+        struct S {
+            init(clock: @escaping @Sendable () -> Date = { Date() }) {}
+        }
+        """).isEmpty)
+    }
+
+    @Test("a multi-statement default closure is not reported either")
+    func multiStatementDefaultClosureIsNotReported() {
+        #expect(analyze("""
+        func f(make: () -> UUID = { let id = UUID(); return id }) {}
+        """).isEmpty)
+    }
+
+    @Test("a closure argument at a call site is still reported")
+    func closureArgumentIsStillReported() {
+        // Not a default, so nothing about it is substitutable: this runs, and the caller of `f`
+        // has no say in what it reads.
+        #expect(analyze("func f(_ xs: [Int]) -> [Date] { xs.map { _ in Date() } }").count == 1)
+    }
+
+    @Test("a stored closure property with a default is still reported")
+    func storedClosurePropertyIsStillReported() {
+        // `var maker: () -> Date = { Date() }` is a stored property, not a parameter. Whether it
+        // can be replaced depends on an initialiser this rule cannot see from here.
+        #expect(analyze("struct S { var maker: () -> Date = { Date() } }").count == 1)
+    }
+
+    @Test("a nested declaration's body inside a default is still reported")
+    func bodyInsideADefaultIsStillReported() {
+        // The walk stops at a function body: code that runs is not a value being handed over.
+        #expect(analyze("""
+        func outer(a: Int = 1) {
+            func inner() -> Date { Date() }
+        }
+        """).count == 1)
+    }
+}

--- a/Tests/CoreTests/Testability/NonInjectedNondeterminismFreshReadTests.swift
+++ b/Tests/CoreTests/Testability/NonInjectedNondeterminismFreshReadTests.swift
@@ -1,0 +1,137 @@
+@testable import Core
+import Foundation
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+/// A computed property is a fresh read on every access, and that is a third fault under this marker.
+///
+/// `WaiversView` carried `private var now: Date { Date() }` under a comment reading *"One reference
+/// instant for every state resolution in a render pass"* — a property the declaration could not
+/// deliver. It took seventeen reads in one pass, so a waiver crossing its expiry between the
+/// summary tiles and the list underneath was counted "Active" above and shown under "Expired"
+/// below.
+///
+/// The rule already reported that line, as a value a test could not pin. That is true and is not
+/// what was wrong with it: the disagreement survives injection, because a provider read seventeen
+/// times still answers seventeen times. So this changes what the rule *says* and not what it
+/// counts — every site here was already reported, and still is.
+@Suite("A computed nondeterministic property reads afresh on every access")
+struct NonInjectedNondeterminismFreshReadTests {
+
+    private func analyze(_ source: String) -> [LintIssue] {
+        let visitor = NonInjectedNondeterminismVisitor(patternCategory: .testability)
+        let syntax = Parser.parse(source: source)
+        visitor.setSourceLocationConverter(
+            SourceLocationConverter(fileName: "Logic.swift", tree: syntax)
+        )
+        visitor.setFilePath("Logic.swift")
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == .nonInjectedNondeterminism }
+    }
+
+    @Test("the implicit getter form names the property and the mechanism")
+    func implicitGetterIsReportedAsAFreshRead() {
+        let issues = analyze("struct V { private var now: Date { Date() } }")
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Fresh read per access") == true)
+        #expect(issues.first?.message.contains("`now`") == true)
+    }
+
+    @Test("the explicit getter form is the same declaration and the same message")
+    func explicitGetterIsReportedAsAFreshRead() {
+        let issues = analyze("struct V { var now: Date { get { Date() } } }")
+        #expect(issues.first?.message.contains("Fresh read per access") == true)
+    }
+
+    @Test("the suggestion refuses injection as the fix")
+    func suggestionSaysInjectionDoesNotFixIt() {
+        // The whole point of the split: a reader who takes the ordinary advice threads a clock
+        // through and leaves the disagreement exactly where it was.
+        let issues = analyze("struct V { var now: Date { Date() } }")
+        #expect(issues.first?.suggestion?.contains("Injecting a source does not fix this") == true)
+    }
+
+    @Test("a stored property keeps the ordinary message")
+    func storedPropertyKeepsTheOrdinaryMessage() {
+        // One read at initialisation is a value. Every use site agrees with every other, which is
+        // the property the computed form cannot offer.
+        let issues = analyze("struct Record { let stamp = Date() }")
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Fresh read per access") == false)
+    }
+
+    @Test("a didSet observer keeps the ordinary message")
+    func didSetKeepsTheOrdinaryMessage() {
+        // An observer runs on write, not on read, so there is no per-access multiplication.
+        let issues = analyze("""
+        struct S {
+            var value: Int = 0 { didSet { stamp = Date() } }
+            var stamp = Date(timeIntervalSince1970: 0)
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Fresh read per access") == false)
+    }
+
+    @Test("a function keeps the ordinary message")
+    func functionKeepsTheOrdinaryMessage() {
+        // Scoped to properties on purpose. `now()` reads as work at every call site; `now` reads
+        // as a value, and only the second one misleads.
+        let issues = analyze("struct V { func now() -> Date { Date() } }")
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Fresh read per access") == false)
+    }
+
+    @Test("a getter that already bound the value keeps the ordinary message")
+    func multiStatementGetterKeepsTheOrdinaryMessage() {
+        // `WaiversView` after the fix this message exists to describe: one read, bound, threaded.
+        // Reporting a fresh read per access here names the remedy as the fault. Caught by running
+        // the corpus, not by this file.
+        let issues = analyze("""
+        struct V {
+            var body: some View {
+                let now = Date()
+                return summary(asOf: now)
+            }
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("Fresh read per access") == false)
+    }
+
+    @Test("a read buried in a longer getter keeps the ordinary message")
+    func readInsideALongerGetterKeepsTheOrdinaryMessage() {
+        // The corpus's second case: a formatted string, not a named instant. The property is not
+        // the read, so the name is not what misleads.
+        let issues = analyze("""
+        struct Row {
+            private var formattedDate: String {
+                let formatter = RelativeDateTimeFormatter()
+                return formatter.localizedString(for: date, relativeTo: Date())
+            }
+        }
+        """)
+        #expect(issues.first?.message.contains("Fresh read per access") == false)
+    }
+
+    @Test("a single expression that computes from the read is still the read")
+    func singleExpressionComputedFromTheReadIsReported() {
+        // `expiryDate` is a fresh instant on every access however much arithmetic sits on top.
+        let issues = analyze("""
+        struct Sheet {
+            private var expiryDate: Date { Date().addingTimeInterval(86_400) }
+        }
+        """)
+        #expect(issues.first?.message.contains("Fresh read per access") == true)
+    }
+
+    @Test("a fabrication inside a getter stays a fabrication")
+    func fabricationInsideAGetterKeepsItsMessage() {
+        // Ordering: inventing a value is the more specific claim, and the reader needs to hear it
+        // ahead of how often the invention happens.
+        let issues = analyze("struct V { var id: UUID { stored ?? UUID() } }")
+        #expect(issues.first?.message.contains("Fabricated fallback") == true)
+    }
+}


### PR DESCRIPTION
Two changes to `Non-Injected Nondeterminism`, both found by reading the corpus
rather than by reasoning about the rule.

## 1. A closure parameter default is the seam

The default-value exemption stopped at any closure, so this was reported:

```swift
init(clock: @escaping @Sendable () -> Date = { Date() }) { … }
```

That is the exact shape the rule's own documentation offers as the fix. The
corpus made the cost visible: **three sites across two repositories carry a
hand-written `swiftprojectlint:disable:next` for this rule**, each with a
comment beside it saying the same thing —

> The seam itself, and the one place in this type that reads a clock. The rule
> is right that this default reads ambient time — that is what a default is for.

None of them had been traced back here. A default value is substitutable by
construction, and it makes no difference whether what is handed over is the
instant (`= Date()`) or the capability that reads it (`= { Date() }`).

**121 → 120 findings**, plus three suppressions in MacCloud_server and
LintStudioUI that no longer suppress anything. Those are not removed here —
they live in other repositories.

## 2. A computed property is a fresh read per access

`WaiversView` carried `private var now: Date { Date() }` under a comment
reading *"One reference instant for every state resolution in a render pass"*,
and took seventeen reads of it in one pass. A waiver crossing its expiry
between the summary tiles and the list underneath was counted "Active" above
and shown under "Expired" below.

The rule reported that line already — as a value a test could not pin, which is
true and is not what was wrong with it. **The disagreement survives injection**:
a provider read seventeen times still answers seventeen times. So this is a
third fault under the same marker and now carries its own message.

**Five sites re-messaged, all in SwiftLintRuleStudioTeam, count unchanged.**
Three of them are live defects and are fixed separately in that repository.

## What a reviewer should scrutinise

- **The single-expression requirement on the getter.** Without it the check
  reported `WaiversView` *after* the fix — `let now = Date()` then a `return` —
  naming the remedy as the fault. That was caught by the corpus sweep, not by
  the tests, and both directions are now pinned
  (`multiStatementGetterKeepsTheOrdinaryMessage`,
  `singleExpressionComputedFromTheReadIsReported`).
- **Ordering in `report`.** The fresh-read branch runs after the fabrication
  branch and after the identity and scratch gates, so it only re-messages what
  would otherwise get the general advice. `fabricationInsideAGetterKeepsItsMessage`
  pins the fabrication half.
- **Scope: properties, not zero-argument functions.** `now()` reads as work at
  every call site; `now` reads as a value. Judgement call, stated in the docs.
- **The `defaultValue` line, not "is a closure".** `items.map { Date() }` and
  `queue.async { stamp = Date() }` stay reported; so does a provider constant
  like `DateProvider { Date() }`, whose substitutability comes from the type
  rather than from a parameter.
- The two file moves are forced by `type_body_length` and `no_grouping_extension`
  together. No behaviour in them changed.

## Verification

`swift test` — 3476 tests in 421 suites pass. Corpus re-swept across all 26
repositories: total findings unchanged at 5920 (the +1 over the pre-change 5919
is the new `computedPropertyName` counting itself in the candidate census),
nondeterminism findings 121 → 120, five re-messaged, nothing else moved.
SwiftLint reports nothing new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)