### PR TITLE
Gate a property that forwards a closure the view was handed

### DIFF
--- a/Docs/rules/computed-property-view.md
+++ b/Docs/rules/computed-property-view.md
@@ -74,9 +74,28 @@ That correction came out of the measurement itself. The harness's first version 
 and reported the opposite conclusion — a shape no real app contains would otherwise have decided
 the design.
 
-Four shapes force capture: reading a stored property's projected value (`$name`), assigning to one,
-calling `toggle()` on one, or calling one of the type's own methods. Followed transitively, since a
-property composing children that each need a binding has to pass those bindings down.
+Five shapes force capture: reading a stored property's projected value (`$name`), assigning to one,
+calling `toggle()` on one, calling one of the type's own methods, or **forwarding a stored closure
+input**. Followed transitively, since a property composing children that each need a binding has to
+pass those bindings down.
+
+The last of those is the callback a view is *handed* rather than one it makes:
+
+```swift
+let onConfirm: () -> Void
+private var footer: some View { Button("ok", action: onConfirm) }   // not reported
+```
+
+It is the same closure crossing the same boundary, arriving by a different route. Whether the child
+can ever compare equal is decided by the call site that supplied the closure — invisible from
+inside the view, and in every instance the corpus contains, it captures. `() -> Void`,
+`(() -> Void)?` and `@escaping (T) -> Void` all count; an optional wraps a *parenthesised* function
+type, which parses as a one-element tuple, so all three spellings resolve to the same test.
+
+Measured before it shipped: **13 findings across six repositories, 0 newly reported.** Two of the
+thirteen had already been declined by hand, in comments written into the code they name, by a
+reader working the rule earlier the same day — the gate silences exactly the properties someone had
+independently judged not worth extracting.
 
 > **`toggle()` was in the gate from the start and never fired.** The helper that resolved its
 > receiver inspected a node's children and not the node itself, so it was handed `isExpanded` and

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift
@@ -155,6 +155,7 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
             if !captures.isDisjoint(with: members.stored) { return true }
             let referenced = members.computedReferences[current] ?? []
             if !referenced.isDisjoint(with: members.instanceMethods) { return true }
+            if !referenced.isDisjoint(with: members.closureInputs) { return true }
             pending.append(contentsOf: referenced.filter { members.computedReferences[$0] != nil })
         }
         return false
@@ -214,6 +215,10 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
         /// Per computed property: the names it uses as a projected value (`$name`) and the names
         /// it assigns to. Both force a `Binding` or a capturing closure across the boundary.
         var capturesFor: [String: Set<String>] = [:]
+        /// Stored properties whose declared type is a function — the callbacks a view is handed.
+        /// Forwarding one to a child puts that closure across the boundary just as creating one
+        /// does.
+        var closureInputs: Set<String> = []
     }
 
     /// The type's stored inputs, what each computed property references, and which of them return
@@ -242,7 +247,10 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
         guard let accessor = binding.accessorBlock else {
             // A stored property. `static let` is a constant, not an input the view re-renders on,
             // so it is not part of the surface.
-            if !isStatic { result.stored.insert(name) }
+            if !isStatic {
+                result.stored.insert(name)
+                if isFunctionType(binding.typeAnnotation?.type) { result.closureInputs.insert(name) }
+            }
             return
         }
         result.computedReferences[name] = referencedNames(in: Syntax(accessor))
@@ -363,6 +371,29 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
             == .keyword(.self) {
             names.insert(member.declName.baseName.text)
         }
+    }
+
+    /// Whether `type` is a function type, seeing through the wrappers a callback is usually
+    /// declared with.
+    ///
+    /// `() -> Void`, `(() -> Void)?` and `@escaping (Template) -> Void` are all the same thing for
+    /// this purpose, and the corpus writes all three. An optional wraps a *parenthesised* function
+    /// type, which parses as a one-element tuple, so the tuple case is what makes the optional
+    /// spelling work rather than an accident.
+    private static func isFunctionType(_ type: TypeSyntax?) -> Bool {
+        guard let type else { return false }
+        if type.is(FunctionTypeSyntax.self) { return true }
+        if let optional = type.as(OptionalTypeSyntax.self) {
+            return isFunctionType(optional.wrappedType)
+        }
+        if let attributed = type.as(AttributedTypeSyntax.self) {
+            return isFunctionType(attributed.baseType)
+        }
+        if let tuple = type.as(TupleTypeSyntax.self), tuple.elements.count == 1,
+           let only = tuple.elements.first {
+            return isFunctionType(only.type)
+        }
+        return false
     }
 
     /// `$isExpanded` and `isExpanded` are the same input.

