### PR TITLE
Direct Instantiation: an @Observable model a view owns is view state

### DIFF
--- a/Docs/rules/direct-instantiation.md
+++ b/Docs/rules/direct-instantiation.md
@@ -28,6 +28,19 @@ Because a `private` type can only be *used* in the file that declares it, the ch
 
 The gate is the entry point, not the whole type: a `@main` type's other methods are ordinary code and hard-wiring a dependency in one is an ordinary finding. Six findings across four repositories went, five of them a spike's `PaymentStore()`/`ProfileStore()` two lines into `static func main()`.
 
+**An `@Observable` model a view owns is not flagged.** That is already why `@State private var model = Model()` is exempt; this is the same ownership one step deferred, and the deferral is forced rather than stylistic. An `@Environment` value cannot be read from a property initializer, so a model that needs one is built in `.task` and stored into an optional `@State`:
+
+```swift
+@Environment(AppState.self) private var appState
+@State private var viewModel: BeadsViewModel?
+...
+.task { if viewModel == nil { viewModel = BeadsViewModel(appState: appState) } }
+```
+
+That construction *is* the injection — `appState` arrives from the environment — and the rule's suggestion, "use `@StateObject`/`@EnvironmentObject`", names the pre-Observation API for a problem Observation does not have. Seven of the corpus's findings were this pattern, written identically seven times in one app.
+
+Two things keep it narrow. It applies only inside a `View` — the same `@Observable` type built by a coordinator is an ordinary dependency of that coordinator — and only to types the project-wide `@Observable` prescan knows about, so a plain service reached for inside a view body is still the case the rule exists for.
+
 **A type the runtime constructs is not flagged.** `ParsableCommand`, `AsyncParsableCommand` and `ParsableArguments` conformers are built by ArgumentParser out of argv and then run. The synthesized initializer takes only the decoded `@Option`/`@Argument`/`@Flag` values, so there is no parameter to inject through, and the one remaining spelling — a stored property with an inline default — is exactly the shape this rule reports. Inside a command, every form of the fix the rule recommends is either impossible or itself a finding, which is what "advice with no reachable end state" means.
 
 The gate covers the command type rather than its `run()`, because the constraint belongs to the type: `BootstrapSkillsCommand.makeDetector()` assembles a registry, an anti-pattern store, a knowledge graph and a builder in a private helper, and it is no more injectable there. Eight findings across two repositories, four of them CLI subcommands reaching for a diagram generator whose protocol seam already exists and is already used — `DiagramViewModel` takes `any ClassDiagramGenerating = ClassDiagramGenerator()`, the defaulted-parameter shape this rule documents as the seam, and the test target has doubles for it.

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/DirectInstantiationVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/DirectInstantiationVisitor.swift
@@ -14,6 +14,9 @@ class DirectInstantiationVisitor: BasePatternVisitor {
     /// spelling — and a flag would be cleared by whichever closed first.
     private var insidePreviewOrDebug = 0
 
+    /// Depth inside a SwiftUI `View`. See `isObservableViewState`.
+    private var insideSwiftUIView = 0
+
     /// Depth inside the program's designated entry point. See `insideEntryPoint`.
     private var insideEntryPoint = 0
 
@@ -59,6 +62,25 @@ class DirectInstantiationVisitor: BasePatternVisitor {
         // the thing this whole sweep is trying to produce — and the rule was reporting their
         // insides as coupling.
         if privatelyDeclaredTypes.contains(typeName) { return nil }
+
+        // An `@Observable` model a view owns is view *state*, not a dependency. That is
+        // already why `@State private var model = Model()` is exempt; this is the same
+        // ownership one step deferred.
+        //
+        // The deferral is forced, not stylistic. An `@Environment` value cannot be read from a
+        // property initializer, so a model that needs one is built in `.task` and stored into
+        // an optional `@State`:
+        //
+        //     @Environment(AppState.self) private var appState
+        //     @State private var viewModel: BeadsViewModel?
+        //     ...
+        //     .task { if viewModel == nil { viewModel = BeadsViewModel(appState: appState) } }
+        //
+        // That construction *is* the injection — `appState` arrives from the environment — and
+        // the rule's suggestion names the pre-Observation API for a problem Observation does
+        // not have. Seven of the corpus's findings were this pattern, written identically
+        // seven times.
+        if insideSwiftUIView > 0, knownObservableTypes.contains(typeName) { return nil }
 
         // A helper handed its own owner cannot be injected into that owner. `self` does not
         // exist before the initializer that would receive the substitute has run, so the
@@ -319,6 +341,7 @@ class DirectInstantiationVisitor: BasePatternVisitor {
         typeNameStack.append(node.name.text)
         mainAttributedTypeDepth.append(Self.carriesMainAttribute(node.attributes))
         if Self.isRuntimeConstructed(node.inheritanceClause) { insideEntryPoint += 1 }
+        if isSwiftUIViewOnly(node) { insideSwiftUIView += 1 }
         return .visitChildren
     }
 
@@ -326,6 +349,7 @@ class DirectInstantiationVisitor: BasePatternVisitor {
         typeNameStack.removeLast()
         mainAttributedTypeDepth.removeLast()
         if Self.isRuntimeConstructed(node.inheritanceClause) { insideEntryPoint -= 1 }
+        if isSwiftUIViewOnly(node) { insideSwiftUIView -= 1 }
     }
 
     override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {

--- a/Tests/CoreTests/Architecture/ArchitectureDirectInstantiationViewStateTests.swift
+++ b/Tests/CoreTests/Architecture/ArchitectureDirectInstantiationViewStateTests.swift
@@ -1,0 +1,91 @@
+@testable import Core
+import Foundation
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+/// `Direct Instantiation`\'s `@Observable`-view-state gate. Separate from the main suite
+/// because it needs a helper that primes `knownObservableTypes`, the project-wide prescan the
+/// gate resolves against.
+@Suite
+struct ArchitectureDirectInstantiationViewStateTests {
+
+    private func analyzeSource(
+        _ source: String,
+        observableTypes: Set<String>,
+        filePath: String = "TestFile.swift"
+    ) -> [LintIssue] {
+        let visitor = DirectInstantiationVisitor(patternCategory: .architecture)
+        visitor.knownObservableTypes = observableTypes
+        let syntax = Parser.parse(source: source)
+        let converter = SourceLocationConverter(fileName: filePath, tree: syntax)
+        visitor.setSourceLocationConverter(converter)
+        visitor.setFilePath(filePath)
+        visitor.walk(syntax)
+        return visitor.detectedIssues
+    }
+
+    @Test func testObservableModelOwnedByAViewIsNotReported() {
+        // An `@Environment` value cannot be read from a property initializer, so a model that
+        // needs one is built in `.task` and stored into an optional `@State`. That
+        // construction *is* the injection — `appState` arrives from the environment — and the
+        // rule's suggestion names the pre-Observation API for a problem Observation does not
+        // have.
+        let source = """
+        struct BeadsView: View {
+            @Environment(AppState.self) private var appState
+            @State private var viewModel: BeadsViewModel?
+
+            var body: some View {
+                Text("beads").task {
+                    if viewModel == nil {
+                        viewModel = BeadsViewModel(appState: appState)
+                    }
+                }
+            }
+        }
+        """
+        let issues = analyzeSource(source, observableTypes: ["BeadsViewModel"])
+            .filter { $0.ruleName == .directInstantiation }
+        #expect(issues.isEmpty)
+    }
+
+    @Test func testNonObservableModelInAViewIsStillReported() throws {
+        // The gate is `@Observable` ownership, not "anything built in a view". A plain service
+        // reached for inside a view body is the case the rule exists for.
+        let source = """
+        struct BeadsView: View {
+            @State private var viewModel: BeadsViewModel?
+
+            var body: some View {
+                Text("beads").task {
+                    let runner = SwiftLintRunner()
+                    _ = runner
+                }
+            }
+        }
+        """
+        let issues = analyzeSource(source, observableTypes: ["BeadsViewModel"])
+            .filter { $0.ruleName == .directInstantiation }
+        let issue = try #require(issues.first)
+        #expect(issue.message.contains("SwiftLintRunner"))
+    }
+
+    @Test func testObservableModelOutsideAViewIsStillReported() throws {
+        // Scoped to `View`. The same `@Observable` type built by a service is an ordinary
+        // dependency of that service.
+        let source = """
+        final class Coordinator {
+            func start() {
+                let model = BeadsViewModel(appState: appState)
+                _ = model
+            }
+        }
+        """
+        let issues = analyzeSource(source, observableTypes: ["BeadsViewModel"])
+            .filter { $0.ruleName == .directInstantiation }
+        let issue = try #require(issues.first)
+        #expect(issue.message.contains("BeadsViewModel"))
+    }
+}


### PR DESCRIPTION
## What changed

`Direct Instantiation` no longer reports an `@Observable` type constructed inside a SwiftUI `View`.

## Why

`@State private var model = Model()` is already exempt, for exactly this reason — a model a view owns is view state, not an injectable dependency. The rule was still reporting the same ownership one step deferred, and the deferral is forced rather than stylistic:

```swift
@Environment(AppState.self) private var appState
@State private var viewModel: BeadsViewModel?
...
.task { if viewModel == nil { viewModel = BeadsViewModel(appState: appState) } }
```

An `@Environment` value cannot be read from a property initializer, so a model that needs one has to be built later. That construction **is** the injection — `appState` arrives from the environment — and the rule's suggestion, *"use `@StateObject`/`@EnvironmentObject`"*, names the pre-Observation API for a problem Observation does not have.

Seven findings, the same pattern written identically seven times in one app: Beads, Corpus, Health, Insights, Chat, Patterns, Symbols.

## What a reviewer should scrutinise

- **The two edges.** `testNonObservableModelInAViewIsStillReported` puts a `SwiftLintRunner()` inside a view's `.task` and expects it reported — the gate is `@Observable` ownership, not "anything built in a view". `testObservableModelOutsideAViewIsStillReported` builds the same model in a coordinator and expects it reported — the gate is scoped to `View`, and `isSwiftUIViewOnly` deliberately excludes `App`, which the entry-point gate handles for its own reason.
- **That no prescan wiring was needed.** `knownObservableTypes` is already on `BasePatternVisitor`, put there for `Concrete Type Usage` — the rule that reaches the same conclusion about the same types from the declaration end, with a different argument (protocol-abstracting an observation model severs change tracking).

## Measurement

26 repositories: `Direct Instantiation` **39 → 32**, no other rule affected. `swift test`: 3511 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139xQgmEuKzghKVktMhpUy5