### PR TITLE
Drop the unused Foundation import from every pattern registrar

### DIFF
--- a/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/PatternRegistrars/Idempotency.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/PatternRegistrars/Idempotency.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintRegistry
 
 /// Registers patterns related to idempotency contracts for retry-safe code.

--- a/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/PatternRegistrars/IdempotencyViolation.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/PatternRegistrars/IdempotencyViolation.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/PatternRegistrars/MissingIdempotencyKey.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/PatternRegistrars/MissingIdempotencyKey.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/PatternRegistrars/NonIdempotentActionName.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/PatternRegistrars/NonIdempotentActionName.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/PatternRegistrars/NonIdempotentInRetryContext.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/PatternRegistrars/NonIdempotentInRetryContext.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/PatternRegistrars/OnceContractViolation.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/PatternRegistrars/OnceContractViolation.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/PatternRegistrars/TupleEqualityWithUnstableComponents.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/PatternRegistrars/TupleEqualityWithUnstableComponents.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/PatternRegistrars/UnannotatedInStrictReplayableContext.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/PatternRegistrars/UnannotatedInStrictReplayableContext.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/Accessibility.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/Accessibility.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/AnimationWithoutReduceMotion.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/AnimationWithoutReduceMotion.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/ControlMissingAccessibilityLabel.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/ControlMissingAccessibilityLabel.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/HardcodedFontSize.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/HardcodedFontSize.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/IsButtonTraitWithoutAction.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/IsButtonTraitWithoutAction.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/UnlabeledControl.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/PatternRegistrars/UnlabeledControl.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Animation/PatternRegistrars/AnimationHierarchy.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Animation/PatternRegistrars/AnimationHierarchy.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Animation/PatternRegistrars/AnimationPerformance.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Animation/PatternRegistrars/AnimationPerformance.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Animation/PatternRegistrars/HardcodedAnimationValues.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Animation/PatternRegistrars/HardcodedAnimationValues.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Animation/PatternRegistrars/MatchedGeometry.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Animation/PatternRegistrars/MatchedGeometry.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Animation/PatternRegistrars/WithAnimation.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Animation/PatternRegistrars/WithAnimation.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/ArchitecturalBoundary.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/ArchitecturalBoundary.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/Architecture.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/Architecture.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/BooleanControlCoupling.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/BooleanControlCoupling.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/CircularDependency.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/CircularDependency.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/ComputedPropertyView.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/ComputedPropertyView.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/CouldAdoptProtocol.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/CouldAdoptProtocol.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/DuplicateEnumMapping.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/DuplicateEnumMapping.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/DuplicateStructShape.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/DuplicateStructShape.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/FatProtocol.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/FatProtocol.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/GodViewModel.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/GodViewModel.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/HoistableConformerMember.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/HoistableConformerMember.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/HoistableSequenceOperation.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/HoistableSequenceOperation.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/ManualRegistrationList.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/ManualRegistrationList.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/MirrorProtocol.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/MirrorProtocol.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/ParallelEnumShape.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/ParallelEnumShape.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/ParallelListDrift.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/ParallelListDrift.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/PrimitiveBypassingDomainType.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/PrimitiveBypassingDomainType.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/PrimitiveNamedForDomainType.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/PrimitiveNamedForDomainType.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/ScatteredEnumMapping.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/ScatteredEnumMapping.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/SharedDomainEnumField.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/SharedDomainEnumField.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/SingleImplementationProtocol.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/SingleImplementationProtocol.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/SubclassedForMocking.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/SubclassedForMocking.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/SwiftDataUniqueAttribute.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/SwiftDataUniqueAttribute.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/UnabstractedFileIO.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/UnabstractedFileIO.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/UnusedProtocolAbstraction.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/UnusedProtocolAbstraction.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/ViewModelDirectDBAccess.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/PatternRegistrars/ViewModelDirectDBAccess.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/ActorReentrancy.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/ActorReentrancy.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/AsyncLetUnused.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/AsyncLetUnused.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/ButtonClosureWrapping.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/ButtonClosureWrapping.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/CFAbsoluteTime.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/CFAbsoluteTime.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/CatchWithoutHandling.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/CatchWithoutHandling.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/CodeQuality.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/CodeQuality.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/CompletionHandlerDataTask.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/CompletionHandlerDataTask.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/CouldBePrivate.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/CouldBePrivate.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/CouldBePrivateMember.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/CouldBePrivateMember.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/DateNow.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/DateNow.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/DiscardableResultMisuse.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/DiscardableResultMisuse.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/DiscardedTryResult.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/DiscardedTryResult.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/DisfavoredOverload.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/DisfavoredOverload.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/DispatchMainAsync.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/DispatchMainAsync.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/EffectCycle.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/EffectCycle.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/FireAndForgetTask.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/FireAndForgetTask.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/FontWeightBold.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/FontWeightBold.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/ForceCast.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/ForceCast.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/ForceTry.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/ForceTry.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/ForceUnwrap.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/ForceUnwrap.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/GlobalActorMismatch.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/GlobalActorMismatch.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/LegacyNotificationObserver.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/LegacyNotificationObserver.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/LegacyRandom.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/LegacyRandom.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/LossyStructRebuild.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/LossyStructRebuild.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/LowercasedContains.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/LowercasedContains.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/MagicBooleanParameter.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/MagicBooleanParameter.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/MapUsedForSideEffects.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/MapUsedForSideEffects.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/MissingCancellationCheck.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/MissingCancellationCheck.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/MultipleTypesPerFile.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/MultipleTypesPerFile.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/NestedGenericComplexity.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/NestedGenericComplexity.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/NonisolatedUnsafe.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/NonisolatedUnsafe.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/PreconcurrencyConformance.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/PreconcurrencyConformance.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/PreconcurrencyImport.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/PreconcurrencyImport.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/PrintStatement.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/PrintStatement.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/ProtocolCouldBePrivate.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/ProtocolCouldBePrivate.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/PublicInAppTarget.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/PublicInAppTarget.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/RetroactiveConformance.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/RetroactiveConformance.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/StringSwitchOverEnum.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/StringSwitchOverEnum.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/SwallowedInjectionDowncast.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/SwallowedInjectionDowncast.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/SwallowedTaskError.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/SwallowedTaskError.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/SwiftLintSuppression.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/SwiftLintSuppression.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/SwiftProjectLintSuppression.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/SwiftProjectLintSuppression.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/TaskDetached.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/TaskDetached.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/TaskYieldOffload.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/TaskYieldOffload.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/TestMissingAssertion.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/TestMissingAssertion.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/TestMissingExpect.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/TestMissingExpect.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/TestMissingRequire.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/TestMissingRequire.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/ThreadSleep.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/ThreadSleep.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/TodoComment.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/TodoComment.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/UncheckedSendable.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/UncheckedSendable.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/UnconditionalTrap.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/UnconditionalTrap.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/VariableShadowing.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/VariableShadowing.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/MemoryManagement/PatternRegistrars/MemoryManagement.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/MemoryManagement/PatternRegistrars/MemoryManagement.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/CornerRadiusDeprecated.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/CornerRadiusDeprecated.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/ForegroundColorDeprecated.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/ForegroundColorDeprecated.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/IOS17ObservationMigration.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/IOS17ObservationMigration.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/LegacyArrayInit.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/LegacyArrayInit.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/LegacyClosureSyntax.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/LegacyClosureSyntax.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/LegacyFormatter.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/LegacyFormatter.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/LegacyImageRenderer.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/LegacyImageRenderer.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/LegacyObservableObject.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/LegacyObservableObject.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/LegacyReplacingOccurrences.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/LegacyReplacingOccurrences.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/LegacyStringFormat.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/LegacyStringFormat.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/Modernization.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/Modernization.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintRegistry
 
 /// Registers patterns related to API modernization.

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/NavigationViewDeprecated.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/NavigationViewDeprecated.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/OnChangeOldAPI.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/OnChangeOldAPI.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/ScrollViewReaderDeprecated.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/ScrollViewReaderDeprecated.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/ScrollViewShowsIndicators.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/ScrollViewShowsIndicators.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/TabItemDeprecated.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/TabItemDeprecated.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/TaskSleepNanoseconds.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Modernization/PatternRegistrars/TaskSleepNanoseconds.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Networking/PatternRegistrars/Networking.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Networking/PatternRegistrars/Networking.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Networking/PatternRegistrars/URLSessionUnhandledError.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Networking/PatternRegistrars/URLSessionUnhandledError.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Performance/PatternRegistrars/AnyViewUsage.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Performance/PatternRegistrars/AnyViewUsage.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Performance/PatternRegistrars/CustomModifierPerformance.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Performance/PatternRegistrars/CustomModifierPerformance.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Performance/PatternRegistrars/DispatchSemaphoreInAsync.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Performance/PatternRegistrars/DispatchSemaphoreInAsync.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Performance/PatternRegistrars/FormatterInViewBody.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Performance/PatternRegistrars/FormatterInViewBody.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Performance/PatternRegistrars/GeometryReaderOveruse.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Performance/PatternRegistrars/GeometryReaderOveruse.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Performance/PatternRegistrars/OnReceiveWithoutDebounce.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Performance/PatternRegistrars/OnReceiveWithoutDebounce.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Performance/PatternRegistrars/Performance.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Performance/PatternRegistrars/Performance.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Performance/PatternRegistrars/UnboundedTaskGroup.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Performance/PatternRegistrars/UnboundedTaskGroup.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Performance/PatternRegistrars/ViewBuilderComplexity.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Performance/PatternRegistrars/ViewBuilderComplexity.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Security/PatternRegistrars/Security.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Security/PatternRegistrars/Security.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/StateManagement/PatternRegistrars/FlagOptionalPairState.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/StateManagement/PatternRegistrars/FlagOptionalPairState.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/StateManagement/PatternRegistrars/MainActorMissing.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/StateManagement/PatternRegistrars/MainActorMissing.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/StateManagement/PatternRegistrars/MutuallyExclusivePresentationState.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/StateManagement/PatternRegistrars/MutuallyExclusivePresentationState.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/StateManagement/PatternRegistrars/ObservableMainActorMissing.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/StateManagement/PatternRegistrars/ObservableMainActorMissing.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/StateManagement/PatternRegistrars/ObservedObjectInline.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/StateManagement/PatternRegistrars/ObservedObjectInline.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/StateManagement/PatternRegistrars/RedundantDerivedProperty.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/StateManagement/PatternRegistrars/RedundantDerivedProperty.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/StateManagement/PatternRegistrars/StateManagement.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/StateManagement/PatternRegistrars/StateManagement.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/StateManagement/PatternRegistrars/TooManyEnvironmentObjects.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/StateManagement/PatternRegistrars/TooManyEnvironmentObjects.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/ContradictedClockDeterminism.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/ContradictedClockDeterminism.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/ImpureCallInViewBody.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/ImpureCallInViewBody.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/MissingEquatableOnStateType.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/MissingEquatableOnStateType.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/Testability.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/Testability.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/UnreachableEffectClosure.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/PatternRegistrars/UnreachableEffectClosure.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/UI/PatternRegistrars/ImageWithoutResizable.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/UI/PatternRegistrars/ImageWithoutResizable.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/UI/PatternRegistrars/ModifierOrder.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/UI/PatternRegistrars/ModifierOrder.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/UI/PatternRegistrars/TaskInOnAppear.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/UI/PatternRegistrars/TaskInOnAppear.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/UI/PatternRegistrars/UIPatterns.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/UI/PatternRegistrars/UIPatterns.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftProjectLintModels
 import SwiftProjectLintRegistry
 import SwiftProjectLintVisitors


