### PR TITLE
Non-Injected Nondeterminism: skip #Preview fixtures

### DIFF
--- a/Docs/rules/non-injected-nondeterminism.md
+++ b/Docs/rules/non-injected-nondeterminism.md
@@ -361,6 +361,20 @@ The practical consequence is worth stating, because it can be mistaken for progr
 `generatedAt: .now` instead of `Date.now` moves a clock read somewhere the tool cannot see, and the
 rule's count falls. **A read the tool reports where it belongs is better than one it cannot find.**
 
+### Preview fixtures are not flagged
+
+A `#Preview` never ships, and the values in one are fixtures rather than program state. `Date()`
+beside a hardcoded violation count and a literal version string is part of the fixture, and there is
+no caller who could supply it — the preview *is* the caller. Asking for an injected clock there
+means routing one in from somewhere, which is what a preview exists to avoid.
+
+Both spellings are skipped: `#Preview { }` parses as a declaration among other declarations and as
+an *expression* when it is the only item in a file, which is exactly the file a preview tends to
+live in. A preview nested inside `#if DEBUG` is covered by the same counter.
+
+**The gate is the preview, not the file.** A view and its preview live together, and the view's own
+clock reads are the case this rule exists for.
+
 ### What this rule deliberately does not flag
 
 `ContinuousClock()`, `SuspendingClock()`, `Task.sleep(for:)`, `DispatchTime.now()`, the monotonic C functions (`mach_absolute_time`, `clock_gettime`), and `Date(timeIntervalSinceNow:)` all read a clock, and none of them are reported here.

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
@@ -101,6 +101,11 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
 
     private var fileIsTestOrFixture = false
 
+    /// Depth inside a `#Preview` macro. A counter rather than a flag because previews nest —
+    /// a `#Preview` inside `#if DEBUG` is the ordinary spelling — and a flag would be cleared
+    /// by whichever closed first.
+    private var insidePreview = 0
+
     required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
         super.init(pattern: pattern, viewMode: viewMode)
     }
@@ -151,7 +156,9 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
     /// first would silence them.
     private func report(_ source: NondeterminismSources.Source?, at node: Syntax) {
         guard let source, Self.reportedKinds.contains(source.kind) else { return }
-        guard !fileIsTestOrFixture, !isParameterDefaultValue(node) else { return }
+        guard !fileIsTestOrFixture, insidePreview == 0, !isParameterDefaultValue(node) else {
+            return
+        }
 
         if let fallback = nilCoalescingFallback(containing: node), !isLazyCreation(fallback) {
             flagFabrication(source.marker, at: node)
@@ -579,5 +586,36 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
         if let decl = syntax.as(ActorDeclSyntax.self) { return decl.inheritanceClause }
         if let decl = syntax.as(EnumDeclSyntax.self) { return decl.inheritanceClause }
         return nil
+    }
+
+    // MARK: - Preview scaffolding
+
+    /// A `#Preview` never ships, and the values in one are fixtures rather than program state.
+    /// `Date()` beside a hardcoded violation count and a literal version string is part of the
+    /// fixture, and there is no caller who could supply it — the preview *is* the caller.
+    ///
+    /// `Direct Instantiation` has skipped previews since it was written; this rule never did,
+    /// which is the same vocabulary gap that left `MockGenerator` exempt where it was declared
+    /// and reported where it was built.
+    ///
+    /// Both spellings are tracked. `#Preview { }` parses as a *declaration* among other
+    /// declarations and as an *expression* when it is the only item in the file, and handling
+    /// only the declaration form leaves a file containing nothing but a preview still reporting.
+    override func visit(_ node: MacroExpansionDeclSyntax) -> SyntaxVisitorContinueKind {
+        if node.macroName.text == "Preview" { insidePreview += 1 }
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: MacroExpansionDeclSyntax) {
+        if node.macroName.text == "Preview" { insidePreview -= 1 }
+    }
+
+    override func visit(_ node: MacroExpansionExprSyntax) -> SyntaxVisitorContinueKind {
+        if node.macroName.text == "Preview" { insidePreview += 1 }
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: MacroExpansionExprSyntax) {
+        if node.macroName.text == "Preview" { insidePreview -= 1 }
     }
 }

