### PR TITLE
Two value-terminal gaps in Law of Demeter, found by working its 70 findings

### DIFF
--- a/Docs/rules/law-of-demeter.md
+++ b/Docs/rules/law-of-demeter.md
@@ -69,11 +69,13 @@ Several common patterns look like deep chains but are not object-graph coupling.
 | Geometry/layout chains | Chain contains `frame`, `size`, `bounds`, `origin`, `width`, `height`, etc. |
 | Framework API chains | Chain passes through known framework structural members (SwiftSyntax: `signature`, `parameterClause`, `parameters`, `leadingTrivia`, etc.) |
 
-**Recognized value-transform members:** `rawValue`, `hashValue`, `capitalized`, `uppercased`, `lowercased`, `description`, `debugDescription`, `trimmedDescription`, `color`, `lowerBound`, `upperBound`, `text`, `baseName`, `isEmpty`
+**Recognized value-transform members:** `rawValue`, `hashValue`, `capitalized`, `uppercased`, `lowercased`, `description`, `debugDescription`, `trimmedDescription`, `color`, `lowerBound`, `upperBound`, `text`, `baseName`, `isEmpty`, `count`
 
 > **Note on `text` and `baseName`:** These are included because SwiftSyntax nodes expose token text through a fixed `node.declName.baseName.text` accessor chain that is idiomatic framework API, not object-graph navigation. The chain ends at a `String` value and does not expose further structural knowledge.
 
-> **Note on `isEmpty`:** Included as a terminal-only exemption at depth 3. Testing whether a collection is empty is a scalar Boolean result; it does not chain further into internal structure. At depth 4+, `.isEmpty` is not exempt because the preceding four-component chain already constitutes a violation regardless of the terminal.
+> **Note on `isEmpty` and `count`:** Both are terminal exemptions at depth 3. Asking a collection how many elements it holds, or whether it holds any, is a scalar result; it does not chain further into internal structure. At depth 4+ neither is exempt, because the preceding four-component chain is already a violation regardless of the terminal.
+>
+> **`count` was added five months after `isEmpty`, and the gap was the finding.** The two are the same shape and the same argument — `report.totals.regions.isEmpty` was waved through while `report.totals.regions.count` was reported — so the rule was answering one question two ways depending on which scalar the caller happened to want. It cost five findings across the corpus, and it also cost the rule's own documentation: `manager.service.data.count` stood as the flagship *violating* example here and in two tests, and is a chain the rule's own exemption principle says should never have fired. The violating examples below now end in a member of the object graph, which is what the rule is actually about.
 
 ### Fixing a violation
 
@@ -155,14 +157,17 @@ let name = node.extendedType.description.trimmingCharacters(in: .whitespaces)
 
 // Value-transform intermediate — .color maps enum to SwiftUI Color at depth 2
 Color.clear.background(item.severity.color.opacity(0.06))
+
+// Scalar terminal at depth 3 — .count, on the same footing as .isEmpty
+let regions = report.totals.regions.count
 ```
 
 ### Violating examples
 
 ```swift
-// Three-level chain — LoD violation
+// Three-level chain — LoD violation. The terminal is another member of the object graph.
 class Owner {
-    func run() { let _ = manager.service.data.count }
+    func run() { let _ = manager.service.data.owner }
 }
 
 // Three-level chain — Display knows User's internal structure

--- a/Docs/rules/law-of-demeter.md
+++ b/Docs/rules/law-of-demeter.md
@@ -69,13 +69,15 @@ Several common patterns look like deep chains but are not object-graph coupling.
 | Geometry/layout chains | Chain contains `frame`, `size`, `bounds`, `origin`, `width`, `height`, etc. |
 | Framework API chains | Chain passes through known framework structural members (SwiftSyntax: `signature`, `parameterClause`, `parameters`, `leadingTrivia`, etc.) |
 