--- a/Sources/App/Views/ConfigDiffPreviewSheet.swift
+++ b/Sources/App/Views/ConfigDiffPreviewSheet.swift
@@ -33,9 +33,8 @@ struct ConfigDiffPreviewSheet: View {
     /// to re-render exactly as often as the inlined property it replaced. There is no update for
     /// it to skip.
     ///
-    /// `Computed Property View` still reports this. Its capture gate sees a closure the property
-    /// *creates*, not one it is *handed*, and closing that is a decision with its own evidence to
-    /// gather.
+    /// The rule agrees now. Its capture gate saw a closure a property *creates* and not one it is
+    /// *handed*; this property was one of the thirteen that closing the gap silenced.
     private var footer: some View {
         HStack {
             Spacer()

--- a/Tests/CoreTests/Architecture/ComputedPropertyViewCaptureTests.swift
+++ b/Tests/CoreTests/Architecture/ComputedPropertyViewCaptureTests.swift
@@ -214,4 +214,68 @@ struct ComputedPropertyViewCaptureTests {
         """)
         #expect(issues.count == 1)
     }
+
+    /// A callback the view is *handed* crosses the boundary exactly as one it *makes*.
+    ///
+    /// The gate caught a closure a property creates and missed one it forwards, which is the same
+    /// closure arriving by a different route. `Button("ok", action: onConfirm)` puts `onConfirm`
+    /// into the child, and whether that child can ever compare equal is decided by the call site
+    /// that supplied it — invisible from here, and in every corpus instance it captures.
+    ///
+    /// Measured before the gate was written: 13 findings across six repositories, 0 newly
+    /// reported. Two of the thirteen had already been declined by hand in the code they name,
+    /// which is the calibration — the gate silences the properties a reader had independently
+    /// judged not worth extracting.
+    @Test("a property forwarding a closure input is not worth extracting")
+    func forwardedClosureCountsAsCapture() {
+        #expect(filteredIssues("""
+        struct Sheet: View {
+            let title: String
+            let onConfirm: () -> Void
+            private var footer: some View { Button("ok", action: onConfirm) }
+            var body: some View { VStack { footer; Text(title) } }
+        }
+        """).isEmpty)
+    }
+
+    @Test("an optional closure input counts too")
+    func optionalClosureInputCountsAsCapture() {
+        // `(() -> Void)?` parses as an optional wrapping a *parenthesised* function type, which is
+        // a one-element tuple. The corpus writes callbacks this way as often as the plain form.
+        #expect(filteredIssues("""
+        struct Row: View {
+            let title: String
+            var onTap: (() -> Void)?
+            private var button: some View { Button("x") { onTap?() } }
+            var body: some View { VStack { button; Text(title) } }
+        }
+        """).isEmpty)
+    }
+
+    @Test("an attributed closure input counts too")
+    func attributedClosureInputCountsAsCapture() {
+        #expect(filteredIssues("""
+        struct Row: View {
+            let title: String
+            let onApply: @Sendable (Int) -> Void
+            private var button: some View { Button("a") { onApply(1) } }
+            var body: some View { VStack { button; Text(title) } }
+        }
+        """).isEmpty)
+    }
+
+    /// The non-vacuity guard. A stored property that is *not* a closure does not gate, or this
+    /// would silence every property that reads any input.
+    @Test("a value input is still reported")
+    func valueInputIsStillReported() {
+        let issues = filteredIssues("""
+        struct Row: View {
+            let title: String
+            let onConfirm: () -> Void
+            private var heading: some View { Text(title) }
+            var body: some View { VStack { heading; Button("ok", action: onConfirm) } }
+        }
+        """)
+        #expect(issues.count == 1)
+    }
 }


### PR DESCRIPTION
The capture gate caught a closure a property **creates** and missed one it
**forwards**. Both put the same closure across the same boundary.

```swift
let onConfirm: () -> Void
private var footer: some View { Button("ok", action: onConfirm) }   // was reported
```

Whether the extracted child can ever compare equal is decided by the call site
that supplied the closure — invisible from inside the view, and in every
instance the corpus contains, it captures. Gate 3's harness already measured
what follows: a child holding a capturing closure re-renders **exactly as often
as the property it replaced**. There is no update for the extraction to skip.

That is why this needed no new measurement — it is the same fault the gate
already accepts, reached by a different syntactic route.

## Measured before shipping

**13 findings across six repositories, 0 newly reported**, on identical code
with the binary built either side of the change.

| Repository | Gated |
|---|---|
| SwiftLintRuleStudio | 8 |
| SwiftFormatRuleStudio, SwiftLintRuleStudioTeam, SwiftMarkdownWiki, SwiftProjectLint, SwiftUMLStudio | 1 each |

**Two of the thirteen had already been declined by hand**, in comments written
into the code they name while working this rule earlier today —
`ConfigDiffPreviewSheet.footer` and `RuleAuditRow.actionColumn`. The gate
silences exactly the properties a reader had independently judged not worth
extracting, which is the calibration that matters: it was checked against
someone's prior judgement rather than only against its own tests.

Those two comments said "the rule still reports this". One is updated here; the
other lives in SwiftLintRuleStudio and needs a follow-up there.

## What a reviewer should scrutinise

- **This is a deliberate false negative in one case.** A *non-capturing* closure
  input — a static function reference — would let the child skip when some other
  input changed, and this now silences that too. No corpus instance is
  non-capturing, and the project has consistently chosen this direction: sparing
  a property costs a finding, recommending a useless extraction costs the
  reader's time.
- **`isFunctionType` sees through three wrappers** — optional, attributed, and
  the one-element tuple an optional function type parses as. Worth confirming it
  cannot match a non-closure type; `valueInputIsStillReported` is the
  non-vacuity guard.
- Capture is followed transitively, so a property composing a gated one is also
  gated. `p5` in the probe covers it.

## Verification

`swift test` — **3483 tests in 421 suites pass**. SwiftLint clean. Corpus
re-swept: 121 → 108 findings, nothing newly reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)