### PR TITLE
Read the roster out of a run of sibling actions

### DIFF
--- a/Docs/rules/parallel-list-drift.md
+++ b/Docs/rules/parallel-list-drift.md
@@ -39,12 +39,38 @@ in the same file.
    (`"state-management"`), leading-dot members (`.stateManagement`), or type references
    (`StateManagement`). A mixed-kind array is a data structure, not an enumeration, and is
    skipped. The list is named after the binding it belongs to (`let packs = [...]` → `packs`).
-3. **Runs of consecutive registration calls** — the shape
+3. **Runs of consecutive calls**, in two shapes.
+
+   The first is a run of **registration calls** — the shape
    [Manual Registration List](manual-registration-list.md) detects, read for its contents.
    The distinguishing name is taken from the call's trailing closure when it has one
    (`registerFactory { _, _ in StateManagement(…) }` → `StateManagement`), otherwise from the
    first name-like argument (`register("fetch")` → `fetch`). Both rules share the verb
    vocabulary in `RegistrationVerb`, so a verb added for one is honoured by the other.
+
+   The second is a run of **sibling calls whose actions each name a distinct case**:
+
+   ```swift
+   Button("Rules")   { selection = .rules }
+   Button("Reports") { selection = .reports }
+   ```
+
+   A menu built this way is an enumeration transcribed by hand. There is no verb to gate on and
+   none is needed, because the leading-dot member is its own signal — this is not "any run of
+   calls with the same callee", which would read every repeated view builder as a roster.
+
+   **Only the action closure is searched, never the arguments.** A roster entry is what the item
+   *does*, not how it is *styled*. Reading arguments too collected `.red`, `.green` and
+   `.primary` out of lists of summary tiles, so two unrelated views drawing four tiles apiece
+   paired on three shared colour names and reported drift against each other — two false
+   positives, both gone once arguments were excluded. An action naming two members contributes
+   nothing, since it cannot supply one entry without choosing arbitrarily between them.
+
+   This carrier exists because of a defect the rule could not see. A title menu was eleven
+   `Button`s against a twelve-case enum and silently omitted one destination, reachable from the
+   sidebar and nowhere else. Written as `[.rules, .reports, …]` this rule reported it and named
+   the missing case; written as eleven calls it saw nothing. Measured across the corpus, the
+   carrier adds **no findings to code that does not have the defect** — 17 before, 17 after.
 
 Names are **normalized** before comparison — lowercased with separators stripped — so
 `UIPatterns`, `uiPatterns` and `"ui-patterns"` all compare equal. Messages quote the original

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ParallelListDriftVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ParallelListDriftVisitor.swift
@@ -132,8 +132,7 @@ final class ParallelListDriftVisitor: CrossFileVisitorBase, CrossFilePatternVisi
         }
 
         for item in list {
-            guard let call = RegistrationVerb.call(in: item),
-                  let name = registeredName(from: call) else {
+            guard let (call, name) = runEntry(in: item) else {
                 flush()
                 continue
             }
@@ -148,6 +147,64 @@ final class ParallelListDriftVisitor: CrossFileVisitorBase, CrossFilePatternVisi
             }
         }
         flush()
