### PR TITLE
Unreachable Effect Closure: naming a @State write does not give it a seam

### DIFF
--- a/Docs/rules/unreachable-effect-closure.md
+++ b/Docs/rules/unreachable-effect-closure.md
@@ -45,7 +45,7 @@ That extraction has since landed in that project, which gave the rule an end-to-
 
 ### Discussion
 
-`UnreachableEffectClosureVisitor` reports a `ClosureExprSyntax` when all three hold.
+`UnreachableEffectClosureVisitor` reports a `ClosureExprSyntax` when all four hold.
 
 **1. Registered, not called.** Two surfaces, matched by an explicit allowlist:
 
@@ -62,7 +62,33 @@ Note that inverting `isPure` would **not** work: it folds four refuters into one
 
 This is what makes the rule converge. `.onKeyPress(.escape) { clearSelection() }` is the *fixed* form; reporting it would mean the advice can never be satisfied, and a rule that cannot be satisfied gets switched off. A body that is exactly one `FunctionCallExprSyntax` — optionally `return`ed — is already a named seam, and an empty body has nothing to extract.
 
-A single **assignment** is not a call and does report. That asymmetry with `{ clear() }` is deliberate rather than an oversight: `{ selectedId = nil }` has no name either, and naming it is exactly the fix.
+A single **assignment** is not a call and does report. That asymmetry with `{ clear() }` is deliberate rather than an oversight: `{ selectedId = nil }` has no name either, and naming it is exactly the fix — *provided the state it writes is somewhere a test can reach*, which is condition 4.
+
+**4. The effect has somewhere to be observed from.** A closure whose every write is a direct assignment to the enclosing view's own `@State` or `@FocusState` is **not** reported, because for that storage the rule's promise is false.
+
+This is the one condition on the rule that was measured rather than reasoned about, and it had to be: 50 of the rule's 87 corpus findings wrote nothing but view-local `@State`, so more than half of what it asked for turned on whether naming such a write creates a seam. `Tests/AppTests/StateSeamHarnessTests.swift` builds both forms — the reported body and the extraction the suggestion describes — and tries every route a test has to the state afterwards:
+
+| Route | Result |
+| --- | --- |
+| Call the extracted method on the view | property unchanged |
+| Read it back through the rendered body | unchanged |
+| Fire the button through ViewInspector | unchanged, for **both** the inline and the extracted button |
+
+`@State`'s storage is allocated when SwiftUI installs the view. Before that the setter has nowhere to write and the getter answers from the initial value. The one route that observes the property is `ViewHosting.host`, and it goes through SwiftUI's storage rather than through the name — so it works identically either way. **The seam a test uses is the button, and the button exists in both forms.** The method exists in one and adds nothing.
+
+The third row is what makes the other two mean anything. Without it the harness shows only that nothing works, which is not a finding.
+
+**The gate is narrow because the same harness shows where the promise holds.** Three write targets stay reported, each measured:
+
+- **`@Binding`** — the storage belongs to the parent, and a test supplies its own `Binding(get:set:)` and reads the write back. 15 corpus write targets.
+- **`@AppStorage`** — the setter writes straight through to the defaults store, which a test reads with no view at all. 4 corpus write targets.
+- **A member write** — `viewModel.searchQuery = ""`, `model.extraArguments = new`. The object outlives the view, so the method moves onto it and a test calls it directly. 17 corpus write targets.
+
+So *one* non-`@State` write anywhere in the body keeps the whole finding. The gate's claim is about the only thing the body does, and under-gating is the safe direction.
+
+`@FocusState` is included on measurement rather than on mechanism: no corpus finding writes one, and the harness covers it because that was cheaper than arguing about it. `@GestureState` is **not** included — same storage mechanism, no corpus instance, and no harness case, so it is left reporting rather than gated on a theory.
+
+The `@State` set is keyed **per type, not per file**. Two views in one file routinely use the same property name for different storage, and a file-wide set would let one view's `@State private var text` gate another view's `@Binding var text`.
 
 ### Refutations
 
