### PR TITLE
Share one body walk between the three effect visitors

### DIFF
--- a/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Support/AnalysisBodyWalk.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Support/AnalysisBodyWalk.swift
@@ -1,0 +1,94 @@
+import SwiftEffectInference
+import SwiftProjectLintVisitors
+import SwiftSyntax
+
+/// Finalize-phase machinery shared by the cross-file effect visitors.
+///
+/// `IdempotencyViolationVisitor`, `NonIdempotentInRetryContextVisitor` and
+/// `UnannotatedInStrictReplayableContextVisitor` each carried their own copy of
+/// the upward-inference call and the analysis-site body walk. The copies were
+/// identical in behaviour and had drifted only in their comments, so a change
+/// to the traversal policy had to be made in three places to stay consistent —
+/// which is the same trap the escaping-closure policy was extracted to avoid.
+enum AnalysisBodyWalk {
+
+    /// Walks an analysis site's body, calling `visitCall` for every call the
+    /// site owns.
+    ///
+    /// Three boundaries are common to every effect visitor and are enforced
+    /// here: nested function declarations are separate sites, escaping trailing
+    /// closures are replay boundaries, and anything `shouldSkip` claims belongs
+    /// to a site of its own. `shouldSkip` runs before the escaping check so a
+    /// visitor's own annotation boundary wins over the generic one, matching
+    /// the order the three copies used.
+    static func walk(
+        _ syntax: Syntax,
+        skipping shouldSkip: (Syntax) -> Bool,
+        onCall visitCall: (FunctionCallExprSyntax) -> Void
+    ) {
+        if syntax.is(FunctionDeclSyntax.self) { return }
+        if shouldSkip(syntax) { return }
+        if let closure = syntax.as(ClosureExprSyntax.self), EscapingClosurePolicy.isEscaping(closure) {
+            return
+        }
+
+        if let call = syntax.as(FunctionCallExprSyntax.self) {
+            visitCall(call)
+        }
+
+        for child in syntax.children(viewMode: .sourceAccurate) {
+            walk(child, skipping: shouldSkip, onCall: visitCall)
+        }
+    }
+
+    /// True when `syntax` carries a `@lint.context` annotation of its own, and
+    /// so is an analysis site rather than part of the enclosing one.
+    ///
+    /// Covers both spellings: a closure-initialised binding, and a call with an
+    /// annotated trailing closure. The call case deliberately uses the
+    /// *call-site* lookup (call site plus enclosing statement) so a site
+    /// annotated by a prefix statement is not walked twice — once as its own
+    /// site and once as part of its parent.
+    static func carriesOwnContextAnnotation(_ syntax: Syntax) -> Bool {
+        if let varDecl = syntax.as(VariableDeclSyntax.self),
+           varDecl.closureInitializer != nil,
+           ContextAnnotationParser.parseContext(declaration: varDecl) != nil {
+            return true
+        }
+        if let call = syntax.as(FunctionCallExprSyntax.self),
+           call.trailingClosure != nil,
+           ContextAnnotationParser.parseContextAtCallSite(of: call) != nil {
+            return true
+        }
+        return false
+    }
+}
+
+extension EffectSymbolTable {
+
+    /// Phase-2.3 body-based upward inference, with the heuristic fallback made
+    /// import-aware.
+    ///
+    /// Must run at finalize time rather than during the walk: upward inference
+    /// consults cross-file declared effects and heuristic-downward resolution,
+    /// and neither is complete until every file has merged. `multiHop` enables
+    /// fixed-point propagation across chains of un-annotated functions — a
+    /// caller whose body reaches a non-idempotent leaf only through another
+    /// un-annotated function is inferred non-idempotent itself, which one-hop
+    /// would miss.
+    ///
+    /// Imports are computed per source and looked up on each call so framework
+    /// allowlists only fire in files that actually import the module.
+    mutating func applyImportAwareBodyInference(
+        to sources: [SourceFileSyntax],
+        enabledFrameworks: Set<String>?
+    ) {
+        applyBodyInference(to: sources, multiHop: true) { call, source in
+            HeuristicEffectInferrer.infer(
+                call: call,
+                imports: SwiftProjectLintVisitors.ImportCollector.imports(in: source),
+                enabledFrameworks: enabledFrameworks
+            )
+        }
+    }
+}

