### PR TITLE
Suppress the fifth accessibility checker, with the reason beside it

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/AccessibilityVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/AccessibilityVisitor.swift
@@ -79,6 +79,13 @@ class AccessibilityVisitor: BasePatternVisitor {
     private lazy var imageChecker = ImageAccessibilityChecker(visitor: self)
     private lazy var textChecker = TextAccessibilityChecker(visitor: self)
     private lazy var colorChecker = ColorAccessibilityChecker(visitor: self)
+    // The fifth sibling, and the only one the rule still reports: the other four take
+    // `visitor: self` and are exempt because a helper handed its owner cannot be injected
+    // into that owner. This one needs nothing from the visitor, so it takes no arguments —
+    // which is a smaller coupling than its siblings, not a larger one. It has no stored state
+    // and no collaborators; injecting it would mean routing a stateless checker in from
+    // outside to check that this visitor checks custom controls.
+    // swiftprojectlint:disable:next direct-instantiation
     private lazy var customControlChecker = CustomControlAccessibilityChecker()
 
     // MARK: - Initializers


### PR DESCRIPTION
## What changed

One `// swiftprojectlint:disable:next direct-instantiation` on `AccessibilityVisitor`'s `customControlChecker`, with the reasoning written above it.

## Why

The visitor declares five `lazy var` sub-checkers. Four take `visitor: self` and are now exempt — a helper handed its owner cannot be injected into that owner, because `self` does not exist before the initializer that would receive a substitute has run. The fifth needs nothing from the visitor, so it takes no arguments, which is a *smaller* coupling than its siblings and the only one still reported.

It has no stored state and no collaborators. Injecting it would mean routing a stateless checker in from outside to check that this visitor checks custom controls.

## What a reviewer should scrutinise

Whether this should be a gate rather than a suppression. It should — but the gate it wants is "the constructed type has no stored dependencies", which the rule cannot compute today. That question is filed separately with the eleven corpus findings that need it, rather than approximated here with something like "value type" or "no-argument initializer", both of which were measured against the corpus and both of which would have swallowed real findings (`CacheManager` is a `public struct` doing file I/O; `AntiPatternStore()` and `SourceKitClient()` are no-argument constructions of actors that do real work).

## Measurement

This repository now reports **zero** `Direct Instantiation` findings, down from seven at the start of the sweep. `swift test`: 3511 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139xQgmEuKzghKVktMhpUy5