### PR TITLE
Trim the inspection-hook doc to what a reader of the rule needs

### DIFF
--- a/Docs/rules/observable-environment-view-missing-inspection-hook.md
+++ b/Docs/rules/observable-environment-view-missing-inspection-hook.md
@@ -7,43 +7,24 @@
 **Severity:** Info
 
 ### Rationale
-`@Environment(SomeType.self)` — the `@Observable` form — has **no default value**. Read outside a hosted view hierarchy it traps in SwiftUICore's `EnvironmentValues.subscript.getter`, killing the test process rather than failing a single test.
+
+**Run this rule and you find out at lint time what would otherwise be a runtime trap during testing.**
+
+`@Environment(SomeType.self)` — the `@Observable` form — has **no default value**. Read outside a hosted view hierarchy it does not fail gracefully: it traps in SwiftUICore's `EnvironmentValues.subscript.getter` and kills the test process, so every suite scheduled alongside it is reported failed. With parallel execution that is a different set each run, and the backtrace names neither ViewInspector nor the test that triggered it.
 
 The keypath form is not affected. `@Environment(\.someKey)` falls back to a default and merely logs *"Accessing Environment<X>'s value outside of being installed on a View"*. Only the `Type.self` form is fatal, and that distinction is the rule's entire discriminator.
 
-A view reading the fatal form can only be inspected by hosting it and inspecting from inside the live render, which requires the view to carry an inspection relay. Without one, the view is untestable by ViewInspector — and the way you find out is a process-killing trap whose backtrace names neither ViewInspector nor the test that triggered it.
-
-**That claim was re-measured against the pinned ViewInspector revision, because it had a plausible expiry date.** ViewInspector gained `@Observable` environment injection (`EnvironmentInjection.environmentKeyPaths(for:)`), and its own suite inspects such a view with `sut.environment(obj).inspect()` and no relay at all — so the rule looked obsolete. It is not. Three attempts against the revision this project pins, each killing the test process:
-
-| Attempt | Result |
-| --- | --- |
-| `SubjectView().inspect()` | trap |
-| `SubjectView().environment(store).inspect()` | trap |
-| `VStack { SubjectView() }.environment(store).inspect()` | trap |
-
-ViewInspector's passing case differs in a way that matters: its `ObservableOptionalView` declares the environment as **optional** (`… private var obj1: TestObservableObject1?`), which returns `nil` rather than trapping, and its `ObservableOuterView` reads the objects in a *child* rather than in its own body. Neither is the shape this rule reports. The hazard is real and current.
+A view reading the fatal form can only be inspected by hosting it and inspecting from inside the live render, which requires the view to carry an inspection relay. That is still true of current ViewInspector, including its `@Observable` environment injection — the visitor's doc comment records the measurement, because the natural assumption is that the library has since fixed it.
 
 ### Discussion
+
 `ObservableEnvironmentViewMissingInspectionHookVisitor` reports a `struct` conforming to `View` that declares at least one `@Environment(SomeType.self)` property and no stored property named `inspection`. The message names each offending environment type.
 
-This is **advisory**, not a defect: a view nobody inspects needs no hook, and adding one to every view would be noise. It is `Info` severity for that reason.
+**It fires only for a view something is actually trying to inspect** — one named from a file that imports ViewInspector. This is advisory rather than a defect: a view nobody inspects needs no hook, and asking every view for one is noise. `Info` severity for that reason.
 
-**The rule now implements that sentence, having stated it for several runs without doing so.** A finding requires the view to be *named from a file that imports ViewInspector*, which is the project-wide answer to "is anybody trying to inspect this?"
+Both authoring orders work, so there is no chicken-and-egg. Write the naive `MyView().inspect()` test and it compiles, traps at runtime, and the rule fires on the view; write the relay-style test first and the file does not compile — and the rule still fires, because the linter parses rather than builds. You do not need the relay in place for the rule to tell you to add it.
 
-The measurement that prompted it: across seven repositories the rule reported **58 findings, and not one of the 58 views was named from a ViewInspector-importing file**. Nor did any of them carry the relay. The rule was asking fifty-eight views to add production code for tests that did not exist.
-
-What the corpus *does* contain is one repository that took the advice, and it is the argument for keeping the rule rather than deleting it. SwiftMarkdownWiki's `ContentView` and `EditorView` carry the relay and are genuinely inspected through it (`sut.inspection.inspect { … }`), and its vendored `Inspection.swift` records why the type lives in the app target. **The advice works end to end; it was taken exactly where someone wanted the test.** Which is also when the gated rule fires.
-
-**The gate keeps most of the "fires early" property, and the claim needs stating carefully.** The finding becomes *available* the moment a file imports ViewInspector and names the view, which is before that test could pass. It does not follow that anyone sees it then: in an ordinary edit-run loop the test is run before the linter is, so the trap comes first and the finding explains it afterwards. The rule is early relative to the *test being written*, not necessarily relative to the trap being hit.
-
-What does hold unconditionally is that the trigger works in **both** authoring orders, which is the part that could have sunk the design:
-
-- Write the naive test — `SettingsView().inspect()` — and it compiles, traps at runtime, and the rule fires on the view.
-- Write the relay-style test first, referencing `sut.inspection` before the relay exists, and **the file does not compile — and the rule still fires**, because the linter parses with SwiftSyntax and never builds. Verified on a throwaway package rather than assumed.
-
-So there is no chicken-and-egg: you do not need the relay in place for the rule to tell you to add the relay.
-
-**Do not answer this question with `grep`.** Asked that way over this corpus it reports four inspected views. Three are a doc comment listing views the file does not touch, and the fourth is a comment recording that the author hit the trap and chose to stop descending. `InspectedTypeNameCollector` walks syntax, so it sees none of them, and there is a test pinning exactly that.
+### The fix
 
 The relay is two lines, and deliberately lives in the app target so the app never links ViewInspector — the test target supplies the protocol conformance:
 
