### PR TITLE
Write up the affordance gap and a seam-inventory proposal

### DIFF
--- a/Docs/design/seam-inventory-design.md
+++ b/Docs/design/seam-inventory-design.md
@@ -1,0 +1,95 @@
+# `--format seams` — seam inventory design
+
+**Status:** proposal. Not implemented.
+**Shape:** an output format, **not a rule.** Nothing new is reported; nothing existing changes.
+**Sibling:** `--format pbt-seeds`, which answers the same *kind* of question (here is what you can
+reach) for pure functions.
+**Motivation:** [`Docs/reachable-findings.md`](../reachable-findings.md)
+
+## The gap
+
+Every rule in this suite reports an absence. That is correct, and it leaves one question
+unanswered: **where can I reach this type from a test?**
+
+The question came up while writing tests for `SwiftFormatRuleStudio.ImpactModel`. The answer was
+`cli` and `reader` — `init` parameters with defaults — and it was found by grepping for `let cli`
+and `init(`. `missing-dependency-injection` was silent, correctly: the seam exists, so there is
+nothing missing to report.
+
+The suite already knows where that seam is. It has to, in order to decide *not* to report it.
+
+## What a seam is, for this purpose
+
+A named point at which a test can substitute behaviour without changing production code. Four
+carriers, all already recognised somewhere in the codebase:
+
+| Carrier | Example | Already read by |
+|---|---|---|
+| Initialiser parameter with a default | `init(cli: any SwiftFormatCLIProtocol = .makePreferred())` | `direct-instantiation` (as the shape it must *not* report) |
+| Debug-only initialiser | `#if DEBUG init(viewModel:) { … }` | `missing-dependency-injection` (as an exemption) |
+| Protocol-typed stored property | `private let cli: any SwiftFormatCLIProtocol` | `concrete-type-usage` (as the shape it wants) |
+| Defaulted closure parameter | `now: @Sendable () -> Date = { Date() }` | `non-injected-nondeterminism` (as the shape it must not report) |
+
+Every one is already computed. In each case a rule decides *not* to fire because the seam is
+present — and then throws that knowledge away.
+
+## Output
+
+Machine-readable, keyed by the type it opens:
+
+```json
+{
+  "type": "ImpactModel",
+  "file": "…/Services/ImpactModel.swift",
+  "seams": [
+    { "kind": "initializerDefault", "name": "cli",
+      "type": "any SwiftFormatCLIProtocol", "line": 52 },
+    { "kind": "initializerDefault", "name": "reader",
+      "type": "any SourceFileReading", "line": 53 }
+  ]
+}
+```
+
+and a text form for reading:
+
+```
+ImpactModel (Services/ImpactModel.swift)
+  cli     any SwiftFormatCLIProtocol   init default, line 52
+  reader  any SourceFileReading        init default, line 53
+```
+
+## Why an output and not a rule
+
+A rule that fires on correct code is noise, and this fires on nothing *but* correct code — a seam
+is the thing the rules are asking for. As an output it costs a reader who wants faults exactly
+nothing, because they never ask for it.
+
+`--format pbt-seeds` is the precedent: it answers *here are the pure functions* and hands them to
+`swift-infer discover --seeds`. It is not a finding, not counted in the ranking, and not noise.
+This is the same move for a different question.
+
+## What it is not
+
+- **Not a coverage tool.** It says a seam exists, not whether a test uses it.
+- **Not a recommendation.** It makes no claim that a seam *should* be used, or that a type with
+  none is wrong — `missing-dependency-injection` already owns that judgement.
+- **Not type resolution.** `any SwiftFormatCLIProtocol` is reported as written. Whether the
+  protocol is satisfiable by a test double is the reader's call.
+
+## Open questions
+
+1. **Scope.** Every type, or only those a rule has already reasoned about? The second is cheaper
+   and self-limiting, but makes the output depend on which rules ran.
+2. **Environment values.** `@Environment(TeamDataStore.self)` is a substitution point in SwiftUI
+   and does not look like the four carriers above. Include it, and the output grows a
+   framework-specific arm; exclude it, and the inventory is incomplete for exactly the views that
+   most need testing.
+3. **Does it earn its place?** The honest case for it is one session's friction, which is thin.
+   Worth revisiting after keeping a note of how often *"where is the seam?"* actually comes up —
+   if the answer is "rarely, and grep was fine", this should not be built.
+
+## Prior art in this repo worth copying
+
+`--format pbt-seeds` hands its output to another tool rather than to a human. If a seam inventory
+has a consumer — a test-scaffold generator, say — that is a much stronger case than a reading
+format, and would settle question 3.