@@ -70,6 +96,7 @@ A single **assignment** is not a call and does report. That asymmetry with `{ cl
 - **Empty bodies** — nothing to extract.
 - **Read-only closures** — no captured write. That is the pure sibling's territory when pure, and nobody's when it merely reads.
 - **Local-only writes** — writes to a `var` declared inside the closure never escape, and neither do writes to a closure parameter, including an `inout` accumulator in a nested `reduce(into:)`.
+- **Writes to nothing but the view's own `@State` / `@FocusState`** — condition 4. Measured, not assumed.
 - **Test files** — the same skip the other testability visitors apply.
 - **`Button` bodies that are a single no-argument call** — [Button Closure Wrapping](button-closure-wrapping.md) owns that exact shape, and condition 3 already excludes it here, so the two cannot double-report.
 - **`onAppear` / `onDisappear`** — see below.
@@ -88,6 +115,10 @@ A single **assignment** is not a call and does report. That asymmetry with `{ cl
 
 The bound-name set backing condition 2 is **flat — scopes are not tracked**. A genuine captured write to `total` goes unrecorded if some unrelated nested closure also binds a `total`. That errs toward *not* reporting, which is the right direction for a rule making a positive claim, but it is a real hole.
 
+**Condition 2 detects assignments only, so a body of nothing but mutating calls is never reported.** `PurityInferrer.mutatesCapturedState(_:)` walks `SequenceExprSyntax` for an assignment operator, so `.onTapGesture { items.append(x); items.sort() }` mutates captured state, has no name, and has never appeared in a count. Closing it would *raise* the number, which is why it is written down here rather than done quietly. Condition 4's own collector does recognise those calls, but only as a disqualifier — reachable when the body also contains an assignment, and never on its own.
+
+**Condition 4 cannot tell a value the view owns from an object it references.** `@State private var draft = Draft()` writing `draft.title = x` is a member write on an object that outlives the view, and `@State private var items: [Int]` writing `items.append(x)` is a mutation of view-local storage. Both are `name.member(…)` and neither is gated. Under-gating, which is the direction this rule chooses everywhere else.
+
 ### Severity
 
-`Info`. This reports a refactor, not a defect — the code works, it is simply unobservable. Unlike its pure sibling it is **not** part of the collapsed candidate inventory, because that inventory means *property-test seeds* and this rule is definitionally not one; findings are listed in text output by default.
+`Info`. This reports a refactor, not a defect — the code works, it is simply unobservable. Condition 4 sharpens what *unobservable* means: the rule now claims only that the effect has somewhere it could be observed from once it has a name, which is the claim the category makes and the one the harness can check. Unlike its pure sibling it is **not** part of the collapsed candidate inventory, because that inventory means *property-test seeds* and this rule is definitionally not one; findings are listed in text output by default.

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/UnreachableEffectClosureVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/UnreachableEffectClosureVisitor.swift
@@ -36,6 +36,12 @@ final class UnreachableEffectClosureVisitor: BasePatternVisitor {
     private var fileIsTestOrFixture = false
     private let purityInferrer = PurityInferrer()
 
+    /// Per type, the names of its `@State` and `@FocusState` properties. See `writesOnlyViewState`.
+    private var viewLocalState: [String: Set<String>] = [:]
+
+    /// The nominal types currently being visited, innermost last.
+    private var typeNameStack: [String] = []
+
     required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
         super.init(pattern: pattern, viewMode: viewMode)
     }
@@ -45,12 +51,20 @@ final class UnreachableEffectClosureVisitor: BasePatternVisitor {
         fileIsTestOrFixture = isTestOrFixtureFile()
     }
 
+    override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
+        let collector = ViewLocalStateCollector(viewMode: .sourceAccurate)
+        collector.walk(node)
+        viewLocalState = collector.byType
+        return .visitChildren
+    }
+
     override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
         guard !fileIsTestOrFixture,
               let surface = CallbackSurface(call: node),
               let closure = surface.callbackClosure(in: node),
               isWorthExtracting(closure),
-              purityInferrer.mutatesCapturedState(closure) else {
+              purityInferrer.mutatesCapturedState(closure),
+              !writesOnlyViewState(closure) else {
             return .visitChildren
         }
 
@@ -67,6 +81,61 @@ final class UnreachableEffectClosureVisitor: BasePatternVisitor {
         )
         return .visitChildren
     }