--- a/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Visitors/IdempotencyViolationVisitor.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Visitors/IdempotencyViolationVisitor.swift
@@ -108,26 +108,10 @@ final class IdempotencyViolationVisitor: CrossFileVisitorBase, CrossFilePatternV
     // MARK: - Finalize phase: emit issues
 
     func finalizeAnalysis() {
-        // Phase-2.3: after all files have merged declared effects into the
-        // symbol table, run body-based upward inference. Must happen here
-        // (not during walk) because upward inference uses cross-file
-        // declared effects and heuristic-downward resolution, both of which
-        // are only complete at finalize time.
-        //
-        // `multiHop: true` enables fixed-point propagation across chains
-        // of un-annotated functions. A function whose body calls another
-        // un-annotated function whose own body has a non-idempotent leaf
-        // is now inferred non-idempotent itself. One-hop catches only the
-        // direct caller of the leaf.
-        let allSources = orderedSources
-        let enabledFrameworks = self.enabledFrameworkAllowlists
-        symbolTable.applyBodyInference(to: allSources, multiHop: true) { call, source in
-            HeuristicEffectInferrer.infer(
-                call: call,
-                imports: SwiftProjectLintVisitors.ImportCollector.imports(in: source),
-                enabledFrameworks: enabledFrameworks
-            )
-        }
+        symbolTable.applyImportAwareBodyInference(
+            to: orderedSources,
+            enabledFrameworks: enabledFrameworkAllowlists
+        )
 
         for site in analysisSites {
             analyzeBody(site.body, site: site)
@@ -135,29 +119,22 @@ final class IdempotencyViolationVisitor: CrossFileVisitorBase, CrossFilePatternV
     }
 
     private func analyzeBody(_ syntax: Syntax, site: AnalysisSite) {
-        if syntax.is(FunctionDeclSyntax.self) { return }
-        // Nested closure-initialised variable bindings that carry their
-        // own `@lint.effect` annotation are independent analysis sites.
-        // Don't descend — calls inside would otherwise be attributed to
-        // the outer effect. Unannotated closure-bound bindings keep the
-        // old behaviour: they inherit the outer site's effect and are
-        // walked through.
-        if let varDecl = syntax.as(VariableDeclSyntax.self),
-           varDecl.closureInitializer != nil,
-           EffectAnnotationParser.parseEffect(declaration: varDecl) != nil {
-            return
-        }
-        if let closure = syntax.as(ClosureExprSyntax.self), EscapingClosurePolicy.isEscaping(closure) {
-            return
-        }
-
-        if let call = syntax.as(FunctionCallExprSyntax.self) {
+        AnalysisBodyWalk.walk(syntax, skipping: carriesOwnEffectAnnotation) { call in
             analyzeCall(call, site: site)
         }
+    }
 
-        for child in syntax.children(viewMode: .sourceAccurate) {
-            analyzeBody(child, site: site)
+    /// Nested closure-initialised variable bindings that carry their own
+    /// `@lint.effect` annotation are independent analysis sites. Don't descend
+    /// — calls inside would otherwise be attributed to the outer effect.
+    /// Unannotated closure-bound bindings keep the old behaviour: they inherit
+    /// the outer site's effect and are walked through.
+    private func carriesOwnEffectAnnotation(_ syntax: Syntax) -> Bool {
+        guard let varDecl = syntax.as(VariableDeclSyntax.self),
+              varDecl.closureInitializer != nil else {
+            return false
         }
+        return EffectAnnotationParser.parseEffect(declaration: varDecl) != nil
     }
 
     /// Resolves a call's callee effect via the symbol table, falling back to

--- a/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Visitors/NonIdempotentInRetryContextVisitor.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Visitors/NonIdempotentInRetryContextVisitor.swift
@@ -108,26 +108,13 @@ final class NonIdempotentInRetryContextVisitor: CrossFileVisitorBase, CrossFileP
     }
 
     func finalizeAnalysis() {
-        // Phase-2.3 upward inference — see IdempotencyViolationVisitor for
-        // rationale. Runs before the body walk so every lookup in
-        // analyzeCall can consult upward-inferred entries. `multiHop: true`
-        // enables fixed-point propagation across chains of un-annotated
-        // helpers between the `@context replayable` boundary and the
-        // non-idempotent leaf.
-        //
-        // Round-14: the heuristic callback is now import-aware. We
-        // precompute per-source imports once and look them up on each
-        // call so framework allowlists only fire in files that actually
-        // import the relevant module.
-        let allSources = orderedSources
-        let enabledFrameworks = self.enabledFrameworkAllowlists
-        symbolTable.applyBodyInference(to: allSources, multiHop: true) { call, source in
-            HeuristicEffectInferrer.infer(
-                call: call,
-                imports: SwiftProjectLintVisitors.ImportCollector.imports(in: source),
-                enabledFrameworks: enabledFrameworks
-            )
-        }
+        // Runs before the body walk so every lookup in analyzeCall can consult
+        // upward-inferred entries — chains of un-annotated helpers between the
+        // `@context replayable` boundary and the non-idempotent leaf.
+        symbolTable.applyImportAwareBodyInference(
+            to: orderedSources,
+            enabledFrameworks: enabledFrameworkAllowlists
+        )
 
         for site in analysisSites {
             analyzeBody(site.body, site: site)
@@ -135,39 +122,8 @@ final class NonIdempotentInRetryContextVisitor: CrossFileVisitorBase, CrossFileP
     }
 
     private func analyzeBody(_ syntax: Syntax, site: AnalysisSite) {
-        if syntax.is(FunctionDeclSyntax.self) { return }
-        // Nested closure-initialised variable bindings that carry their
-        // own `@lint.context` annotation are independent analysis sites.
-        // Don't descend — calls inside would otherwise be attributed to
-        // the outer context. Unannotated closure-bound bindings keep the
-        // old behaviour: they inherit the outer site's context and are
-        // walked through.
-        if let varDecl = syntax.as(VariableDeclSyntax.self),
-           varDecl.closureInitializer != nil,
-           ContextAnnotationParser.parseContext(declaration: varDecl) != nil {
-            return
-        }
-        // Same rule for annotated trailing-closure sites: the outer walk
-        // must not descend into a call whose closure is its own analysis
-        // site, or the inner calls would be attributed to the outer
-        // context twice. Must mirror the `visit` method's trivia lookup
-        // (call site + enclosing statement) or prefix-statement annotated
-        // sites get walked twice.
-        if let call = syntax.as(FunctionCallExprSyntax.self),
-           call.trailingClosure != nil,
-           ContextAnnotationParser.parseContextAtCallSite(of: call) != nil {
-            return
-        }
-        if let closure = syntax.as(ClosureExprSyntax.self), EscapingClosurePolicy.isEscaping(closure) {
-            return
-        }
-
-        if let call = syntax.as(FunctionCallExprSyntax.self) {
+        AnalysisBodyWalk.walk(syntax, skipping: AnalysisBodyWalk.carriesOwnContextAnnotation) { call in
             analyzeCall(call, site: site)
-        }
-
-        for child in syntax.children(viewMode: .sourceAccurate) {
-            analyzeBody(child, site: site)
         }
     }
 

--- a/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Visitors/UnannotatedInStrictReplayableContextVisitor.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Visitors/UnannotatedInStrictReplayableContextVisitor.swift
@@ -108,15 +108,10 @@ final class UnannotatedInStrictReplayableContextVisitor:
     }
 
     func finalizeAnalysis() {
-        let allSources = orderedSources
-        let enabledFrameworks = self.enabledFrameworkAllowlists
-        symbolTable.applyBodyInference(to: allSources, multiHop: true) { call, source in
-            HeuristicEffectInferrer.infer(
-                call: call,
-                imports: SwiftProjectLintVisitors.ImportCollector.imports(in: source),
-                enabledFrameworks: enabledFrameworks
-            )
-        }
+        symbolTable.applyImportAwareBodyInference(
+            to: orderedSources,
+            enabledFrameworks: enabledFrameworkAllowlists
+        )
 
         for site in analysisSites {
             analyzeBody(site.body, site: site)
@@ -124,34 +119,8 @@ final class UnannotatedInStrictReplayableContextVisitor:
     }
 
     private func analyzeBody(_ syntax: Syntax, site: AnalysisSite) {
-        if syntax.is(FunctionDeclSyntax.self) { return }
-        // Nested closure-initialised variable bindings that carry their
-        // own `@lint.context` annotation are independent analysis sites;
-        // don't descend.
-        if let varDecl = syntax.as(VariableDeclSyntax.self),
-           varDecl.closureInitializer != nil,
-           ContextAnnotationParser.parseContext(declaration: varDecl) != nil {
-            return
-        }
-        // Same rule for annotated trailing-closure sites (round-11). Use
-        // the call-site variant so prefix-statement annotations don't get
-        // double-walked — see NonIdempotentInRetryContextVisitor's matching
-        // guard.
-        if let call = syntax.as(FunctionCallExprSyntax.self),
-           call.trailingClosure != nil,
-           ContextAnnotationParser.parseContextAtCallSite(of: call) != nil {
-            return
-        }
-        if let closure = syntax.as(ClosureExprSyntax.self), EscapingClosurePolicy.isEscaping(closure) {
-            return
-        }
-
-        if let call = syntax.as(FunctionCallExprSyntax.self) {
+        AnalysisBodyWalk.walk(syntax, skipping: AnalysisBodyWalk.carriesOwnContextAnnotation) { call in
             analyzeCall(call, site: site)
-        }
-
-        for child in syntax.children(viewMode: .sourceAccurate) {
-            analyzeBody(child, site: site)
         }
     }
 


### PR DESCRIPTION
## What

`IdempotencyViolationVisitor`, `NonIdempotentInRetryContextVisitor` and `UnannotatedInStrictReplayableContextVisitor` each held their own copy of the finalize-phase machinery:

- the `applyBodyInference(to:multiHop:)` call with the import-aware heuristic callback (12 lines, byte-identical in all three), and
- the recursive `analyzeBody(_:site:)` walk.

New `Support/AnalysisBodyWalk.swift` holds `AnalysisBodyWalk.walk` and an `EffectSymbolTable.applyImportAwareBodyInference` extension. Net −90 lines of production code.

## Why

SwiftCloneDetector reported these as an exact 45-line clone across three files (PMD CPD independently reported 78 lines across two of them). Reading it, the copies had already drifted in their *comments* while staying identical in behaviour — `NonIdempotentInRetryContextVisitor` documents the multiHop rationale, `UnannotatedInStrictReplayableContextVisitor` documents none of it, and `IdempotencyViolationVisitor` is the one the other two say "see ... for rationale". Three copies of a traversal policy is exactly what `EscapingClosurePolicy` was extracted to prevent.

## What a reviewer should scrutinise

**Guard order is behaviour, not style.** All three copies ran their annotation guards *before* the escaping-closure guard, so `walk` calls `shouldSkip` first and the escaping check second. Reordering these would change which site a call is attributed to.

**The two context predicates really were identical.** `NonIdempotentInRetryContextVisitor` and `UnannotatedInStrictReplayableContextVisitor` both skip (a) closure-initialised bindings carrying `@lint.context`, and (b) calls with an annotated trailing closure, using the *call-site* lookup so prefix-statement annotations aren't double-walked. Worth diffing against the pre-change files to confirm.

**`IdempotencyViolationVisitor` keeps its own predicate** — it gates on `@lint.effect`, not `@lint.context`, and has no trailing-closure case. That asymmetry is preserved deliberately.

`swift test`: 3,486 tests in 422 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWXP15UqwGCSDJrjhM3okf