### PR TITLE
A view nobody inspects needs no hook — the rule said so and did not do it

### DIFF
--- a/Docs/rules/observable-environment-view-missing-inspection-hook.md
+++ b/Docs/rules/observable-environment-view-missing-inspection-hook.md
@@ -13,10 +13,30 @@ The keypath form is not affected. `@Environment(\.someKey)` falls back to a defa
 
 A view reading the fatal form can only be inspected by hosting it and inspecting from inside the live render, which requires the view to carry an inspection relay. Without one, the view is untestable by ViewInspector — and the way you find out is a process-killing trap whose backtrace names neither ViewInspector nor the test that triggered it.
 
+**That claim was re-measured against the pinned ViewInspector revision, because it had a plausible expiry date.** ViewInspector gained `@Observable` environment injection (`EnvironmentInjection.environmentKeyPaths(for:)`), and its own suite inspects such a view with `sut.environment(obj).inspect()` and no relay at all — so the rule looked obsolete. It is not. Three attempts against the revision this project pins, each killing the test process:
+
+| Attempt | Result |
+| --- | --- |
+| `SubjectView().inspect()` | trap |
+| `SubjectView().environment(store).inspect()` | trap |
+| `VStack { SubjectView() }.environment(store).inspect()` | trap |
+
+ViewInspector's passing case differs in a way that matters: its `ObservableOptionalView` declares the environment as **optional** (`… private var obj1: TestObservableObject1?`), which returns `nil` rather than trapping, and its `ObservableOuterView` reads the objects in a *child* rather than in its own body. Neither is the shape this rule reports. The hazard is real and current.
+
 ### Discussion
 `ObservableEnvironmentViewMissingInspectionHookVisitor` reports a `struct` conforming to `View` that declares at least one `@Environment(SomeType.self)` property and no stored property named `inspection`. The message names each offending environment type.
 
-This is **advisory**, not a defect: a view nobody inspects needs no hook, and adding one to every view would be noise. It is `Info` severity for that reason. The value is that it fires at the moment the view is written, rather than leaving the constraint to be discovered later from a crash log.
+This is **advisory**, not a defect: a view nobody inspects needs no hook, and adding one to every view would be noise. It is `Info` severity for that reason.
+
+**The rule now implements that sentence, having stated it for several runs without doing so.** A finding requires the view to be *named from a file that imports ViewInspector*, which is the project-wide answer to "is anybody trying to inspect this?"
+
+The measurement that prompted it: across seven repositories the rule reported **58 findings, and not one of the 58 views was named from a ViewInspector-importing file**. Nor did any of them carry the relay. The rule was asking fifty-eight views to add production code for tests that did not exist.
+
+What the corpus *does* contain is one repository that took the advice, and it is the argument for keeping the rule rather than deleting it. SwiftMarkdownWiki's `ContentView` and `EditorView` carry the relay and are genuinely inspected through it (`sut.inspection.inspect { … }`), and its vendored `Inspection.swift` records why the type lives in the app target. **The advice works end to end; it was taken exactly where someone wanted the test.** Which is also when the gated rule fires.
+
+The gate does not trade the "fires early" property away. A developer writing `import ViewInspector` and naming the view gets the finding *before the test is ever run* — earlier than the trap, not later.
+
+**Do not answer this question with `grep`.** Asked that way over this corpus it reports four inspected views. Three are a doc comment listing views the file does not touch, and the fourth is a comment recording that the author hit the trap and chose to stop descending. `InspectedTypeNameCollector` walks syntax, so it sees none of them, and there is a test pinning exactly that.
 
 The relay is two lines, and deliberately lives in the app target so the app never links ViewInspector — the test target supplies the protocol conformance:
 