+
+    /// Condition 4 — the effect has somewhere to be observed from.
+    ///
+    /// The rule's promise is a testability one, in its own description: *"no test can reach its
+    /// effect … naming it gives the effect one."* For a write to the enclosing view's own `@State`
+    /// that promise is false, and `Tests/AppTests/StateSeamHarnessTests.swift` is the measurement
+    /// rather than the argument.
+    ///
+    /// `@State`'s storage is allocated when SwiftUI installs the view. Before that the setter has
+    /// nowhere to write and the getter answers from the initial value, so calling the extracted
+    /// method leaves the property unchanged — and so does firing the button through ViewInspector,
+    /// which the harness checks as its control because without it the result is only "nothing
+    /// works". The one route that does observe the state is `ViewHosting.host`, and it goes through
+    /// SwiftUI's storage rather than through the name, so it works identically for the inline body
+    /// and the extracted method. **The seam a test uses is the button, and the button exists in
+    /// both forms.**
+    ///
+    /// Deliberately narrow, because the harness also shows where the promise holds:
+    ///
+    /// - `@Binding` — the storage belongs to the parent, and a test supplies its own
+    ///   `Binding(get:set:)` and reads the write back. Fifteen corpus write targets. Reported.
+    /// - `@AppStorage` — the setter writes straight through to the defaults store, which a test
+    ///   reads with no view at all. Four corpus write targets. Reported.
+    /// - A member write (`viewModel.query = ""`, `items.append(x)`) — the object outlives the
+    ///   view, so the method can move onto it and be called directly. Reported.
+    ///
+    /// So a single non-`@State` write anywhere in the body keeps the finding: the gate needs
+    /// *every* write to be a direct assignment to view-local storage.
+    ///
+    /// `@FocusState` is included on measurement, not on mechanism — no corpus finding writes one,
+    /// and the harness covers it anyway because that was cheaper than arguing about it.
+    private func writesOnlyViewState(_ closure: ClosureExprSyntax) -> Bool {
+        guard let enclosing = typeNameStack.last,
+              let stateNames = viewLocalState[enclosing] else { return false }
+        let collector = ClosureWriteTargetCollector(viewMode: .sourceAccurate)
+        collector.walk(closure.statements)
+        guard !collector.directWrites.isEmpty, collector.otherWrites.isEmpty else { return false }
+        return collector.directWrites.isSubset(of: stateNames)
+    }
+
+    // MARK: - Enclosing-type tracking
+
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        typeNameStack.append(node.name.text)
+        return .visitChildren
+    }
+
+    override func visitPost(_ _: StructDeclSyntax) { typeNameStack.removeLast() }
+
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+        typeNameStack.append(node.name.text)
+        return .visitChildren
+    }
+
+    override func visitPost(_ _: ClassDeclSyntax) { typeNameStack.removeLast() }
 
     /// Condition 3 — the body is more than a single call, so there is something to name.
     ///
