### PR TITLE
Extract the view properties that can actually skip an update

### DIFF
--- a/Sources/App/Views/ConfigDiffPreviewSheet.swift
+++ b/Sources/App/Views/ConfigDiffPreviewSheet.swift
@@ -11,7 +11,7 @@ struct ConfigDiffPreviewSheet: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            header
+            DiffSheetHeader()
             Divider()
             UnifiedDiffContentView(
                 before: beforeYAML,
@@ -25,18 +25,17 @@ struct ConfigDiffPreviewSheet: View {
         .frame(minWidth: 600, idealWidth: 700, minHeight: 400, idealHeight: 500)
     }
 
-    private var header: some View {
-        HStack {
-            Image(systemName: "doc.text.magnifyingglass")
-                .foregroundStyle(.secondary)
-                .accessibilityHidden(true)
-            Text("Review Configuration Changes")
-                .font(.headline)
-            Spacer()
-        }
-        .padding()
-    }
-
+    /// Kept inline deliberately, and this is a decline rather than an oversight.
+    ///
+    /// Extracting it would hand a child `onConfirm` and `onCancel`. Both capture `viewModel` at
+    /// the call site in `ContentView`, so they allocate a fresh context on every parent body run
+    /// and the child value never compares equal — a child holding a capturing closure was measured
+    /// to re-render exactly as often as the inlined property it replaced. There is no update for
+    /// it to skip.
+    ///
+    /// `Computed Property View` still reports this. Its capture gate sees a closure the property
+    /// *creates*, not one it is *handed*, and closing that is a decision with its own evidence to
+    /// gather.
     private var footer: some View {
         HStack {
             Spacer()
@@ -45,6 +44,24 @@ struct ConfigDiffPreviewSheet: View {
             Button("Save Changes", action: onConfirm)
                 .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
+        }
+        .padding()
+    }
+}
+
+/// The sheet's title bar, which depends on nothing.
+///
+/// A child with no inputs compares equal to itself on every parent update, so SwiftUI skips it —
+/// measured at **0** re-renders over three changes, against 3 for the inlined property.
+private struct DiffSheetHeader: View {
+    var body: some View {
+        HStack {
+            Image(systemName: "doc.text.magnifyingglass")
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            Text("Review Configuration Changes")
+                .font(.headline)
+            Spacer()
         }
         .padding()
     }

--- a/Sources/App/Views/LintIssueRow.swift
+++ b/Sources/App/Views/LintIssueRow.swift
@@ -35,47 +35,16 @@ struct LintIssueRow: View {
 
     private var summaryRow: some View {
         HStack {
-            severityIcon
-            issueSummary
+            SeverityIcon(severity: issue.severity)
+            IssueSummary(issue: issue)
             Spacer()
             expandToggle
         }
     }
 
-    private var issueSummary: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(issue.message)
-                .font(.headline)
-                .foregroundStyle(.primary)
-                .fixedSize(horizontal: true, vertical: true)
-                .lineLimit(nil)
-            Text(issue.ruleName.rawValue)
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-                .fontDesign(.monospaced)
-            locationLines
-        }
-    }
-
-    @ViewBuilder
-    private var locationLines: some View {
-        if issue.locations.count == 1 {
-            Text("\(issue.locations[0].filePath):\(issue.locations[0].lineNumber)")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        } else {
-            VStack(alignment: .leading, spacing: 2) {
-                ForEach(Array(issue.locations.enumerated()), id: \.offset) { _, location in
-                    Text("\(location.filePath):\(location.lineNumber)")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            }
-        }
-    }
-
+    /// Kept inline deliberately. Extracting it would hand a child a `Binding<Bool>`, and a child
+    /// holding a binding re-renders exactly as often as the property it replaced — measured, and
+    /// the reason `Computed Property View` does not report this one.
     private var expandToggle: some View {
         Button {
             withAnimation(.easeInOut(duration: Self.expandAnimationDuration)) {
@@ -87,13 +56,73 @@ struct LintIssueRow: View {
         }
         .accessibilityLabel(isExpanded ? "Collapse details" : "Expand details")
     }
+}
 
-    private var severityIcon: some View {
-        let style = IssueSeverityStyle(issue.severity)
+// MARK: - Summary subviews
+
+/// The severity glyph, which depends on the severity and nothing else.
+///
+/// The narrowest input in this file: `IssueSeverity` is an enum, so two rows showing the same
+/// severity compare equal and SwiftUI can skip this entirely. Expanding a row changes neither the
+/// issue nor its severity, so this no longer re-evaluates when the chevron is tapped.
+private struct SeverityIcon: View {
+    let severity: IssueSeverity
+
+    var body: some View {
+        let style = IssueSeverityStyle(severity)
         return Image(systemName: style.iconName)
             .foregroundStyle(style.color)
             .font(.title2)
             .accessibilityLabel(style.accessibilityLabel)
+    }
+}
+
+/// Message, rule name and locations — everything in the row that depends on the issue.
+///
+/// Its input is a strict subset of the parent's, which is the condition for SwiftUI to skip it:
+/// `LintIssueRow` re-renders on `issue` *or* `isExpanded`, and this depends only on the first.
+private struct IssueSummary: View {
+    let issue: LintIssue
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(issue.message)
+                .font(.headline)
+                .foregroundStyle(.primary)
+                .fixedSize(horizontal: true, vertical: true)
+                .lineLimit(nil)
+            Text(issue.ruleName.rawValue)
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .fontDesign(.monospaced)
+            IssueLocationLines(locations: issue.locations)
+        }
+    }
+}
+
+/// One `file:line` when there is a single location, a stacked list when there are several.
+///
+/// Takes the locations rather than the whole issue, so it is untouched by a change to the message
+/// or the rule name.
+private struct IssueLocationLines: View {
+    let locations: [(filePath: String, lineNumber: Int)]
+
+    var body: some View {
+        if locations.count == 1 {
+            Text("\(locations[0].filePath):\(locations[0].lineNumber)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        } else {
+            VStack(alignment: .leading, spacing: 2) {
+                ForEach(Array(locations.enumerated()), id: \.offset) { _, location in
+                    Text("\(location.filePath):\(location.lineNumber)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Applies `Computed Property View` to this repository's own app. **6 → 1
finding**, and the one that remains is a decline with the reasoning written
beside it.

This is the first time the rule has been *worked* rather than tightened. Three
gates were added to it on the strength of hand-classifying `LintIssueRow`;
this is that classification carried through to the code.

## What was extracted

`LintIssueRow` re-renders on `issue` **or** `isExpanded`. Three of its
properties read only `issue`, so every tap of the chevron re-evaluated them for
a row whose content had not changed.

- **`SeverityIcon(severity:)`** — the narrowest input in the file.
  `IssueSeverity` is an enum, so it compares equal and SwiftUI skips it.
- **`IssueSummary(issue:)`** — message, rule name, locations.
- **`IssueLocationLines(locations:)`** — takes the locations rather than the
  whole issue, so a change to the message leaves it alone.
- **`DiffSheetHeader()`** in `ConfigDiffPreviewSheet` — depends on nothing at
  all, which the harness measured at **0** re-renders against 3 for the inlined
  property.

## What was declined, and why it is written down

**`expandToggle`** stays inline: extracting it hands a child a `Binding<Bool>`,
measured to re-render exactly as often as the property it replaced. The rule
agrees — this is the finding #147 stopped reporting.

**`footer`** stays inline and the rule *still reports it*. Extracting it would
hand a child `onConfirm` and `onCancel`, and both capture `viewModel` at the
call site in `ContentView`, so the child value never compares equal and there is
no update for it to skip. The comment says so at the site rather than leaving
the next reader to re-derive it.

## What a reviewer should scrutinise

- **The 17 ViewInspector tests pass unchanged**, which is the check that
  matters: they assert on rendered text and image names, so they would fail if
  the extraction changed what the row draws. They also traverse into the new
  child views, which is worth confirming is real coverage rather than a
  vacuous pass.
- **`IssueSummary(issue:)` takes the whole `LintIssue`.** That is still a strict
  subset of the parent's inputs, but it is not narrow. `LintIssue` also cannot
  be `Equatable` — `locations` is `[(filePath: String, lineNumber: Int)]`, and
  tuples cannot conform — so how well SwiftUI compares it is worth knowing and
  I have not measured it here. A separate question, noted below.
- The extracted types are `private` to their files, so nothing else can pick
  them up by accident.

## Two things this turned up

**`LintIssue` cannot be `Equatable`** because `locations` is an array of tuples,
while `Core/Export` already has an `IssueLocation` struct for the same data.
Making the model use it would let the type conform, which is what SwiftUI needs
to skip a child cleanly — and is also what `Missing Equatable on State Type`
exists to ask for. Not done here; it changes the model.

**The capture gate cannot see a closure the property is *handed*.** 14 of the
remaining 133 findings across six repositories are properties forwarding a
stored closure input. Whether extracting them helps depends on whether the
closure captures, which is decided at the call site and is invisible from inside
the view. Measured but not acted on.

## Verification

`swift test` — 3479 tests in 421 suites pass. SwiftLint clean. The rule's count
for this repository goes 6 → 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)