### PR TITLE
Bump SwiftEffectInference past the `contentsOf` over-refutation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -84,7 +84,7 @@ let package = Package(
         // swift-syntax exact 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "fff33cff0e5dca156fcaf9ee95ecc2dbd38877a5"
+            revision: "23d1dabe7501d267af5aeea26ac4a6a318083fc2"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintIdempotencyRules/Package.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // root and SwiftProjectLintVisitors pins.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "fff33cff0e5dca156fcaf9ee95ecc2dbd38877a5"
+            revision: "23d1dabe7501d267af5aeea26ac4a6a318083fc2"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintVisitors/Package.swift
+++ b/Packages/SwiftProjectLintVisitors/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "fff33cff0e5dca156fcaf9ee95ecc2dbd38877a5"
+            revision: "23d1dabe7501d267af5aeea26ac4a6a318083fc2"
         )
     ],
     targets: [


### PR DESCRIPTION
SEI `fff33cf` added `contentsOf` to `sideEffectMarkers`, which is matched **by bare token**. `contentsOf` is also the argument label of `append(contentsOf:)` — so every function reaching for that operation was refuted.

`PurityInferrer` is the oracle `ExtractableTotalKernelVisitor` and `PureClosureCandidateVisitor` consult before nominating a pure candidate, so the failure was silent in the direction that hides: **fewer nominations, no error.**

Fixed upstream in [SwiftEffectInference#16](https://github.com/Joseph-Cursio/SwiftEffectInference/pull/16) (`23d1dab`), which matches the same reads on the callee instead — `String(contentsOf: url)` still refutes, `array.append(contentsOf: other)` no longer does.

## Measured, same corpus either side

`--format pbt-seeds` over this repository:

| | candidates |
|---|---|
| before (`fff33cf`) | 760 |
| after (`23d1dab`) | **764** |
| gained | 4 |
| lost | **0** |

Recovered: `LintConfigurationWriter.render`, and three in `ComputedPropertyViewVisitor`.

**The zero is the half worth keeping.** It shows the fix narrowed the refutation without loosening it anywhere else — every candidate the regressed build found is still found.

**Four is smaller than it sounds elsewhere, deliberately stated.** Upstream, 43 functions changed purity *verdict* on a different corpus. These count different things: a verdict can flip to `.pure` and still fail a later gate in the candidate rule, so most flips never become seeds. Four is the user-visible number here.

Functions only — the same oracle runs over closures via `PureClosureCandidateVisitor`, and the seed manifest doesn't emit those, so the closure-side recovery is unmeasured in either direction.

## How this was caught, and why not here

Nothing in this repository noticed. The regression arrived in `e90d3962` (2026-09-05, *"Bump SwiftEffectInference to fff33cf, matching SwiftProjectLint"*) and sat for two days through a green suite.

It was caught by SwiftInferProperties' purity census, which re-derives SEI's refuters and asserts the replica reproduces `SoundPurity` on every function it scans. A test that pins behaviour to a rebuilt model catches upstream drift; tests that pin behaviour to expected outputs don't.

`SEIPinAgreementTests` passed throughout, correctly — it compares the three pins to **each other**, and all three were consistently on the regressed revision. Its own doc names this limit: *"This test cannot see that cross-repo gap; nothing in a single repository can."*

## What a reviewer should scrutinise

1. **All three manifests move together** — root, `SwiftProjectLintVisitors`, `SwiftProjectLintIdempotencyRules` — as `SEIPinAgreementTests` requires.
2. **Whether four candidates justifies the bump.** I think yes, because a wrong purity verdict is wrong regardless of how many survive downstream filtering, and `PurityInferrer` has consumers beyond this rule. But it is not the broad degradation the upstream number might suggest.
3. **The before/after runs were on a contended machine.** Seed counts are deterministic functions of the source and the analyzer, so timing doesn't affect them — but the runs were 10+ minutes each and I did not repeat them.

3,550 tests in 427 suites, passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)