@@ -220,5 +289,118 @@ enum CallbackSurface {
             .filter { $0.label?.text == label }
             .compactMap { $0.expression.as(ClosureExprSyntax.self) }
             .first
+    }
+}
+
+/// Per type, the `@State` and `@FocusState` property names a file declares.
+///
+/// Keyed by type rather than gathered per file: two views in one file routinely use the same
+/// property name for different storage, and a file-wide set would let one view's `@State private
+/// var text` gate another view's `@Binding var text`.
+private final class ViewLocalStateCollector: SyntaxVisitor {
+
+    private(set) var byType: [String: Set<String>] = [:]
+
+    private static let viewLocalWrappers: Set<String> = ["State", "FocusState"]
+
+    private var typeNameStack: [String] = []
+
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        typeNameStack.append(node.name.text)
+        return .visitChildren
+    }
+
+    override func visitPost(_ _: StructDeclSyntax) { typeNameStack.removeLast() }
+
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+        typeNameStack.append(node.name.text)
+        return .visitChildren
+    }
+
+    override func visitPost(_ _: ClassDeclSyntax) { typeNameStack.removeLast() }
+
+    override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard let type = typeNameStack.last else { return .visitChildren }
+        let wrapped = node.attributes.contains { attribute in
+            guard let name = attribute.as(AttributeSyntax.self)?
+                .attributeName.as(IdentifierTypeSyntax.self)?.name.text else { return false }
+            return Self.viewLocalWrappers.contains(name)
+        }
+        guard wrapped else { return .visitChildren }
+        for binding in node.bindings {
+            if let identifier = binding.pattern.as(IdentifierPatternSyntax.self) {
+                byType[type, default: []].insert(identifier.identifier.text)
+            }
+        }
+        return .visitChildren
+    }
+}
+
+/// What a closure body writes to, split by whether the write lands in view-local storage.
+///
+/// `directWrites` are bare-identifier assignments and `toggle()` — the shapes that reach a
+/// `@State` property itself. `otherWrites` is everything else that mutates: a member assignment
+/// (`viewModel.error = nil`), or a mutating call on a receiver (`items.append(x)`). One entry in
+/// `otherWrites` disqualifies the whole closure, because the gate's claim is about the *only*
+/// thing the body does.
+private final class ClosureWriteTargetCollector: SyntaxVisitor {
+
+    private(set) var directWrites: Set<String> = []
+    private(set) var otherWrites: Set<String> = []
+
+    /// Calls that mutate their receiver. An allowlist, for the reason `CallbackSurface` gives:
+    /// an unlisted name is a missed disqualification and so a kept finding, which is the safe
+    /// direction, while a wrong inference gates something real.
+    private static let mutatingCalls: Set<String> = [
+        "append", "insert", "remove", "removeAll", "removeFirst", "removeLast", "removeValue",
+        "sort", "reverse", "popLast", "formUnion", "subtract"
+    ]
+
+    /// Assignment is read off `SequenceExprSyntax`, not `InfixOperatorExprSyntax`: an unfolded
+    /// tree — what `Parser.parse` produces and what every visitor here walks — represents
+    /// `flag = true` as a three-element sequence. `InfixOperatorExprSyntax` appears only after
+    /// operator folding, which the linter never does.
+    override func visit(_ node: SequenceExprSyntax) -> SyntaxVisitorContinueKind {
+        let elements = Array(node.elements)
+        guard elements.count >= 2, Self.isAssignment(elements[1]) else { return .visitChildren }
+        record(target: elements[0])
+        return .visitChildren
+    }
+
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        guard let member = node.calledExpression.as(MemberAccessExprSyntax.self),
+              let receiver = member.base?.as(DeclReferenceExprSyntax.self) else {
+            return .visitChildren
+        }
+        let name = member.declName.baseName.text
+        if name == "toggle" {
+            directWrites.insert(receiver.baseName.text)
+        } else if Self.mutatingCalls.contains(name) {
+            otherWrites.insert(receiver.baseName.text)
+        }
+        return .visitChildren
+    }
+
+    private func record(target: ExprSyntax) {
+        if let reference = target.as(DeclReferenceExprSyntax.self) {
+            directWrites.insert(reference.baseName.text)
+            return
+        }
+        if let member = target.as(MemberAccessExprSyntax.self) {
+            otherWrites.insert(member.description.trimmingCharacters(in: .whitespaces))
+            return
+        }
+        // A subscript, a tuple destructuring, anything else — treat as a write that is not a
+        // plain `@State` assignment rather than ignoring it.
+        otherWrites.insert(target.description.trimmingCharacters(in: .whitespaces))
+    }
+
+    /// `=` is an `AssignmentExprSyntax`; `+=` and friends are binary operators whose text ends
+    /// in `=` without being a comparison.
+    private static func isAssignment(_ element: ExprSyntax) -> Bool {
+        if element.is(AssignmentExprSyntax.self) { return true }
+        guard let binary = element.as(BinaryOperatorExprSyntax.self) else { return false }
+        let text = binary.operator.text
+        return text.hasSuffix("=") && !["==", "!=", "<=", ">=", "==="].contains(text)
     }
 }

--- a/Tests/AppTests/StateSeamHarnessTests.swift
+++ b/Tests/AppTests/StateSeamHarnessTests.swift
@@ -101,4 +101,71 @@ struct StateSeamHarnessTests {
         selection.clear()
         #expect(selection.chosen == nil)
     }