-**Recognized value-transform members:** `rawValue`, `hashValue`, `capitalized`, `uppercased`, `lowercased`, `description`, `debugDescription`, `trimmedDescription`, `color`, `lowerBound`, `upperBound`, `text`, `baseName`, `isEmpty`, `count`
+**Recognized value-transform members:** `rawValue`, `hashValue`, `capitalized`, `uppercased`, `lowercased`, `description`, `debugDescription`, `trimmedDescription`, `color`, `lowerBound`, `upperBound`, `text`, `baseName`, `isEmpty`, `count`, `absoluteURL`, `standardizedFileURL`, `lastPathComponent`
 
 > **Note on `text` and `baseName`:** These are included because SwiftSyntax nodes expose token text through a fixed `node.declName.baseName.text` accessor chain that is idiomatic framework API, not object-graph navigation. The chain ends at a `String` value and does not expose further structural knowledge.
 
 > **Note on `isEmpty` and `count`:** Both are terminal exemptions at depth 3. Asking a collection how many elements it holds, or whether it holds any, is a scalar result; it does not chain further into internal structure. At depth 4+ neither is exempt, because the preceding four-component chain is already a violation regardless of the terminal.
 >
 > **`count` was added five months after `isEmpty`, and the gap was the finding.** The two are the same shape and the same argument — `report.totals.regions.isEmpty` was waved through while `report.totals.regions.count` was reported — so the rule was answering one question two ways depending on which scalar the caller happened to want. It cost five findings across the corpus, and it also cost the rule's own documentation: `manager.service.data.count` stood as the flagship *violating* example here and in two tests, and is a chain the rule's own exemption principle says should never have fired. The violating examples below now end in a member of the object graph, which is what the rule is actually about.
+
+> **Note on the URL members:** `absoluteURL` and `standardizedFileURL` are URL-to-URL normalisations and `lastPathComponent` is URL-to-String. In `sources.absoluteURL.standardizedFileURL.path` the object-graph coupling is `sources.absoluteURL` — one hop — and every component after it operates on a normalised value. Foundation's URL API is written as a chain by design; treating each normalisation as a hop into someone's internals mistakes a value pipeline for an object graph.
 
 ### Fixing a violation
 
@@ -160,6 +162,10 @@ Color.clear.background(item.severity.color.opacity(0.06))
 
 // Scalar terminal at depth 3 — .count, on the same footing as .isEmpty
 let regions = report.totals.regions.count