@@ -109,13 +90,7 @@ struct Holder {
 
 ### Known limitations
 
-The catalog is **name-keyed and deliberately over-collects**: every capitalised identifier in a ViewInspector-importing file counts, not only views and not only ones under inspection. A view sharing a name with something merely mentioned in such a file will be reported. That is the safe direction — the cost of collecting too much is a finding that still reports, and the cost of collecting too little is a view that takes a test process down with no warning.
+The catalog behind the gate is name-keyed and deliberately over-collects: every capitalised identifier in a ViewInspector-importing file counts. A view sharing a name with something merely mentioned in such a file will be reported. That is the safe direction — over-collecting costs a finding you dismiss, under-collecting costs a test process.
 
 ### Companion
 [ViewHosting Before Inspection](view-hosting-before-inspection.md) catches the same hazard from the *test* side, and consumes the sibling prescan `ObservableEnvironmentViewCollector` as its own precondition — the two rules ask "can this view trap?" and "is anyone about to make it?" from opposite ends.
-
-### A note on wiring
-
-This gate shipped dead the first time. Seven of the eight hops that carry a prescan from `ProjectLinter` to a visitor were done, the eighth was a `det.known… =` assignment whose parameter had a `nil` default, and so the package built, 3,537 tests passed, and the corpus count did not move by one. The visitor was correct in isolation the whole time.
-
-`ProjectLinterTests.testInspectionHookGateReachesTheVisitorEndToEnd` exists for that reason and no other: it drives the real linter over a two-view fixture and fails if the catalog does not arrive. Verified by removing the eighth hop again and watching it fail. **A unit test on the visitor cannot catch this class of bug, and this project has now shipped it twice.**

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ObservableEnvironmentViewMissingInspectionHookVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ObservableEnvironmentViewMissingInspectionHookVisitor.swift
@@ -24,6 +24,15 @@ import SwiftSyntax
 /// }
 /// ```
 ///
+/// **Before deleting this rule, read this.** ViewInspector gained `@Observable` environment
+/// injection — `EnvironmentInjection.environmentKeyPaths(for:)` — and its own suite inspects such
+/// a view with `sut.environment(obj).inspect()` and no relay, which makes the rule look obsolete.
+/// It is not. Measured against the pinned revision, three shapes each killed the test process:
+/// `SubjectView().inspect()`, the same with `.environment(store)`, and wrapped in a `VStack`.
+/// ViewInspector's passing case declares the environment **optional** — which returns `nil`
+/// rather than trapping — and reads it in a *child* rather than in its own body. Neither is the
+/// shape this rule reports.
+///
 /// This is advisory rather than a defect: a view nobody inspects needs no hook.
 /// It fires early, at the point the view is written, instead of leaving the
 /// discovery to a process-killing trap whose backtrace names neither


### PR DESCRIPTION
## What changed

`Docs/rules/observable-environment-view-missing-inspection-hook.md`, 121 lines → 96, and the two long sections rewritten.

## Why

Rationale and Discussion had turned into a record of how the gate was arrived at: three trapping experiments in a table, a 58-findings census, an analysis of which authoring order fires first, a warning about `grep`, and a note about prescan wiring. All true; none of it what someone reaching for this page wants, which is **what does this catch, when does it fire, and what do I do**.

Rationale now opens with the point — *run this rule and you find out at lint time what would otherwise be a runtime trap during testing* — then the mechanism and the keypath discriminator. Discussion says what is reported, that it fires only for a view something is actually trying to inspect, and that both authoring orders work.

## Nothing is lost — the cut material was already in better places

| What | Where it lives |
| --- | --- |
| Why the catalog walks syntax rather than grepping | `InspectedTypeNameCollector`'s doc comment, next to the code that does it |
| The eight-hop wiring, and why a visitor unit test cannot catch a dead gate | the doc comment on `testInspectionHookGateReachesTheVisitorEndToEnd` — the test that enforces it |
| The 58-findings corpus census | the sweep report, where corpus measurements belong |

## The one piece that needed relocating

The ViewInspector re-measurement had no home. It is the argument against a **future deletion** of this rule: the library's `@Observable` environment injection makes the rule look obsolete, and three measurements show it is not.

That is now on the visitor under a heading that says when it matters — *"Before deleting this rule, read this"* — rather than on a page about how to use the rule. Someone about to delete it is reading the source, not the docs.

`swift test`: passing, including the rule-documentation consistency check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139xQgmEuKzghKVktMhpUy5