+
+    // MARK: - Which wrappers the finding actually holds
+
+    private struct BindingSubject: View {
+        @Binding var flag: Bool
+        func present() { flag = true }
+        var body: some View { Button("go", action: present) }
+    }
+
+    @Test("A @Binding write IS observable, so it must not be gated")
+    func bindingWriteIsObservable() {
+        // Fifteen of the corpus write targets are `@Binding`. A binding is the parent's storage,
+        // and a test supplies its own — so the write lands somewhere the test owns and can read.
+        // This is the case that keeps the gate from being "any property wrapper".
+        final class Box: @unchecked Sendable { var value = false }
+        let box = Box()
+        let view = BindingSubject(
+            flag: Binding(get: { box.value }, set: { box.value = $0 })
+        )
+
+        view.present()
+
+        #expect(box.value == true)
+    }
+
+    private struct StorageSubject: View {
+        @AppStorage("uec.harness.flag") private var flag = false
+        var isOn: Bool { flag }
+        func present() { flag = true }
+        var body: some View { Button("go", action: present) }
+    }
+
+    @Test("An @AppStorage write IS observable, so it must not be gated either")
+    func appStorageWriteIsObservable() {
+        // Four of the corpus write targets are `@AppStorage`. Unlike `@State`, its setter writes
+        // straight through to the defaults store, which a test reads without any view at all.
+        UserDefaults.standard.removeObject(forKey: "uec.harness.flag")
+        defer { UserDefaults.standard.removeObject(forKey: "uec.harness.flag") }
+
+        let view = StorageSubject()
+        #expect(view.isOn == false)
+
+        view.present()
+
+        #expect(UserDefaults.standard.bool(forKey: "uec.harness.flag") == true)
+        #expect(view.isOn == true)
+    }
+
+    private struct FocusSubject: View {
+        private enum Field: Hashable { case name }
+        @FocusState private var focus: Field?
+        var isFocused: Bool { focus == .name }
+        func focusName() { focus = .name }
+        var body: some View { TextField("name", text: .constant("")).focused($focus, equals: .name) }
+    }
+
+    @Test("@FocusState behaves like @State, measured rather than assumed")
+    func focusStateWriteIsNotObservable() {
+        // No corpus finding writes `@FocusState`, so this is the one wrapper the gate covers on
+        // mechanism rather than on evidence. Measuring it is cheaper than arguing about it.
+        let view = FocusSubject()
+        #expect(view.isFocused == false)
+
+        view.focusName()
+
+        #expect(view.isFocused == false)
+    }
 }