### PR DESCRIPTION
## What

`import Foundation` deleted from all 144 files under `PatternRegistrars/`. 144 files changed, 144 deletions, nothing else touched.

## Why

I had written off the clone detector's largest single finding in this repo — ~100 classes and ~2,400 "removable" lines across the registrars — as a false positive, on the grounds that a registrar is a per-rule declaration table where every field differs and nothing factors out. Measuring it showed that was wrong twice over:

- **The alternative shape already exists here.** `Architecture.swift`, `CodeQuality.swift`, `Accessibility.swift` and twelve others are `BasePatternRegistrar` subclasses that build `SyntaxPattern` values inline in a list — same data, no per-rule type, no per-rule file, no imports.
- **The files are 57% ceremony, not 100% payload.** Across the 129 pure-data registrars: 1,993 ceremony lines against 1,526 payload lines, 15.4 fixed lines per file. The fixed part is what the detector was matching, and it was right to.

What *does* justify leaving the other ~1,850 lines alone is that one-file-per-rule is a live convention, not an accident: the aggregates all date from the March package extraction, and every rule added since has been its own file — 51 in April, 22 in June, 9 in July, 2 in August, 2 in September. Collapsing them would reverse six months of deliberate practice and cost greppability, the 1:1 docs mapping, and conflict-free parallel rule additions.

This line is the part of the preamble that buys none of that.

## What a reviewer should scrutinise

**That it really is dead in all 144, not just the one I spot-checked.** The check is mechanical and the result is in the PR: strip the line everywhere, `swift build` → `Build complete`, `swift test` → 3,479 tests in 420 suites pass. `MemberImportVisibility` is enabled for these targets, so an import that were load-bearing would fail the build rather than pass silently.

**Import order is still sorted.** `Foundation` sorted first, so removing it leaves `SwiftProjectLintModels` / `SwiftProjectLintRegistry` / `SwiftProjectLintVisitors` in order — no reflow, no other edit.

**The other three imports stay.** They are unqualified sources of `SyntaxPattern`, `PatternRegistrarProtocol` and the visitor types; only `Foundation` was testable as dead and only `Foundation` was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWXP15UqwGCSDJrjhM3okf