+
+// URL normalisation — absoluteURL and standardizedFileURL are URL -> URL value transforms
+let resolved = sources.absoluteURL.standardizedFileURL.path
+let name = input.task.workspaceRoot.lastPathComponent
 ```
 
 ### Violating examples

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/LawOfDemeterVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/LawOfDemeterVisitor.swift
@@ -53,6 +53,7 @@ class LawOfDemeterVisitor: BasePatternVisitor {
     /// - `memberAccess.declName.baseName.text` — SwiftSyntax token text accessor
     /// - `node.body.statements.isEmpty` — collection membership test
     /// - `report.totals.regions.count` — a scalar count, on the same footing as `isEmpty`
+    /// - `directory.absoluteURL.standardizedFileURL` — Foundation URL normalisation, URL to URL
     private static let valueTransformMembers: Set<String> = [
         "rawValue", "hashValue", "capitalized", "uppercased", "lowercased",
         "description", "debugDescription", "trimmedDescription",
@@ -61,6 +62,8 @@ class LawOfDemeterVisitor: BasePatternVisitor {
         "text", "baseName", "tokenKind",
         // Scalar terminals — a number or a flag, not another object to traverse
         "isEmpty", "isNotEmpty", "count",
+        // URL value normalisations — URL -> URL, and URL -> String
+        "absoluteURL", "standardizedFileURL", "lastPathComponent",
         // Trivia terminals
         "containsComments", "isNotSingleSpaceWithoutComments",
         "withTrailingEmptyLineRemoved", "splitBlocks",

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/LawOfDemeterVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/LawOfDemeterVisitor.swift
@@ -52,14 +52,15 @@ class LawOfDemeterVisitor: BasePatternVisitor {
     /// - `range.lowerBound` / `range.upperBound` — standard Range value accessors
     /// - `memberAccess.declName.baseName.text` — SwiftSyntax token text accessor
     /// - `node.body.statements.isEmpty` — collection membership test
+    /// - `report.totals.regions.count` — a scalar count, on the same footing as `isEmpty`
     private static let valueTransformMembers: Set<String> = [
         "rawValue", "hashValue", "capitalized", "uppercased", "lowercased",
         "description", "debugDescription", "trimmedDescription",
         "color", "lowerBound", "upperBound",
         // SwiftSyntax token/trivia accessors
         "text", "baseName", "tokenKind",
-        // Boolean terminals — scalar results, not graph traversal
-        "isEmpty", "isNotEmpty",
+        // Scalar terminals — a number or a flag, not another object to traverse
+        "isEmpty", "isNotEmpty", "count",
         // Trivia terminals
         "containsComments", "isNotSingleSpaceWithoutComments",
         "withTrailingEmptyLineRemoved", "splitBlocks",

--- a/Tests/CoreTests/Architecture/ArchitectureLawOfDemeterTests.swift
+++ b/Tests/CoreTests/Architecture/ArchitectureLawOfDemeterTests.swift
@@ -460,8 +460,8 @@ struct LawOfDemeterCollapsingTests {
     }
 }
 
-/// The scalar terminal, added when the corpus showed the rule flagging `.count` while exempting
-/// `.isEmpty` — the same shape, the same argument, opposite answers.
+/// The scalar and URL value terminals, added when the corpus showed the rule flagging `.count`
+/// while exempting `.isEmpty` — the same shape, the same argument, opposite answers.
 @Suite("Law of Demeter exempts scalar and URL value terminals")
 struct LawOfDemeterValueTerminalTests {
     private func analyze(_ source: String) -> [LintIssue] {
@@ -495,5 +495,27 @@ struct LawOfDemeterValueTerminalTests {
             func summarise(_ report: Report) -> Int { report.totals.regions.spans.count }
         }
         """).count == 1)
+    }
+
+    @Test("URL normalisation is a value transform, not a hop")
+    func urlNormalisationIsExempt() {
+        // `absoluteURL` and `standardizedFileURL` are URL-to-URL: the coupling is
+        // `sources.absoluteURL`, and everything after it operates on a normalised value.
+        #expect(analyze("""
+        class Resolver {
+            func path(for sources: URL) -> String {
+                sources.absoluteURL.standardizedFileURL.path
+            }
+        }
+        """).isEmpty)
+    }
+
+    @Test("lastPathComponent is a URL-to-String terminal")
+    func lastPathComponentIsExempt() {
+        #expect(analyze("""
+        class Namer {
+            func name(for input: Input) -> String { input.task.workspaceRoot.lastPathComponent }
+        }
+        """).isEmpty)
     }
 }

--- a/Tests/CoreTests/Architecture/ArchitectureLawOfDemeterTests.swift
+++ b/Tests/CoreTests/Architecture/ArchitectureLawOfDemeterTests.swift
@@ -26,15 +26,18 @@ struct ArchitectureLawOfDemeterTests {
     // MARK: - Detects violations (4+ levels)
 
     @Test func testDetectsFourLevelChain() throws {
+        // The terminal is another member of the object graph, so the chain really is four deep.
+        // `manager.service.data.count` used to stand here and no longer fires — see
+        // LawOfDemeterValueTerminalTests.
         let source = """
         class Owner {
-            func run() { let _ = manager.service.data.count }
+            func run() { let _ = manager.service.data.owner }
         }
         """
         let issues = analyzeSource(source)
         let lodIssues = issues.filter { $0.ruleName == .lawOfDemeter }
         let issue = try #require(lodIssues.first)
-        #expect(issue.message.contains("manager.service.data.count"))
+        #expect(issue.message.contains("manager.service.data.owner"))
     }
 
     @Test func testDetectsDeepChainInFunction() throws {
@@ -294,7 +297,7 @@ struct ArchitectureLawOfDemeterTests {
     @Test func testStillDetectsRealViolationInNonTestFile() {
         let source = """
         class Owner {
-            func run() { let _ = manager.service.data.count }
+            func run() { let _ = manager.service.data.owner }
         }
         """
         let issues = analyzeSource(source, filePath: "Owner.swift")
@@ -454,5 +457,43 @@ struct LawOfDemeterCollapsingTests {
         }
         """)
         #expect(issues.first?.suggestion?.contains("'location'") == true)
+    }
+}
+
+/// The scalar terminal, added when the corpus showed the rule flagging `.count` while exempting
+/// `.isEmpty` — the same shape, the same argument, opposite answers.
+@Suite("Law of Demeter exempts scalar and URL value terminals")
+struct LawOfDemeterValueTerminalTests {
+    private func analyze(_ source: String) -> [LintIssue] {
+        let visitor = LawOfDemeterVisitor(patternCategory: .architecture)
+        let syntax = Parser.parse(source: source)
+        visitor.setSourceLocationConverter(
+            SourceLocationConverter(fileName: "TestFile.swift", tree: syntax)
+        )
+        visitor.setFilePath("TestFile.swift")
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == RuleIdentifier.lawOfDemeter }
+    }
+
+    @Test("a count terminal at the threshold is not a reach-through")
+    func countTerminalIsExempt() {
+        // The object-graph reach is `report.totals.regions` — two dots, under the threshold — and
+        // the last hop asks it for a number. `.isEmpty` was already exempt for this reason.
+        #expect(analyze("""
+        class Reporter {
+            func summarise(_ report: Report) -> Int { report.totals.regions.count }
+        }
+        """).isEmpty)
+    }
+
+    @Test("one hop deeper, the terminal stops mattering")
+    func countAtDepthFourStillFires() {
+        // The terminal exemption applies only at exactly the threshold: the preceding chain is
+        // already a violation whatever is asked of it.
+        #expect(analyze("""
+        class Reporter {
+            func summarise(_ report: Report) -> Int { report.totals.regions.spans.count }
+        }
+        """).count == 1)
     }
 }

--- a/Tests/CoreTests/ImplementationDetailNamingTests.swift
+++ b/Tests/CoreTests/ImplementationDetailNamingTests.swift
@@ -35,7 +35,7 @@ struct ImplementationDetailNamingTests {
     func underscoreRootedChainIsExempt() {
         let issues = demeterIssues("""
         struct Buffer {
-            func count() -> Int { _storage.buffer.header.count }
+            func owner() -> Owner { _storage.buffer.header.owner }
         }
         """)
 
@@ -44,11 +44,14 @@ struct ImplementationDetailNamingTests {
 
     /// Control: the same chain shape without the underscore is still a violation, so the
     /// exemption is the underscore's doing rather than the chain being too short.
+    ///
+    /// The pair used to end in `.count`, which now falls under the scalar-terminal exemption —
+    /// so the control was about to start proving the underscore mattered when the terminal did.
     @Test("control — the same chain shape without an underscore still fires")
     func plainRootedChainStillFires() {
         let issues = demeterIssues("""
         struct Buffer {
-            func count() -> Int { storage.buffer.header.count }
+            func owner() -> Owner { storage.buffer.header.owner }
         }
         """)
 


### PR DESCRIPTION
Working the 70 Law of Demeter findings from run 26 of the corpus sweep, starting with the question the sweep's own method asks first: are they true?

Fifteen of them were not, for two reasons.

## `.count` was flagged while `.isEmpty` was exempt

The rule exempts a *scalar terminal* at exactly the threshold — `node.body.statements.isEmpty` — on the grounds that the object-graph reach is only two dots and the last hop asks for a value, not another object. `.count` is the same shape and the same argument, and it was reported.

The gap cost more than the nine findings it removes. `manager.service.data.count` stood as the rule's flagship **violating** example, in `Docs/rules/law-of-demeter.md` and in two tests — a chain the rule's own exemption principle says should never have fired. Those examples now end in a member of the object graph.

A third test moved for the same reason: the underscore-root exemption's control case ("the same chain *without* the underscore still fires") ended in `.count`, so it was one commit away from proving the underscore mattered when the terminal did.

## Foundation's URL API is a value pipeline

`sources.absoluteURL.standardizedFileURL.path` was reported as reaching three levels into `standardizedFileURL`'s internals. There are none — `absoluteURL` and `standardizedFileURL` are URL-to-URL normalisations, `lastPathComponent` is URL-to-String, and the coupling in that chain is `sources.absoluteURL`, one hop. Same argument `description` and `trimmedDescription` were already exempt under. Six findings, all of them path handling written the way Foundation asks for it.

## Measured

26-repo corpus, `--categories architecture --include-nested-packages`:

| | findings | repos reporting |
|---|---|---|
| before | 70 | 5 |
| after `.count` | 61 | 4 |
| after URL members | **55** | **3** |

SwiftMarkdownWiki and SwiftLintRuleStudio now report nothing on this rule. The 55 that remain are genuine reach-throughs in SwiftAssist (23), SwiftInferProperties (28) and SwiftUMLStudio (4), and are being refactored in those repositories rather than exempted here.

Full suite: 3554 tests, green.

## What a reviewer should scrutinise

- **Is `.count` really the same as `.isEmpty`?** The claim is that both are scalars and the coupling is the preceding two dots. If you think `a.b.c.count` is a violation, then `a.b.c.isEmpty` has been under-reported for five months and the fix runs the other way.
- **The depth-4 boundary.** `report.totals.regions.spans.count` still fires; the terminal exemption applies only at exactly the threshold. There is a test for it, and writing that test caught something else — the first version used `.lines` as the penultimate hop, which is in `frameworkAPIMembers` and exempted the chain for an unrelated reason.
- **`lastPathComponent` as a terminal but not `path`.** `path` is a common enough member name on non-URL types that exempting it was not worth the reach; `standardizedFileURL` as an *intermediate* already covers every `.path` chain in the corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSPQgvroTfRr7mKnQEQxe7