--- a/Tests/AppTests/StateSeamHarnessTests.swift
+++ b/Tests/AppTests/StateSeamHarnessTests.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+import Testing
+import ViewInspector
+
+/// Does extracting a callback body into a named method make the effect assertable?
+///
+/// `Unreachable Effect Closure` is a `testability` rule and its description makes a testability
+/// claim: *"No test can fire the callback, so the effect has no seam to be observed through;
+/// naming it gives the effect one."* Fifty of its 87 corpus findings write to nothing but the
+/// enclosing view's own `@State`, so the claim has to hold for that case or the rule is asking
+/// for 50 refactors that buy nothing.
+///
+/// This is the harness rather than the argument. It builds both halves — the reported form and
+/// the form the rule asks for — and tries every route a test has to the state afterwards.
+@Suite("Does a named method give a @State write a seam?")
+@MainActor
+struct StateSeamHarnessTests {
+
+    /// The shape the rule reports, and the shape it asks for, in one view.
+    private struct SubjectView: View {
+        @State private var flag = false
+
+        /// Readable from a test. The point of the harness is that this still answers `false`
+        /// after a write, so exposing it is not what is missing.
+        var isOn: Bool { flag }
+
+        /// The extraction the rule's suggestion describes: the body lifted into a named method.
+        func present() { flag = true }
+
+        var body: some View {
+            VStack {
+                Button("reported") { flag = true }
+                Button("extracted", action: present)
+                Text(flag ? "on" : "off")
+            }
+        }
+    }
+
+    @Test("Calling the extracted method on an uninstalled view does not change the state")
+    func extractedMethodOnUninstalledView() {
+        let view = SubjectView()
+        #expect(view.isOn == false)
+
+        view.present()
+
+        // The whole of the rule's promise, tested directly. `@State`'s storage is allocated by
+        // SwiftUI when it installs the view; before that the setter has nowhere to write and the
+        // getter answers from the initial value. Naming the mutation changes none of that.
+        #expect(view.isOn == false)
+    }
+
+    @Test("Reading the state back through the rendered body also shows nothing")
+    func extractedMethodThroughRenderedBody() throws {
+        let view = SubjectView()
+        view.present()
+
+        // Not a limitation of the reader: the body renders from the same uninstalled storage.
+        let text = try view.inspect().find(ViewType.Text.self).string()
+        #expect(text == "off")
+    }
+
+    @Test("Firing the callback does not reach it either, and reaches it equally badly both ways")
+    func firingTheCallbackReachesNothing() throws {
+        // Without a control the two tests above prove only that nothing works, which is not a
+        // finding. So: fire each button and read the state back.
+        let inline = SubjectView()
+        try inline.inspect().find(button: "reported").tap()
+        let afterInline = try inline.inspect().find(ViewType.Text.self).string()
+
+        let extracted = SubjectView()
+        try extracted.inspect().find(button: "extracted").tap()
+        let afterExtracted = try extracted.inspect().find(ViewType.Text.self).string()
+
+        // Both read "off". Tapping an unhosted view runs the action, the action writes, and the
+        // write goes nowhere — the same as calling the method directly. The only route that
+        // observes this state at all is `ViewHosting.host`, and that route goes through SwiftUI's
+        // storage rather than through the name, so it works identically for both forms.
+        //
+        // Which is the finding stated as sharply as it can be: the seam a test uses is the
+        // *button*, and the button exists in both forms. The method exists in one and adds
+        // nothing.
+        #expect(afterInline == "off")
+        #expect(afterExtracted == "off")
+    }
+
+    @Test("And a model write is reachable without any of this")
+    func aModelWriteNeedsNoView() {
+        // The other half of the corpus, for contrast. Thirty-four of the 87 findings write to an
+        // object the view does not own. Lifting one of those onto the model gives a method a test
+        // calls directly — no view, no hosting, no inspection.
+        @MainActor
+        final class Selection {
+            private(set) var chosen: Int?
+            func clear() { chosen = nil }
+            func choose(_ value: Int) { chosen = value }
+        }
+
+        let selection = Selection()
+        selection.choose(3)
+        #expect(selection.chosen == 3)
+        selection.clear()
+        #expect(selection.chosen == nil)
+    }
+}