--- a/Docs/reachable-findings.md
+++ b/Docs/reachable-findings.md
@@ -1,0 +1,75 @@
+# When the tool already knows and cannot say it
+
+**Status:** observation, written up after a working session. No code change proposed here; the
+concrete follow-on is [`Docs/design/seam-inventory-design.md`](design/seam-inventory-design.md).
+
+Two things happened in one session that look unrelated and are the same thing.
+
+## 1. A rule that could find a bug, but not in the spelling it was written in
+
+`SwiftLintRuleStudio` had a title menu of eleven `Button`s against a twelve-case enum. It silently
+omitted one destination — Config Map was reachable from the sidebar and from nowhere else. That is
+exactly what `parallel-list-drift` exists to catch, and written as an array literal it catches it,
+naming the missing case:
+
+> `offeredSections` (array, 11 entries) agrees with `AppSection` (enum) on 11 entries but is
+> missing 1: **configMap**.
+
+Written as eleven sibling calls it reported nothing, for two narrow reasons: `Button` is not a
+`RegistrationVerb`, so the run was never collected; and the first name-like argument is the *label*
+(`"Enabled Rule Violations"`), which normalizes nowhere near the case name it belongs to.
+
+The knowledge was there. The **carrier** was missing. Closing it took about thirty lines and moved
+the corpus count by zero — 17 findings before, 17 after — because no other code in 18 repositories
+has the defect. It is worth having anyway: the next menu written this way is reported instead of
+shipped.
+
+## 2. A rule that is silent for the right reason, and unhelpful anyway
+
+Writing a test for `SwiftFormatRuleStudio.ImpactModel` needed one fact: **is there a seam?** There
+was — `cli` and `reader` are `init` parameters with defaults — and finding it took a `grep` for
+`let cli` and `init(`.
+
+`missing-dependency-injection` had nothing to say, correctly. It reports the *absence* of a seam,
+and this type has one. It discriminates well, too: `ViolationInspectorView` builds its view model
+inline but carries a `#if DEBUG init(viewModel:)` and is **not** reported, while
+`SwiftUMLStudio.ContentView` has the same shape without the initialiser and **is**. Same syntax,
+opposite verdicts, decided by whether the seam exists.
+
+So the rule is right and the question still went unanswered, because it is the *other* question.
+
+## The shape
+
+Every rule in this suite reports an absence: a missing seam, an unreachable closure, a drifted
+list, a stamp nobody can pin. That is what a linter is for, and a rule that fires on correct code
+is noise.
+
+But the suite is not only used to find faults. It is used while **working** — and the questions
+that come up then are positive ones:
+
+| While fixing | The question is | Answered by |
+|---|---|---|
+| anything | *what is wrong here?* | every rule |
+| writing a test | *where can I reach this from?* | nothing |
+| naming a law | *what is already pure?* | `pbt-seeds`, partially |
+| refactoring a view | *what does this actually depend on?* | nothing directly |
+
+`--format pbt-seeds` is the one place the suite already answers a positive question — *here are the
+pure functions, hand them to `swift-infer`*. It is the model for what is missing elsewhere, and the
+proof that a positive output need not be noise: it is a **separate output**, not a finding, so it
+costs nothing to a reader who wants faults.
+
+## What follows from it
+
+1. **A carrier gap is worth closing even at zero findings.** The measurement that matters is *does
+   it report the defect when the defect exists*, not *did the count move*. Judging carrier work by
+   corpus delta would have rejected the `parallel-list-drift` fix, which found nothing and would
+   have caught the bug.
+
+2. **A positive inventory belongs in an output, never in a rule.** See the design note. The rule
+   set stays a fault detector; the inventory is a different question asked of the same AST.
+
+3. **Silence has two meanings and the tool cannot distinguish them.** "No finding" means either
+   *this is fine* or *this shape is invisible to me*. Case 1 above was the second, and looked
+   exactly like the first for months. That is an argument for occasionally checking a rule against
+   a defect you already know about — the corpus sweep will not surface what the rule cannot see.


### PR DESCRIPTION
Two documents, no code change.

While working through `unreachable-effect-closure` findings, two things happened
that looked unrelated and are the same thing.

**A rule that could find a bug, but not in the spelling it was written in.** A
title menu of eleven `Button`s against a twelve-case enum silently omitted a
destination. `parallel-list-drift` catches exactly that — written as an array
literal it names the missing case. Written as sibling calls it saw nothing. The
knowledge was there; the *carrier* was missing (closed in #150, corpus delta
zero).

**A rule that is silent for the right reason and unhelpful anyway.** Writing a
test for `ImpactModel` needed one fact: is there a seam? There was, and `grep`
found it. `missing-dependency-injection` was correctly silent — it reports the
*absence* of a seam and this type has one. It discriminates well, too:
`ViolationInspectorView` has a `#if DEBUG init(viewModel:)` and is not reported;
`SwiftUMLStudio.ContentView` has the same shape without one and is.

## The documents

**`Docs/reachable-findings.md`** — the observation. Every rule reports an
absence, which is what a linter is for; but the suite is also used *while
working*, and the questions that arise then are positive ones. Three
consequences are drawn out, the sharpest being that **"no finding" means either
*this is fine* or *this shape is invisible to me*, and nothing distinguishes
them** — case 1 looked like the former for months.

**`Docs/design/seam-inventory-design.md`** — the concrete follow-on. A
`--format seams` output modelled on `--format pbt-seeds`, listing the four seam
carriers the rules **already compute in order to decide not to fire**: defaulted
init parameters, `#if DEBUG` initialisers, protocol-typed stored properties,
defaulted closure parameters. An output rather than a rule, because a rule that
fires on correct code is noise and this fires on nothing but correct code.

## What a reviewer should scrutinise

- **Whether the proposal earns its place at all.** Its own open question 3 says
  the case is one session's friction, which is thin, and recommends keeping a
  tally of how often *"where is the seam?"* actually comes up before building
  anything. I would rather it be rejected on that basis than built on this
  evidence.
- **Open question 2 — `@Environment`** is a real substitution point in SwiftUI
  and fits none of the four carriers. Including it grows a framework-specific
  arm; excluding it makes the inventory incomplete for the views that most need
  testing.
- The claim that `pbt-seeds` is precedent rests on it being a separate output
  rather than a finding. If that reading of it is wrong, the argument weakens.

`swift test` unaffected; `RuleDocumentationConsistency` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)