--- a/Tests/CoreTests/Testability/NonInjectedNondeterminismPreviewTests.swift
+++ b/Tests/CoreTests/Testability/NonInjectedNondeterminismPreviewTests.swift
@@ -1,0 +1,87 @@
+@testable import Core
+import Foundation
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+/// A `#Preview` never ships, and the values in one are fixtures rather than program state.
+///
+/// `Date()` beside a hardcoded violation count and a literal version string is part of the
+/// fixture, and there is no caller who could supply it — the preview *is* the caller. Asking for
+/// an injected clock there means routing one in from somewhere, which is what a preview exists to
+/// avoid.
+///
+/// `Direct Instantiation` has skipped previews since it was written; this rule never did. That is
+/// the same vocabulary gap that once left `MockGenerator` exempt where it was declared and
+/// reported where it was built.
+@Suite("Preview fixtures are not injectable")
+struct NonInjectedNondeterminismPreviewTests {
+
+    private func analyze(_ source: String) -> [LintIssue] {
+        let visitor = NonInjectedNondeterminismVisitor(patternCategory: .testability)
+        let syntax = Parser.parse(source: source)
+        visitor.setSourceLocationConverter(
+            SourceLocationConverter(fileName: "RepoCard.swift", tree: syntax)
+        )
+        visitor.setFilePath("RepoCard.swift")
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == .nonInjectedNondeterminism }
+    }
+
+    @Test("a clock read inside #Preview is not reported")
+    func previewFixtureIsNotReported() {
+        // The corpus shape: a preview building a card out of literals, with `Date()` sitting in
+        // the middle of them.
+        #expect(analyze("""
+        #Preview {
+            FleetRepoCard(
+                name: "Payments",
+                swiftLintVersion: "0.63.2",
+                violationCount: 143,
+                lastAnalyzed: Date()
+            )
+        }
+        """).isEmpty)
+    }
+
+    @Test("the expression spelling is covered too")
+    func previewAsTheOnlyItemInAFile() {
+        // `#Preview { }` parses as a declaration among other declarations and as an *expression*
+        // when it is the only item in the file — which is exactly the file a preview tends to live
+        // in. Handling only the declaration form leaves that file reporting.
+        #expect(analyze("#Preview { RepoCard(lastAnalyzed: Date()) }").isEmpty)
+    }
+
+    @Test("a preview nested in #if DEBUG is covered")
+    func previewInsideDebugBlock() {
+        #expect(analyze("""
+        #if DEBUG
+        #Preview {
+            RepoCard(lastAnalyzed: Date())
+        }
+        #endif
+        """).isEmpty)
+    }
+
+    @Test("the same read outside the preview is still reported")
+    func productionReadInTheSameFileIsReported() throws {
+        // The gate is the preview, not the file. A view and its preview live together, and the
+        // view's own clock reads are the case the rule exists for.
+        let issues = analyze("""
+        struct RepoCard: View {
+            var body: some View {
+                let now = Date()
+                Text(now.formatted())
+            }
+        }
+
+        #Preview {
+            RepoCard(lastAnalyzed: Date())
+        }
+        """)
+        #expect(issues.count == 1)
+        let issue = try #require(issues.first)
+        #expect(issue.locations.first?.lineNumber == 3)
+    }
+}


### PR DESCRIPTION
## What changed

`Non-Injected Nondeterminism` no longer reports a clock or identity read inside a `#Preview`.

## Why

A `#Preview` never ships, and the values in one are fixtures rather than program state:

```swift
#Preview {
    FleetRepoCard(name: "Payments", swiftLintVersion: "0.63.2",
                  violationCount: 143, lastAnalyzed: Date())
}
```

`Date()` sits between a literal version string and a hardcoded count. It is part of the fixture, and there is no caller who could supply it — **the preview is the caller.** Asking for an injected clock means routing one in from somewhere, which is what a preview exists to avoid.

`Direct Instantiation` has skipped previews since it was written; this rule never did. That is the same vocabulary gap that once left `MockGenerator` exempt where it was *declared* and reported where it was *built*.

## What a reviewer should scrutinise

- **That the gate is the preview, not the file.** A view and its preview live in one source; `testProductionReadInTheSameFileIsReported` puts a reported read and an exempt one together and checks the reported one is on the expected line.
- **Both spellings.** `#Preview { }` parses as a *declaration* among other declarations and as an *expression* when it is the only item in a file — which is exactly the file a preview tends to live in. Handling only the declaration form would leave that file reporting.
- **Why a counter rather than a flag.** A `#Preview` inside `#if DEBUG` is the ordinary spelling, and a flag would be cleared by whichever closed first.

## Measurement

26 repositories: **76 → 68**, no other rule's count moved. All eight were previews. `swift test`: passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139xQgmEuKzghKVktMhpUy5