--- a/Tests/CoreTests/Testability/UnreachableEffectClosureViewStateTests.swift
+++ b/Tests/CoreTests/Testability/UnreachableEffectClosureViewStateTests.swift
@@ -1,0 +1,249 @@
+@testable import Core
+import Foundation
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+private func analyze(_ source: String, filePath: String = "ContentView.swift") -> [LintIssue] {
+    let visitor = UnreachableEffectClosureVisitor(patternCategory: .testability)
+    let syntax = Parser.parse(source: source)
+    visitor.setSourceLocationConverter(
+        SourceLocationConverter(fileName: filePath, tree: syntax)
+    )
+    visitor.setFilePath(filePath)
+    visitor.walk(syntax)
+    return visitor.detectedIssues.filter { $0.ruleName == .unreachableEffectClosure }
+}
+
+/// Condition 4: the effect has to have somewhere to be observed from.
+///
+/// The rule's description makes a testability claim — *"no test can reach its effect … naming it
+/// gives the effect one"* — and for a write to the enclosing view's own `@State` that claim is
+/// false. `Tests/AppTests/StateSeamHarnessTests.swift` is the measurement: calling the extracted
+/// method on an uninstalled view leaves the property unchanged, reading it back through the
+/// rendered body shows the same, and firing the button through ViewInspector reaches it no better.
+/// The seam a test uses is the button, and the button exists in both forms.
+///
+/// The same harness shows where the promise *does* hold, which is what these tests pin: `@Binding`
+/// writes into storage a test supplies, `@AppStorage` writes straight through to the defaults
+/// store, and a member write lands on an object that outlives the view.
+@Suite("A write to the view's own @State has no seam to gain")
+struct UnreachableEffectClosureViewStateTests {
+
+    // MARK: - Gated
+
+    @Test("a Button writing only the view's own @State is not reported")
+    func stateOnlyButtonIsNotReported() {
+        let issues = analyze("""
+        struct LoginView: View {
+            @State private var showingConfig = false
+
+            var body: some View {
+                Button("Configure") {
+                    showingConfig = true
+                }
+            }
+        }
+        """)
+        #expect(issues.isEmpty)
+    }
+
+    @Test("several @State writes in one body are still gated")
+    func multipleStateWritesAreGated() {
+        // The corpus shape: an alert's OK button clearing two flags at once.
+        let issues = analyze("""
+        struct ContentView: View {
+            @State private var errorMessage: String?
+            @State private var showError = false
+
+            var body: some View {
+                Button("OK") {
+                    errorMessage = nil
+                    showError = false
+                }
+            }
+        }
+        """)
+        #expect(issues.isEmpty)
+    }
+
+    @Test("toggle and compound assignment on @State are gated too")
+    func toggleAndCompoundAssignmentAreGated() {
+        let issues = analyze("""
+        struct ContentView: View {
+            @State private var isExpanded = false
+            @State private var step = 0
+
+            var body: some View {
+                Button("More") {
+                    isExpanded.toggle()
+                    step += 1
+                }
+            }
+        }
+        """)
+        #expect(issues.isEmpty)
+    }
+
+    @Test("@FocusState is gated on the same measurement")
+    func focusStateIsGated() {
+        let issues = analyze("""
+        struct ContentView: View {
+            @FocusState private var focus: Field?
+
+            var body: some View {
+                Button("Name") {
+                    focus = .name
+                }
+            }
+        }
+        """)
+        #expect(issues.isEmpty)
+    }
+
+    // MARK: - Still reported, because the seam is real
+
+    @Test("a @Binding write is reported — the parent owns the storage")
+    func bindingWriteIsReported() throws {
+        // A test supplies its own `Binding(get:set:)` and reads the write back, so the extracted
+        // method genuinely becomes assertable. Fifteen of the corpus write targets are these.
+        let issues = analyze("""
+        struct ConfigRow: View {
+            @Binding var serverURL: String
+
+            var body: some View {
+                Button("Local Development") {
+                    serverURL = "http://localhost:8080"
+                }
+            }
+        }
+        """)
+        let issue = try #require(issues.first)
+        #expect(issue.message.contains("Button"))
+    }
+
+    @Test("an @AppStorage write is reported — it lands in the defaults store")
+    func appStorageWriteIsReported() {
+        let issues = analyze("""
+        struct SizeCommands: View {
+            @AppStorage("textSizeStep") private var textSizeStep = 0
+
+            var body: some View {
+                Button("Larger Text") {
+                    textSizeStep = min(textSizeStep + 1, 4)
+                }
+            }
+        }
+        """)
+        #expect(issues.count == 1)
+    }
+
+    @Test("a member write is reported — the object outlives the view")
+    func memberWriteIsReported() {
+        let issues = analyze("""
+        struct SearchBar: View {
+            @Bindable var viewModel: SearchViewModel
+
+            var body: some View {
+                Button("Clear") {
+                    viewModel.searchQuery = ""
+                    viewModel.searchResults = []
+                }
+            }
+        }
+        """)
+        #expect(issues.count == 1)
+    }
+
+    @Test("one non-@State write anywhere keeps the whole finding")
+    func mixedBodyIsReported() {
+        // The gate's claim is about the *only* thing the body does, so a body that clears a flag
+        // and also touches a model is not gated. Under-gating is the safe direction here.
+        let issues = analyze("""
+        struct ContentView: View {
+            @State private var showingSheet = false
+            let viewModel: ViewModel
+
+            var body: some View {
+                Button("Apply") {
+                    showingSheet = false
+                    viewModel.apply()
+                    viewModel.dirty = true
+                }
+            }
+        }
+        """)
+        #expect(issues.count == 1)
+    }
+
+    @Test("a body of nothing but mutating calls is not reported, and never was")
+    func mutatingCallsAloneAreNotReported() {
+        // Not this gate. `PurityInferrer.mutatesCapturedState` detects *assignments* only, so a
+        // closure whose whole body is `items.append(x)` never satisfied condition 2 and has never
+        // been reported by this rule. Recorded here rather than left as a surprise: closing it
+        // would raise the count, and it is filed rather than done quietly.
+        let issues = analyze("""
+        struct ContentView: View {
+            @State private var items: [Int] = []
+
+            var body: some View {
+                Button("Add") {
+                    items.append(1)
+                    items.append(2)
+                }
+            }
+        }
+        """)
+        #expect(issues.isEmpty)
+    }
+
+    @Test("a mutating call beside an assignment disqualifies the gate")
+    func mutatingCallBesideAnAssignmentIsReported() {
+        // Where the disqualifier is reachable. Whether `items` is a value the view owns or an
+        // object it merely references cannot be told from syntax, so the finding is kept.
+        let issues = analyze("""
+        struct ContentView: View {
+            @State private var isAdding = false
+            @State private var items: [Int] = []
+
+            var body: some View {
+                Button("Add") {
+                    isAdding = false
+                    items.append(1)
+                }
+            }
+        }
+        """)
+        #expect(issues.count == 1)
+    }
+
+    // MARK: - Per type, not per file
+
+    @Test("the same name is @State in one view and @Binding in another")
+    func stateNamesAreKeyedByType() throws {
+        // Two views in one file routinely use the same property name for different storage. A
+        // file-wide set would let the first view's `@State private var text` gate the second
+        // view's `@Binding var text`, which the harness says is a real seam.
+        let issues = analyze("""
+        struct OwnerView: View {
+            @State private var text = ""
+
+            var body: some View {
+                Button("Clear") { text = "" }
+            }
+        }
+
+        struct ChildView: View {
+            @Binding var text: String
+
+            var body: some View {
+                Button("Reset") { text = "" }
+            }
+        }
+        """)
+        #expect(issues.count == 1)
+        let issue = try #require(issues.first)
+        #expect(issue.symbol == "body")
+    }
+}


