### PR TITLE
Prose about a directive is not a directive

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/SuppressionVisitorBase.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/SuppressionVisitorBase.swift
@@ -64,9 +64,16 @@ class SuppressionVisitorBase: BasePatternVisitor {
 
         // Check most-specific directives first — "disable" alone would also match
         // the qualified forms.
+        //
+        // The directive must START the comment, which is the same line `InlineSuppressionParser`
+        // draws: it requires `hasPrefix("// swiftprojectlint:")` before it will suppress anything.
+        // This used to be a `range(of:)` search, so a comment that merely *mentioned* a directive
+        // in prose was inventoried as one — and prose about suppression directives is written by
+        // exactly the people who go looking for this rule's output. Every following word became a
+        // "suppressed rule": one sentence produced four entries, none of which suppressed anything.
         for directive in directives {
-            guard let range = cleaned.range(of: directive) else { continue }
-            let remainder = cleaned[range.upperBound...]
+            guard cleaned.hasPrefix(directive) else { continue }
+            let remainder = cleaned.dropFirst(directive.count)
                 .trimmingCharacters(in: .whitespaces)
             guard remainder.isEmpty == false else { continue }
 

--- a/Tests/CoreTests/CodeQuality/SwiftProjectLintSuppressionVisitorTests.swift
+++ b/Tests/CoreTests/CodeQuality/SwiftProjectLintSuppressionVisitorTests.swift
@@ -87,7 +87,13 @@ struct SwiftProjectLintSuppressionVisitorTests {
         "// This is a normal comment\nlet value = 42",
         "// swiftlint:disable force_cast\nlet val = 1",
         "let disable = \"swiftprojectlint:disable\"\nlet val = 1",
-        "// swiftprojectlint:enable force-try\nlet val = 1"
+        "// swiftprojectlint:enable force-try\nlet val = 1",
+        // Prose that mentions a directive is not a directive. `InlineSuppressionParser`
+        // requires the comment to start with one before it will suppress anything, so
+        // inventorying these was reporting suppressions that suppress nothing — and every
+        // word after the token counted as a separate "suppressed rule".
+        "// A note about swiftprojectlint:disable:next force-try written in prose.\nlet val = 1",
+        "// See swiftprojectlint:disable force-try for the reasoning.\nlet val = 1"
     ])
     func noIssueForNonSuppressionComment(source: String) {
         let visitor = makeVisitor()


### PR DESCRIPTION
## The bug

`SuppressionVisitorBase` found directives with `range(of:)`, so the token matched **anywhere** in a comment. A sentence that merely *mentions* a directive was inventoried as one — and every word after the token counted as a separate suppressed rule:

```swift
// A note about swiftprojectlint:disable:next force-try written in prose.
```

produced **four** entries: `force-try`, `written`, `in`, `prose.`

None of them suppressed anything. `InlineSuppressionParser` requires `hasPrefix("// swiftprojectlint:")` before it will honour a directive at all, so the rule whose job is to inventory suppressions disagreed with the code that applies them — in the direction that manufactures phantom entries.

It also disagreed with the audit `non-injected-nondeterminism.md` recommends (`grep -rn "swiftprojectlint:disable"`). And the people most likely to write prose about suppression directives are exactly the people reading this rule's output.

## The fix

`hasPrefix` instead of `range(of:)` — the same line the parser draws.

## What a reviewer should scrutinise

- **Block comments still work.** The delimiters are stripped and the text trimmed before the check, so `/* swiftprojectlint:disable magic-number */` still starts with the directive. The existing parameterised test covers it.
- **`SwiftLintSuppressionVisitor` shares this base** and gets the same tightening, which is what you want — a comment discussing `swiftlint:disable` is not one either.
- **Nothing real was lost.** SwiftProjectLint's own inventory is unchanged at **9** entries; every genuine directive in this repo already started its comment. That is the measurement that matters, because the risk of `hasPrefix` is a directive that stops being counted.
- Two negative cases added. Both pass, and both fail against the old `range(of:)`.

3550 tests in 427 suites pass.

## How it surfaced

I was writing a comment in another repo explaining *why* two suppressions were there, and watched the explanation become four suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139xQgmEuKzghKVktMhpUy5