@@ -80,5 +100,15 @@ struct Holder {
 }
 ```
 
+### Known limitations
+
+The catalog is **name-keyed and deliberately over-collects**: every capitalised identifier in a ViewInspector-importing file counts, not only views and not only ones under inspection. A view sharing a name with something merely mentioned in such a file will be reported. That is the safe direction — the cost of collecting too much is a finding that still reports, and the cost of collecting too little is a view that takes a test process down with no warning.
+
 ### Companion
-[ViewHosting Before Inspection](view-hosting-before-inspection.md) catches the same hazard from the *test* side.
+[ViewHosting Before Inspection](view-hosting-before-inspection.md) catches the same hazard from the *test* side, and consumes the sibling prescan `ObservableEnvironmentViewCollector` as its own precondition — the two rules ask "can this view trap?" and "is anyone about to make it?" from opposite ends.
+
+### A note on wiring
+
+This gate shipped dead the first time. Seven of the eight hops that carry a prescan from `ProjectLinter` to a visitor were done, the eighth was a `det.known… =` assignment whose parameter had a `nil` default, and so the package built, 3,537 tests passed, and the corpus count did not move by one. The visitor was correct in isolation the whole time.
+
+`ProjectLinterTests.testInspectionHookGateReachesTheVisitorEndToEnd` exists for that reason and no other: it drives the real linter over a two-view fixture and fails if the catalog does not arrive. Verified by removing the eighth hop again and watching it fail. **A unit test on the visitor cannot catch this class of bug, and this project has now shipped it twice.**

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
@@ -178,7 +178,8 @@ extension ProjectLinter {
         let ruleIdentifiers: [RuleIdentifier]?
         let identifiableTypes: Set<String>
         /// `View` names reading `@Environment(SomeType.self)`; `nil` when no pre-scan ran.
-        let observableEnvironmentViews: Set<String>?
+        let observableEnvironmentViews: Set<String>
+        let inspectedTypeNames: Set<String>?
         let functionTypeAliases: Set<String>
         let spiMembers: Set<String>
         let underscoredMembers: Set<String>
@@ -215,6 +216,7 @@ extension ProjectLinter {
             ruleIdentifiers: env.ruleIdentifiers,
             identifiableTypes: env.identifiableTypes,
             observableEnvironmentViews: env.observableEnvironmentViews,
+            inspectedTypeNames: env.inspectedTypeNames,
             functionTypeAliases: env.functionTypeAliases,
             spiMembers: env.spiMembers,
             underscoredMembers: env.underscoredMembers,
@@ -241,6 +243,7 @@ extension ProjectLinter {
         ruleIdentifiers: [RuleIdentifier]?,
         identifiableTypes: Set<String> = [],
         observableEnvironmentViews: Set<String>? = nil,
+        inspectedTypeNames: Set<String>? = nil,
         functionTypeAliases: Set<String> = [],
         spiMembers: Set<String> = [],
         underscoredMembers: Set<String> = [],
@@ -270,6 +273,7 @@ extension ProjectLinter {
         let det = SourcePatternDetector(registry: registry)
         det.knownIdentifiableTypes = identifiableTypes
         det.knownObservableEnvironmentViews = observableEnvironmentViews
+        det.knownInspectedTypeNames = inspectedTypeNames
         det.knownFunctionTypeAliases = functionTypeAliases
         det.knownSPIMembers = spiMembers
         det.knownUnderscoredMembers = underscoredMembers

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
@@ -234,6 +234,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         /// `View` names reading `@Environment(SomeType.self)`. See
         /// `ObservableEnvironmentViewCollector` for why the keypath form is excluded.
         let observableEnvironmentViews: Set<String>
+        let inspectedTypeNames: Set<String>
         /// `typealias` names whose underlying type is a function type.
         let functionTypeAliases: Set<String>
         /// Member names declared under `@_spi(...)`.
@@ -278,6 +279,9 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
                 observableEnvironmentViews: collectTypes(
                     ObservableEnvironmentViewCollector.self, from: filePaths
                 ),
+                inspectedTypeNames: collectTypes(
+                    InspectedTypeNameCollector.self, from: filePaths
+                ),
                 functionTypeAliases: collectTypes(FunctionTypeAliasCollector.self, from: filePaths),
                 spiMembers: collectTypes(SPIMemberCollector.self, from: filePaths),
                 underscoredMembers: collectTypes(UnderscoredMemberCollector.self, from: filePaths),
@@ -300,6 +304,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         resolved.knownLocalTypeNames = collected.local
         resolved.knownObservableTypes = collected.observable
         resolved.knownObservableEnvironmentViews = collected.observableEnvironmentViews
+        resolved.knownInspectedTypeNames = collected.inspectedTypeNames
         resolved.knownSPIMembers = collected.spiMembers
         resolved.knownUnderscoredMembers = collected.underscoredMembers
         resolved.knownFunctionTypeAliases = collected.functionTypeAliases
@@ -331,6 +336,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
             ruleIdentifiers: ruleIdentifiers,
             identifiableTypes: collected.identifiable,
             observableEnvironmentViews: collected.observableEnvironmentViews,
+            inspectedTypeNames: collected.inspectedTypeNames,
             functionTypeAliases: collected.functionTypeAliases,
             spiMembers: collected.spiMembers,
             underscoredMembers: collected.underscoredMembers,

--- a/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetector.swift
+++ b/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetector.swift
@@ -32,6 +32,7 @@ public final class SourcePatternDetector: SourcePatternDetectorProtocol, @unchec
     /// Set by `ProjectLinter` after a pre-scan phase and passed through to visitors.
     /// `View` names reading `@Environment(SomeType.self)`; `nil` when no pre-scan ran.
     public var knownObservableEnvironmentViews: Set<String>?
+    public var knownInspectedTypeNames: Set<String>?
 
     /// `typealias` names whose underlying type is a function type.
     /// Member names declared under `@_spi(...)`.
@@ -200,6 +201,7 @@ public final class SourcePatternDetector: SourcePatternDetectorProtocol, @unchec
             let visitor = entry.type.init(pattern: entry.patterns[0])
             visitor.setSourceLocationConverter(converter)
             visitor.knownObservableEnvironmentViews = knownObservableEnvironmentViews
+            visitor.knownInspectedTypeNames = knownInspectedTypeNames
             visitor.knownSPIMembers = knownSPIMembers
             visitor.knownUnderscoredMembers = knownUnderscoredMembers
             visitor.knownFunctionTypeAliases = knownFunctionTypeAliases

--- a/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetectorProtocol.swift
+++ b/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetectorProtocol.swift
@@ -35,6 +35,7 @@ public protocol SourcePatternDetectorProtocol {
     /// Type names known to be declared as protocols across the project.
     /// `View` names reading `@Environment(SomeType.self)`; `nil` when no pre-scan ran.
     var knownObservableEnvironmentViews: Set<String>? { get set }
+    var knownInspectedTypeNames: Set<String>? { get set }
 
     var knownSPIMembers: Set<String> { get set }
     var knownUnderscoredMembers: Set<String> { get set }

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ObservableEnvironmentViewMissingInspectionHookVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ObservableEnvironmentViewMissingInspectionHookVisitor.swift
@@ -43,6 +43,7 @@ final class ObservableEnvironmentViewMissingInspectionHookVisitor: BasePatternVi
         let observableReads = Self.observableEnvironmentProperties(in: node)
         guard !observableReads.isEmpty else { return .visitChildren }
         guard !Self.hasInspectionHook(node) else { return .visitChildren }
+        guard isInspected(node.name.text) else { return .visitChildren }
 
         let names = observableReads.joined(separator: ", ")
         addIssue(
@@ -57,6 +58,30 @@ final class ObservableEnvironmentViewMissingInspectionHookVisitor: BasePatternVi
             ruleName: .observableEnvironmentViewMissingInspectionHook
         )
         return .visitChildren
+    }
+
+    /// Whether anybody is trying to inspect this view.
+    ///
+    /// The rule's own scope, from the paragraph above: *a view nobody inspects needs no hook.*
+    /// Without this the rule states that sentence and does not implement it — it reported 58
+    /// findings across seven repositories, and **not one of the 58 views was named from a file
+    /// that imports ViewInspector**.
+    ///
+    /// The relay is production code added for a test: a stored property plus an `.onReceive` in
+    /// the body of every view that carries it. For a view nobody inspects that is cost with no
+    /// benefit, and the corpus agrees — in the single repository that adopted the pattern, all
+    /// three views that carry it were given it *because someone wanted the test*, and the two that
+    /// are inspected are inspected through it.
+    ///
+    /// So the trigger is a reference from a ViewInspector-importing file, which is earlier than
+    /// the trap rather than later: the developer writes `import ViewInspector` and names the view,
+    /// and the rule fires before the test is ever run. What it no longer does is fire on the other
+    /// fifty-odd views on the chance that somebody might one day.
+    ///
+    /// `nil` — no project-wide prescan, so a visitor driven straight by a unit test — reports.
+    private func isInspected(_ viewName: String) -> Bool {
+        guard let inspected = knownInspectedTypeNames else { return true }
+        return inspected.contains(viewName)
     }
 
     // MARK: - Detection

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/BasePatternVisitor.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/BasePatternVisitor.swift
@@ -107,6 +107,12 @@ open class BasePatternVisitor: SyntaxVisitor, PatternVisitorProtocol {
     /// quiet in exactly the single-file case where it has no way to know better.
     public var knownObservableEnvironmentViews: Set<String>?
 
+    /// Type names referenced from a file importing ViewInspector. `nil` when no project-wide
+    /// prescan ran — a visitor driven directly by a unit test — in which case a rule that
+    /// consults it must report rather than gate, so its own tests keep meaning what they say.
+    /// See `InspectedTypeNameCollector`.
+    public var knownInspectedTypeNames: Set<String>?
+
     /// `typealias` names whose underlying type is a function type. A property typed with one
     /// is already injected — the closure is the seam.
     /// Member names declared under `@_spi(...)` — published deliberately, not leaked.

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/InspectedTypeNameCollector.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/InspectedTypeNameCollector.swift
@@ -1,0 +1,60 @@
+import SwiftSyntax
+
+/// Type names referenced from a file that imports ViewInspector — the project-wide answer to
+/// "is anybody trying to inspect this view?"
+///
+/// `ObservableEnvironmentViewMissingInspectionHook` asks a view to carry test scaffolding: a
+/// stored `Inspection<Self>()` and an `.onReceive` relay in its body. That is production code
+/// added for a test, and the rule's own documentation says when it is worth it — *"a view nobody
+/// inspects needs no hook."* This catalog is how the rule can tell.
+///
+/// Deliberately over-collects. Every capitalised identifier in such a file counts, not only views
+/// and not only ones under inspection, because the cost of collecting too much is a finding that
+/// still reports and the cost of collecting too little is a view that traps a test process with no
+/// warning. Erring toward reporting is the direction every gate in this project takes.
+///
+/// Comments are not collected, and that is load-bearing rather than incidental. A `grep` for the
+/// same question over this corpus reported four inspected views; three were prose in a doc comment
+/// naming views the file does *not* touch, and the fourth was a comment explaining why the author
+/// had stopped descending. Syntax sees none of those.
+public final class InspectedTypeNameCollector: SyntaxVisitor, TypeCollectorProtocol {
+    public var collectedTypes: Set<String> { names }
+
+    private var names: Set<String> = []
+    private var fileImportsViewInspector = false
+
+    public init() {
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override public func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
+        fileImportsViewInspector = node.statements.contains { statement in
+            guard let importDecl = statement.item.as(ImportDeclSyntax.self) else { return false }
+            return importDecl.path.contains { $0.name.text == "ViewInspector" }
+        }
+        return fileImportsViewInspector ? .visitChildren : .skipChildren
+    }
+
+    override public func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
+        record(node.baseName.text)
+        return .visitChildren
+    }
+
+    override public func visit(_ node: IdentifierTypeSyntax) -> SyntaxVisitorContinueKind {
+        record(node.name.text)
+        return .visitChildren
+    }
+
+    override public func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
+        // `SettingsView.self` parses the base as a declaration reference, which the visit above
+        // already records. The member is captured too so `ViewType.Text` and similar spellings
+        // do not depend on which half the parser hands over.
+        record(node.declName.baseName.text)
+        return .visitChildren
+    }
+
+    private func record(_ name: String) {
+        guard name.first?.isUppercase == true else { return }
+        names.insert(name)
+    }
+}

--- a/Tests/CoreTests/ProjectLinterTests.swift
+++ b/Tests/CoreTests/ProjectLinterTests.swift
@@ -324,6 +324,28 @@ struct ProjectLinterNestedPackageTests {
         #expect(concrete.contains { $0.message.contains("PlainService") })
     }
 
+    /// End-to-end: the ViewInspector pre-scan must reach
+    /// `ObservableEnvironmentViewMissingInspectionHook`, so a view somebody inspects is asked for
+    /// a relay and one nobody inspects is left alone.
+    ///
+    /// This test exists because the unit tests could not have caught the bug it was written
+    /// after. Seven of the eight wiring hops were done, the parameter carrying the eighth had a
+    /// `nil` default, the package built, 3,537 tests passed — and the gate removed nothing from
+    /// the corpus. The visitor was correct in isolation the whole time.
+    @Test func testInspectionHookGateReachesTheVisitorEndToEnd() async {
+        let root = makeProjectWithInspectedAndUninspectedViews()
+        let linter = ProjectLinter()
+        let system = PatternRegistryFactory.createConfiguredSystem()
+
+        let issues = await linter.analyzeProject(at: root, detector: system.detector)
+        let hooks = issues.filter { $0.ruleName == .observableEnvironmentViewMissingInspectionHook }
+
+        // The view a test names in code is asked for the relay...
+        #expect(hooks.contains { $0.message.contains("InspectedView") })
+        // ...and the one named only in a comment is not, which is the whole gate.
+        #expect(hooks.contains { $0.message.contains("UninspectedView") } == false)
+    }
+
     /// Excluding a test directory must not hide the mock conformers that justify a
     /// DI-seam protocol. `excludedPaths` is a *reporting* filter, not an *evidence*
     /// filter: the excluded `MockDataParsing` is still walked for cross-file evidence,
@@ -534,6 +556,37 @@ struct ProjectLinterNestedPackageTests {
     /// Package with an `@Observable` model and a plain service, each referenced as a
     /// stored property in a non-view coordinator. Exercises the observable exemption
     /// (SessionStore) against the active rule (PlainService).
+    private func makeProjectWithInspectedAndUninspectedViews() -> String {
+        let root = makeTempPackageRoot(named: "InspectionHook")
+        writeFile(at: "\(root)/Sources/Root/InspectedView.swift", """
+        struct InspectedView: View {
+            @Environment(AppState.self) private var appState
+            var body: some View { Text(appState.title) }
+        }
+        """)
+        writeFile(at: "\(root)/Sources/Root/UninspectedView.swift", """
+        struct UninspectedView: View {
+            @Environment(AppState.self) private var appState
+            var body: some View { Text(appState.title) }
+        }
+        """)
+        // Names `InspectedView` in code and `UninspectedView` only in a comment. The comment must
+        // not count — a `grep` for this question over the real corpus reported four inspected
+        // views and three of them were prose.
+        writeFile(at: "\(root)/Tests/RootTests/InspectedViewTests.swift", """
+        import ViewInspector
+        import XCTest
+
+        // UninspectedView is deliberately named here in prose only.
+        final class InspectedViewTests: XCTestCase {
+            func testBody() throws {
+                _ = try InspectedView().inspect()
+            }
+        }
+        """)
+        return root
+    }
+
     private func makeProjectWithObservableAndPlainService() -> String {
         let root = makeTempPackageRoot(named: "ObservableExemption")
         writeFile(at: "\(root)/Sources/Root/SessionStore.swift", """

--- a/Tests/CoreTests/Testability/InspectedTypeNameCollectorTests.swift
+++ b/Tests/CoreTests/Testability/InspectedTypeNameCollectorTests.swift
@@ -1,0 +1,77 @@
+import SwiftParser
+@testable import SwiftProjectLintVisitors
+import SwiftSyntax
+import Testing
+
+/// The catalog behind `ObservableEnvironmentViewMissingInspectionHook`'s gate.
+@Suite("Type names referenced from a ViewInspector file")
+struct InspectedTypeNameCollectorTests {
+
+    private func collect(_ source: String) -> Set<String> {
+        let collector = InspectedTypeNameCollector()
+        collector.walk(Parser.parse(source: source))
+        return collector.collectedTypes
+    }
+
+    @Test("A file importing ViewInspector yields the types it names")
+    func importingFileYieldsNames() {
+        let names = collect("""
+        import ViewInspector
+        import XCTest
+
+        final class SettingsViewTests: XCTestCase {
+            func testBody() throws {
+                _ = try SettingsView().inspect()
+            }
+        }
+        """)
+        #expect(names.contains("SettingsView"))
+    }
+
+    @Test("A file that does not import ViewInspector yields nothing")
+    func nonImportingFileYieldsNothing() {
+        let names = collect("""
+        import XCTest
+
+        final class SettingsViewTests: XCTestCase {
+            func testBody() {
+                _ = SettingsView()
+            }
+        }
+        """)
+        #expect(names.isEmpty)
+    }
+
+    @Test("A view named only in a comment is not collected")
+    func commentsAreNotCollected() {
+        // This is the case that makes the collector worth having over a `grep`. Asking the same
+        // question of the real corpus with `grep` reported four inspected views: three were a doc
+        // comment listing views the file does not touch, and the fourth was a comment recording
+        // that the author had hit the trap and chosen to stop descending. Syntax sees none of them.
+        let names = collect("""
+        import ViewInspector
+        import XCTest
+
+        // RootView gates between StartupView and the main TabView, and descending further
+        // evaluates StartupView, which reads an @Observable @Environment object.
+        final class RootViewTests: XCTestCase {
+            func testShell() throws {
+                _ = try RootView().inspect()
+            }
+        }
+        """)
+        #expect(names.contains("RootView"))
+        #expect(names.contains("StartupView") == false)
+        #expect(names.contains("TabView") == false)
+    }
+
+    @Test("Lowercase identifiers are not collected")
+    func onlyTypeLikeNames() {
+        let names = collect("""
+        import ViewInspector
+        let value = someFunction()
+        """)
+        #expect(names.contains("someFunction") == false)
+        #expect(names.contains("value") == false)
+    }
+}

--- a/Tests/CoreTests/Testability/ObservableEnvironmentViewMissingInspectionHookVisitorTests.swift
+++ b/Tests/CoreTests/Testability/ObservableEnvironmentViewMissingInspectionHookVisitorTests.swift
@@ -112,4 +112,54 @@ struct ObservableEnvironmentViewMissingInspectionHookVisitorTests {
 
         #expect(visitor.detectedIssues.isEmpty)
     }
+
+    // MARK: - Is anybody inspecting it?
+
+    private func run(_ source: String, inspected: Set<String>?) -> [LintIssue] {
+        let pattern = SyntaxPattern(
+            name: .observableEnvironmentViewMissingInspectionHook,
+            visitor: ObservableEnvironmentViewMissingInspectionHookVisitor.self,
+            severity: .info,
+            category: .testability,
+            messageTemplate: "",
+            suggestion: "",
+            description: ""
+        )
+        let visitor = ObservableEnvironmentViewMissingInspectionHookVisitor(pattern: pattern)
+        visitor.knownInspectedTypeNames = inspected
+        visitor.walk(Parser.parse(source: source))
+        return visitor.detectedIssues
+    }
+
+    private static let subject = """
+    struct SettingsView: View {
+        @Environment(VaultManager.self) private var vault
+        var body: some View { Text(vault.name) }
+    }
+    """
+
+    @Test("A view no ViewInspector file names is not flagged")
+    func uninspectedViewIsNotFlagged() {
+        // The rule's own scope, which it stated and did not implement: "a view nobody inspects
+        // needs no hook." All 58 corpus findings were this case.
+        #expect(run(Self.subject, inspected: []).isEmpty)
+    }
+
+    @Test("A view some ViewInspector file names is flagged")
+    func inspectedViewIsFlagged() {
+        #expect(run(Self.subject, inspected: ["SettingsView"]).count == 1)
+    }
+
+    @Test("Another view being inspected does not implicate this one")
+    func gateIsPerView() {
+        #expect(run(Self.subject, inspected: ["SomeOtherView"]).isEmpty)
+    }
+
+    @Test("With no prescan the rule reports, so its own unit tests keep meaning what they say")
+    func nilCatalogReports() {
+        // `nil` is "nobody ran a project-wide scan", not "nobody inspects anything". A visitor
+        // driven straight by a unit test has no catalog, and gating on absence would quietly
+        // turn every other test in this suite into a tautology.
+        #expect(run(Self.subject, inspected: nil).count == 1)
+    }
 }


### PR DESCRIPTION
## What changed

`Observable Environment View Missing Inspection Hook` now requires the view to be **referenced from a file that imports ViewInspector** before it reports.

## Why

The rule's own Discussion already said this: *"a view nobody inspects needs no hook, and adding one to every view would be noise."* It did not implement it.

Across seven repositories it reported **58 findings, and not one of the 58 views was named from a ViewInspector-importing file**. None carried the relay either. The rule was asking fifty-eight views to add production code — a stored property plus an `.onReceive` in the body — for tests that do not exist.

## The hazard is real, and I checked before gating

It had a plausible expiry date. ViewInspector gained `@Observable` environment injection, and **its own test suite inspects such a view with `sut.environment(obj).inspect()` and no relay at all**. That would have made the rule obsolete rather than over-eager. Three attempts against the revision this project pins, each killing the test process:

| Attempt | Result |
| --- | --- |
| `SubjectView().inspect()` | trap |
| `SubjectView().environment(store).inspect()` | trap |
| `VStack { SubjectView() }.environment(store).inspect()` | trap |

ViewInspector's passing case differs in ways that matter: `ObservableOptionalView` declares the environment **optional**, which returns `nil` rather than trapping, and `ObservableOuterView` reads the objects in a *child* rather than in its own body. Neither is the shape this rule reports.

## Why keep the rule rather than delete it

One repository took the advice, and it settles the question. SwiftMarkdownWiki's `ContentView` and `EditorView` carry the relay and are genuinely inspected through it (`sut.inspection.inspect { … }`). **The advice works end to end, and it was taken exactly where someone wanted the test** — which is when the gated rule fires. The "fires early" property survives: writing `import ViewInspector` and naming the view produces the finding *before the test is ever run*, which is earlier than the trap, not later.

## What a reviewer should scrutinise

- **That the gate does not silence a view under inspection.** Verified against the real corpus, not only in tests: removing `ContentView`'s relay in SwiftMarkdownWiki makes the rule fire on it, and restoring it silences it again.
- **Why this is a syntax collector rather than a grep.** Asked with `grep`, this corpus reports four inspected views. Three are a doc comment listing views the file does not touch; the fourth is a comment recording that the author hit the trap and chose to stop descending. `commentsAreNotCollected` pins it.
- **The `nil` case.** No prescan means "nobody scanned", not "nobody inspects" — the visitor reports, so its own unit tests keep meaning what they say.

## The gate shipped dead the first time, and that is why there is an end-to-end test

Seven of the eight hops carrying a prescan to a visitor were done. The eighth was a `det.known… =` assignment whose parameter had a `nil` default — so the package built, **3,537 tests passed, and the corpus count did not move by one**. The visitor was correct in isolation the whole time.

`testInspectionHookGateReachesTheVisitorEndToEnd` drives the real linter over a two-view fixture and fails if the catalog does not arrive. I verified it by removing the eighth hop again and watching it fail. **A unit test on the visitor cannot catch this class of bug, and this project has now shipped it twice** — the sweep notes record the same failure on the underscore-exemption prescan.

## Measurement

26 repositories: **58 → 0**, no other rule's count moved. `swift test`: 3546 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139xQgmEuKzghKVktMhpUy5