+    }
+
+    /// One entry of a run, from either of the two shapes that carry a roster.
+    ///
+    /// The registration shape — `register("fetch")` — is the original, and is gated on
+    /// `RegistrationVerb` so that arbitrary calls are not read as a list.
+    ///
+    /// The second shape has no verb to gate on and needs none, because its own signal is
+    /// stronger: a run of sibling calls that each mention a **distinct leading-dot member**.
+    ///
+    /// ```swift
+    /// Button("Rules")   { selection = .rules }
+    /// Button("Reports") { selection = .reports }
+    /// ```
+    ///
+    /// A menu built this way is an enumeration transcribed by hand, and it is exactly the carrier
+    /// that was missing. The real instance: a title menu of eleven `Button`s against a twelve-case
+    /// enum, silently omitting one destination. Written as `[.rules, .reports, …]` this rule
+    /// reported it and named the missing case; written as eleven calls it saw nothing, because
+    /// `Button` is not a registration verb and the first name-like argument is the *label*
+    /// (`"Enabled Rule Violations"`), which normalizes nowhere near the case name it belongs to.
+    ///
+    /// Requiring a leading-dot member is what keeps this narrow. It is not "any run of calls with
+    /// the same callee" — that would read every repeated view builder as a roster.
+    private func runEntry(in item: CodeBlockItemSyntax) -> (FunctionCallExprSyntax, String)? {
+        if let call = RegistrationVerb.call(in: item), let name = registeredName(from: call) {
+            return (call, name)
+        }
+        guard case .expr(let expr) = item.item,
+              let call = expr.as(FunctionCallExprSyntax.self),
+              let name = leadingDotMemberName(in: call) else { return nil }
+        return (call, name)
+    }
+
+    /// The single leading-dot member `call`'s **action closure** mentions, or `nil`.
+    ///
+    /// Only the trailing closure is searched, and that restriction is the whole precision of this
+    /// carrier. A roster entry is what the item *does*, not how it is *styled*: reading arguments
+    /// too collected `.red`, `.green` and `.primary` from lists of summary tiles, so two unrelated
+    /// views drawing four tiles apiece paired on three shared colour names and reported drift
+    /// against each other. Both were false positives, and both are gone with arguments excluded.
+    ///
+    /// Several members is as disqualifying as none: `Button("x") { mode = .a; other = .b }` names
+    /// two things and cannot contribute one entry without choosing arbitrarily between them.
+    private func leadingDotMemberName(in call: FunctionCallExprSyntax) -> String? {
+        guard let closure = call.trailingClosure else { return nil }
+        var found: Set<String> = []
+        collectLeadingDotMembers(in: Syntax(closure), into: &found)
+        return found.count == 1 ? found.first : nil
+    }
+
+    private func collectLeadingDotMembers(in node: Syntax, into found: inout Set<String>) {
+        for child in node.children(viewMode: .sourceAccurate) {
+            if let member = child.as(MemberAccessExprSyntax.self), member.base == nil {
+                found.insert(member.declName.baseName.text)
+            }
+            collectLeadingDotMembers(in: child, into: &found)
+        }
     }
 
     /// The distinguishing name a registration call contributes. Checks the trailing

--- a/Tests/CoreTests/CrossFileAnalysis/ParallelListDriftVisitorTests.swift
+++ b/Tests/CoreTests/CrossFileAnalysis/ParallelListDriftVisitorTests.swift
@@ -222,3 +222,117 @@ struct ParallelListDriftVisitorTests {
         #expect(issues.isEmpty)
     }
 }
+
+/// A menu built as sibling calls is an enumeration transcribed by hand.
+///
+/// This carrier exists because of a real defect the rule could not see. A title menu was eleven
+/// `Button`s against a twelve-case enum and silently omitted one destination — reachable from the
+/// sidebar and from nowhere else. Written as `[.rules, .reports, …]` the rule reported it and
+/// named the missing case; written as eleven calls it saw nothing.
+///
+/// Two things had to change. `Button` is not a `RegistrationVerb`, so the run was never collected;
+/// and the first name-like argument is the *label* (`"Enabled Rule Violations"`), which normalizes
+/// nowhere near the case name it belongs to. The entry has to come from the action.
+@Suite("A run of sibling calls carries the roster its actions name")
+struct ParallelListDriftActionRunTests {
+
+    private func analyze(files: [String: String]) -> [LintIssue] {
+        var cache: [String: SourceFileSyntax] = [:]
+        for (name, source) in files {
+            cache[name] = Parser.parse(source: source)
+        }
+        let visitor = ParallelListDriftVisitor(fileCache: cache)
+        visitor.setPattern(ParallelListDrift().pattern)
+        for (name, ast) in cache {
+            visitor.setFilePath(name)
+            visitor.setSourceLocationConverter(SourceLocationConverter(fileName: name, tree: ast))
+            visitor.walk(ast)
+        }
+        visitor.finalizeAnalysis()
+        return visitor.detectedIssues.filter { $0.ruleName == .parallelListDrift }
+    }
+
+    private static let sections = """
+    enum AppSection {
+        case rules, violations, exportReport, dashboard, ruleAudit
+        case versionHistory, compareConfigs, versionCheck, importConfig
+        case branchDiff, migration, configMap
+    }
+    """
+
+    @Test("a menu missing one case is reported, and the missing case is named")
+    func menuMissingOneCaseIsReported() {
+        let issues = analyze(files: [
+            "Section.swift": Self.sections,
+            "Menu.swift": """
+            struct TitleMenu: View {
+                var body: some View {
+                    Button("Rules") { selection = .rules }
+                    Button("Violations") { selection = .violations }
+                    Button("Export") { selection = .exportReport }
+                    Button("Dashboard") { selection = .dashboard }
+                    Button("Audit") { selection = .ruleAudit }
+                    Button("History") { selection = .versionHistory }
+                    Button("Compare") { selection = .compareConfigs }
+                    Button("Check") { selection = .versionCheck }
+                    Button("Import") { selection = .importConfig }
+                    Button("Diff") { selection = .branchDiff }
+                    Button("Migration") { selection = .migration }
+                }
+            }
+            """
+        ])
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("configMap") == true)
+    }
+
+    /// The precision lever, and the reason arguments are not searched.
+    ///
+    /// Reading arguments too collected `.red`, `.green` and `.primary` out of lists of summary
+    /// tiles, so two unrelated views drawing four tiles apiece paired on three shared colour names
+    /// and reported drift against each other. Both were false positives. A roster entry is what
+    /// the item *does*, not how it is *styled*.
+    @Test("styling arguments are not roster entries")
+    func stylingArgumentsAreNotEntries() {
+        #expect(analyze(files: [
+            "Left.swift": """
+            struct Left: View {
+                var body: some View {
+                    summaryItem(count: a, label: "Only in Left", color: .red)
+                    summaryItem(count: b, label: "Only in Right", color: .green)
+                    summaryItem(count: c, label: "Changed", color: .orange)
+                    summaryItem(count: d, label: "Same", color: .primary)
+                }
+            }
+            """,
+            "Right.swift": """
+            struct Right: View {
+                var body: some View {
+                    SummaryCard(title: "TOTAL", color: .primary)
+                    SummaryCard(title: "ERRORS", color: .red)
+                    SummaryCard(title: "WARNINGS", color: .orange)
+                    SummaryCard(title: "PASSED", color: .green)
+                }
+            }
+            """
+        ]).isEmpty)
+    }
+
+    /// An action naming two things cannot contribute one entry without choosing between them.
+    @Test("an action naming two members contributes nothing")
+    func ambiguousActionContributesNothing() {
+        #expect(analyze(files: [
+            "Section.swift": Self.sections,
+            "Menu.swift": """
+            struct TitleMenu: View {
+                var body: some View {
+                    Button("A") { selection = .rules; mode = .compact }
+                    Button("B") { selection = .violations; mode = .compact }
+                    Button("C") { selection = .exportReport; mode = .compact }
+                    Button("D") { selection = .dashboard; mode = .compact }
+                }
+            }
+            """
+        ]).isEmpty)
+    }
+}


