### PR TITLE
Document the rule changes that shipped without docs

### DIFF
--- a/Docs/rules/computed-property-view.md
+++ b/Docs/rules/computed-property-view.md
@@ -10,7 +10,81 @@
 Computed properties that return `some View` are a common pattern for breaking up `body`, but they defeat SwiftUI's structural identity. SwiftUI can only diff views at the `body` boundary; sub-views expressed as computed properties get re-evaluated on every parent update with no diffing. Separate `struct` views give SwiftUI a stable identity boundary and can independently hold `@State`.
 
 ### Discussion
-`ComputedPropertyViewVisitor` inspects `VariableDeclSyntax` nodes inside types that conform to `View` (or have a `var body: some View` property). It flags any computed property (other than `body`) whose type annotation is `some View`. Properties annotated with `@ViewBuilder` are flagged at `.info` severity since they at least get `@ViewBuilder` result-builder behaviour, though they still lack a stable identity boundary.
+`ComputedPropertyViewVisitor` inspects `VariableDeclSyntax` nodes inside types that conform to `View`
+(or have a `var body: some View` property), and considers any computed property other than `body`
+whose type annotation is `some View`. Properties annotated with `@ViewBuilder` are reported at
+`.info` severity since they at least get result-builder behaviour, though they still lack a stable
+identity boundary.
+
+**It does not report all of them.** The mechanism above is real but its benefit is *conditional*,
+and the rule used to report it unconditionally — 341 findings across nine repositories, of which a
+hand audit found many that could not benefit at all. Three gates now stand between a property and a
+finding, and every one of them was measured against a 26-repository corpus rather than argued for.
+The count is **134**.
+
+#### Gate 1 — the property must take a narrower input than its parent
+
+A child `View` only skips an update when its inputs are *narrower* than its parent's. Extract
+`SummaryRow(issue:)` out of a view that re-renders whenever `issue` changes and the child re-renders
+in lockstep: the same work, one more type.
+
+So a property is reported only when its transitive dependency on the enclosing type's stored inputs
+is a **strict subset** of them. A view with no inputs yields nothing — its value already compares
+equal to itself, so SwiftUI can skip it unaided.
+
+Dependencies are followed **transitively** through the type's other computed properties: a property
+that reads nothing itself but calls one that reads `isExpanded` depends on `isExpanded`. Without
+that, every wrapper property looks input-free and all of them fire.
+
+This is a *necessary* condition for the diffing benefit, not a sufficient one — a two-line `Text`
+gains little either way — but it is the condition the rule can check. A property depending on four
+of five inputs still passes and its benefit is marginal; no threshold has a principled defence, so
+none was invented.
+
+#### Gate 2 — dialog and menu builders are left alone
+
+`confirmationDialog(actions:)`, `alert(actions:)` and `Menu(content:)` read a *collection of
+buttons* out of the closure they are handed. A `View` struct wrapping those buttons is a container
+they are not specified to accept, so following this rule there could change **what the app does**
+rather than only how it redraws. It is the one shape with that risk, and it is now silent.
+
+The search covers a builder's arguments and trailing closures but never the called expression —
+for a modifier that holds the receiver, which is the entire view it is applied to. It is
+deliberately coarse in one direction: a name appearing in `alert`'s `message:` closure is spared
+along with the ones in `actions:`. Sparing a property costs a finding; reporting one whose
+extraction breaks a dialog costs a working app.
+
+#### Gate 3 — a child that requires capture cannot be skipped
+
+**This one is measured.** A harness counted `body` evaluations while changing state no child reads
+(iOS 26.5, three changes):
+
+| Child holds | Re-renders |
+|---|---|
+| No inputs, a value input, or a *non-capturing* closure | **0** |
+| A `@Binding`, or a *capturing* closure | **3** — once per change |
+
+Three is exactly as often as the inlined property it replaced, so extracting those is a new type for
+no benefit. **The distinction is capture, not closures**: `action: { }` compiles to one static
+function and compares equal, while `action: { showingSheet = true }` allocates a fresh context on
+every parent body run, so the child value never compares equal. A `Binding` carries a getter and
+setter and behaves the same way.
+
+That correction came out of the measurement itself. The harness's first version used `action: { }`
+and reported the opposite conclusion — a shape no real app contains would otherwise have decided
+the design.
+
+Three shapes force capture: reading a stored property's projected value (`$name`), assigning to one,
+or calling one of the type's own methods. Followed transitively, since a property composing children
+that each need a binding has to pass those bindings down.
+
+#### What the rule still cannot see
+
+It fires on the return type, so a property returning `String` or `Color` is invisible to it — and
+those are often the ones holding a decision. Lifting three of them out of one view (a severity icon,
+colour and accessibility label) stated two laws no per-case example could: no two severities may
+share an icon or a colour, and none may share a VoiceOver label. Worth looking for by hand while
+you are in the file.
 
 ### Non-Violating Examples
 ```swift

--- a/Docs/rules/extractable-total-kernel.md
+++ b/Docs/rules/extractable-total-kernel.md
@@ -25,6 +25,26 @@ contains it; the method is `private`, `async` and `throws`, and calling it means
 session and a server. So the part of the code that can actually be **wrong** — the counting, the
 offsets, the fractions — is the part nothing can reach.
 
+### A binding that reads ambient state is not a kernel
+
+The rule's message tells the author a binding *"depends only on its parameters and locals"*. A clock
+read makes that claim false, so any binding whose value reads ambient state is refused outright,
+whatever shape it has below.
+
+This was a defect, and the shape of it is worth keeping. `let elapsed = ContinuousClock.now - lastActivityAt`
+satisfies the rule's shape test — a derived binding, then a comparison that uses it — so three
+findings in SwiftAssist told their author exactly the thing that was not true of them: an idle
+check, a staleness check and a stream deadline.
+
+**The purity oracle already knew.** `ContinuousClock` was classified as a nondeterminism source all
+along; the rule simply never asked it. It survived because the check it *did* run walks call
+expressions, and `ContinuousClock.now` is a member access with no call in it — while `Date()` **is**
+a call and was refused from the start. So the obvious probe passed and only the clock-property
+spelling ever got through.
+
+The general lesson is worth more than the fix: **a rule can be blind to something the tool it is
+built on already knows.** Nothing was missing from the classifier.
+
 ### Discussion
 
 The case this rule was built for:

--- a/Docs/rules/law-of-demeter.md
+++ b/Docs/rules/law-of-demeter.md
@@ -16,6 +16,36 @@ The idiomatic fix is to add a method on the *immediate* collaborator that encaps
 
 Member-access chains of **3 or more dots** (i.e., four or more components: `a.b.c.d`) where the root is a plain identifier — not `self`, a type name, or the result of a function call. The rule reports the full chain in the message so the violation is immediately visible.
 
+### One finding per reach-through, not per occurrence
+
+A finding is reported once per **(enclosing declaration, reach-through target)**, where the target is
+the *penultimate* component — the thing being reached into. A second chain into the same target from
+the same declaration is the same problem and the same fix, so it is not reported again.
+
+**The old count was not merely noisy, it was backwards.** Measured on two repositories before this
+changed: five sort comparators in SwiftInferProperties produced **48 findings for one missing
+`Comparable` conformance**, while eleven DTO-flattening constructors in SwiftAssist produced eleven
+for zero problems — flattening a nested `Range` into flat wire fields is what a DTO is *for*.
+
+Ranking by occurrence therefore put the largest cluster on the page at the top, and that cluster was
+the *cheapest* fix — one conformance, one line — while the single-digit findings were the ones
+needing judgement. The ranking sent a reader to the easy work and called it the biggest thing there.
+
+**The key is the penultimate hop rather than the root**, because that is where the encapsulation
+goes. `lhs.member.location.file` and `rhs.member.location.line` are one problem with `location`;
+keyed on the root they would be two, splitting one fix in half.
+
+Re-measured against source that still contained those clusters: **90 occurrences, 40
+reach-throughs.** Expect reductions on this rule to look smaller and mean more.
+
+> **What the count is good for is finding the file, not sizing the work.** Worked across three
+> repositories, the defect sat *beside* the chain every time rather than in it — five comparators
+> that all ignored `column`, so two declarations on one line compared equal and their order fell to
+> a sort Swift does not promise is stable; a second path format built from
+> `context.jail.root.path`, so one file had two names; a private colour switch four lines under an
+> exempt chain that disagreed with the shared one on four of five categories. One finding in a
+> three-finding repository was worth more than the forty-eight one conformance cleared.
+
 ### Exempt patterns
 
 Several common patterns look like deep chains but are not object-graph coupling. The rule suppresses all of the following:

--- a/Docs/rules/non-injected-nondeterminism.md
+++ b/Docs/rules/non-injected-nondeterminism.md
@@ -63,6 +63,23 @@ repositories**, 2 of them live defects and 2 more already unreachable by constru
 inside this rule rather than promoted to its own, because every one of these sites was already
 reported here and moving them would hand new findings to anyone who had disabled the rule.
 
+#### The identity may be reached through a computed `id`
+
+The exemption used to require a stored binding literally named `id`. Several codebases cannot spell
+it that way: a SwiftLint `identifier_name` minimum of three characters makes `id` unavailable as a
+stored property, so the conformance is satisfied by
+
+```swift
+let identifier = UUID()
+var id: UUID { identifier }
+```
+
+The gate was asking for a name the project's own configuration forbids. It now resolves a computed
+`id` to the property it returns.
+
+**The link is required, not just the conformance.** A second `UUID` on the same type that `id` does
+not return is a different value — it may be a database key or a wire value — and stays reported.
+
 The fabrication check runs *before* the `Identifiable` identity exemption, and that order matters:
 `struct Response: Identifiable { let id = model.id ?? UUID() }` satisfies the exemption exactly, and
 is also the shape of the four DTO defects that motivated the split.
@@ -163,6 +180,17 @@ The uniqueness *is* the point — two concurrent callers handed the same name wo
 every one of these sites creates the directory, uses it, and deletes it on the way out. Nothing
 compares the name, stores it, or sends it anywhere, so there is no second value for it to disagree
 with, which is the same test the fabrication branch applies.
+
+**Both spellings of the temporary directory count.** The gate matched
+`FileManager.default.temporaryDirectory` at the head of a member chain, and the corpus also writes
+
+```swift
+URL(fileURLWithPath: NSTemporaryDirectory())
+    .appendingPathComponent("spm-\(UUID().uuidString)")
+```
+
+where the call sits inside a `URL` initialiser instead. Same scratch path, same reason it needs no
+seam, and the first version of the gate did not see it.
 
 **Only an identity source**, and the first draft got that wrong: it exempted anything
 nondeterministic in a temporary path name, which would have silenced `"run-\(Date())"` — and a


### PR DESCRIPTION
**Audit result: four rules changed behaviour over the last ten merged PRs, and
`Docs/rules/` recorded none of it.** The rule docs date from 6 April; the
changes are from September.

Found by checking every commit that touched a `*Visitor.swift` against whether
the same commit touched `Docs/rules/`. Ten commits changed a visitor with no
doc change.

This is the same failure the sweep report keeps describing from the other
direction — a rule whose message or behaviour no longer matches what it says.
Here the mismatch was between the rule and its documentation, which is worse,
because the doc is what a reader consults when a finding surprises them.

## What was wrong

**Computed Property View** — the doc said the rule "flags **any** computed
property (other than `body`) whose type annotation is `some View`". True in
April. Since then it grew three gates (#131, #133, #135) and went from 341
findings to 134. A reader following the doc would expect it to fire on
everything and have no way to understand why their property was passed over.

**Law of Demeter** — #138 changed it to report once per *(enclosing
declaration, penultimate component)* rather than per occurrence. The doc still
described the old behaviour. That omission matters more than most: the change
was not noise reduction, it was a fix for a count that **inverted the
priority**, putting the cheapest fix at the top of the list.

**Extractable Total Kernel** — #129 added a guard refusing bindings that read
ambient state. Undocumented.

**Non-Injected Nondeterminism** — the two gates in #143 (the
`NSTemporaryDirectory()` spelling, and resolving a computed `id`) shipped with
tests and no docs. The two changes in #144 were documented at the time and are
untouched here.

## What a reviewer should scrutinise

- **Accuracy over completeness.** Each section was written from the visitor's
  own doc comments and the measurements in them, not from memory. The counts
  quoted (134 for Computed Property View; 90 occurrences / 40 reach-throughs
  for Law of Demeter) were re-checked against a fresh 26-repository sweep.
- **The Computed Property View section is long**, because gate 3 is the only
  rule decision on the project made by measurement, and the measurement
  corrected its own first attempt. If that reads as too much for a rule doc,
  the table is the part worth keeping.
- **No rule behaviour changed.** Documentation only — `swift test` passes 3476
  tests in 421 suites, unchanged, and `RuleDocumentationConsistencyTests` still
  passes.

## Worth considering separately

Nothing enforces this. `RuleDocumentationConsistencyTests` checks that a doc
*exists* per rule and that identifiers match, which is why four docs could go
five months out of date without failing. A check that a doc changed whenever
its visitor did would have caught all four, and cannot be written as a unit
test — it is a pre-merge check on the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)