### PR DESCRIPTION
## What changed

A fourth condition on `Unreachable Effect Closure`: a callback closure whose **every write is a direct assignment to the enclosing view's own `@State` or `@FocusState`** is no longer reported.

## Why, and why it needed measuring

The rule is filed under `testability` and its description makes a testability claim — *"no test can fire the callback, so the effect has no seam to be observed through; naming it gives the effect one."*

**Fifty of its 87 corpus findings write nothing but view-local `@State`**, so more than half of what the rule asks for turns on whether that claim holds for that storage. The first commit is the harness, built before any gate:

| Route to the state | Result |
| --- | --- |
| Call the extracted method on the view | property unchanged |
| Read it back through the rendered body | unchanged |
| Fire the button through ViewInspector | unchanged — for **both** the inline and the extracted button |

`@State`'s storage is allocated when SwiftUI installs the view; before that the setter has nowhere to write. The one route that observes the property is `ViewHosting.host`, and it goes through SwiftUI's storage rather than through the name. **The seam a test uses is the button, and the button exists in both forms.**

The third row is the control. Without it the first two show only that nothing works, which is not a finding.

## What a reviewer should scrutinise

- **That the gate is not "any property wrapper".** The same harness measures three cases where the promise *does* hold, and all three stay reported: `@Binding` (a test supplies its own `Binding(get:set:)` and reads the write back — 15 corpus write targets), `@AppStorage` (writes through to the defaults store — 4), and a member write (the object outlives the view — 17). Each has a test.
- **That one non-`@State` write keeps the whole finding.** `testMixedBodyIsReported` puts a flag clear beside a model write and expects the finding.
- **The per-type keying.** A file-wide `@State` set would let one view's `@State private var text` gate another view's `@Binding var text`; there is a test with both in one file.
- **`@GestureState` is deliberately excluded.** Same storage mechanism, no corpus instance, no harness case — so it is left reporting rather than gated on a theory.

## Two limitations found on the way, documented rather than fixed

- **Condition 2 detects assignments only.** `PurityInferrer.mutatesCapturedState` walks for an assignment operator, so `.onTapGesture { items.append(x) }` mutates captured state, has no name, and has never appeared in a count. Closing it *raises* the number, which is why it is written down rather than done quietly. There is a test asserting the current behaviour.
- **Condition 4 cannot tell a value the view owns from an object it references.** `@State var draft = Draft()` writing `draft.title` and `@State var items: [Int]` writing `items.append` are both `name.member(…)`, and neither is gated. Under-gating, which is the direction this rule chooses everywhere else.

## Measurement

26 repositories: `Unreachable Effect Closure` **87 → 40**. No other rule's count moved. `swift test`: 3529 tests passing. Rule documentation carries condition 4, the harness table, and both limitations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139xQgmEuKzghKVktMhpUy5