### PR DESCRIPTION
**This rule could already find the bug. It just could not see the shape it was written in.**

A title menu in SwiftLintRuleStudio was eleven `Button`s against a twelve-case
enum, silently omitting one destination — reachable from the sidebar and from
nowhere else. I found it by hand while working a different rule.

Written as an array literal, this rule reports it exactly:

> `offeredSections` (array, 11 entries) agrees with `AppSection` (enum) on 11
> entries but is **missing 1: configMap**.

Written as eleven sibling calls, it reported nothing.

## Why it was blind

Two independent reasons, both narrow:

- `Button` is not a `RegistrationVerb`, so the run was never collected.
- `registeredName(from:)` takes the first name-like *argument*, which here is
  the label `"Enabled Rule Violations"` — that normalizes nowhere near the case
  name `violations` it belongs to. Even with the verb gate opened, the overlap
  would have been poor and it still would not have fired.

The entry has to come from the **action**.

## The carrier

A run of sibling calls whose actions each name a distinct leading-dot member is
now a name list. No verb gate — the member is its own signal.

This is deliberately **not** "any run of calls with the same callee", which
would read every repeated view builder as a roster.

**Only the action closure is searched, never the arguments**, and that
restriction is the whole precision of it. My first version searched arguments
too and collected `.red`, `.green` and `.primary` out of lists of summary tiles
— two unrelated views drawing four tiles apiece paired on three shared *colour
names* and reported drift against each other. Both false positives, both gone
once arguments were excluded. A roster entry is what the item **does**, not how
it is **styled**.

## Measured

| | Findings |
|---|---|
| 18 repositories, before | 17 |
| after, searching arguments too | 19 — **both new ones false positives** |
| after, action closure only | **17** |

The carrier adds nothing to code that does not have the defect, and reports the
defect when it does. Verified against the real shape in a probe: it names
`configMap`.

## What a reviewer should scrutinise

- **`leadingDotMemberName` requires exactly one member.** An action naming two
  (`{ selection = .rules; mode = .compact }`) contributes nothing rather than
  guessing which is the roster entry. That is a deliberate false negative and
  the third test pins it.
- **The search is recursive through the closure**, so a member nested inside an
  `if` or a `Task` still counts. Worth deciding whether that is wanted or
  whether only top-level statements should qualify.
- The corpus measurement is 17 → 17, so nothing here is exercised by existing
  findings. The evidence that it works is the probe and the three new tests, not
  the sweep.

## Verification

`swift test` — **3486 tests in 422 suites pass**. SwiftLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)