### PR TITLE
A range's bounds are exempt under either spelling

### DIFF
--- a/Docs/rules/law-of-demeter.md
+++ b/Docs/rules/law-of-demeter.md
@@ -69,13 +69,15 @@ Several common patterns look like deep chains but are not object-graph coupling.
 | Geometry/layout chains | Chain contains `frame`, `size`, `bounds`, `origin`, `width`, `height`, etc. |
 | Framework API chains | Chain passes through known framework structural members (SwiftSyntax: `signature`, `parameterClause`, `parameters`, `leadingTrivia`, etc.) |
 
-**Recognized value-transform members:** `rawValue`, `hashValue`, `capitalized`, `uppercased`, `lowercased`, `description`, `debugDescription`, `trimmedDescription`, `color`, `lowerBound`, `upperBound`, `text`, `baseName`, `isEmpty`, `count`, `absoluteURL`, `standardizedFileURL`, `lastPathComponent`
+**Recognized value-transform members:** `rawValue`, `hashValue`, `capitalized`, `uppercased`, `lowercased`, `description`, `debugDescription`, `trimmedDescription`, `color`, `lowerBound`, `upperBound`, `start`, `end`, `text`, `baseName`, `isEmpty`, `count`, `absoluteURL`, `standardizedFileURL`, `lastPathComponent`
 
 > **Note on `text` and `baseName`:** These are included because SwiftSyntax nodes expose token text through a fixed `node.declName.baseName.text` accessor chain that is idiomatic framework API, not object-graph navigation. The chain ends at a `String` value and does not expose further structural knowledge.
 
 > **Note on `isEmpty` and `count`:** Both are terminal exemptions at depth 3. Asking a collection how many elements it holds, or whether it holds any, is a scalar result; it does not chain further into internal structure. At depth 4+ neither is exempt, because the preceding four-component chain is already a violation regardless of the terminal.
 >
 > **`count` was added five months after `isEmpty`, and the gap was the finding.** The two are the same shape and the same argument — `report.totals.regions.isEmpty` was waved through while `report.totals.regions.count` was reported — so the rule was answering one question two ways depending on which scalar the caller happened to want. It cost five findings across the corpus, and it also cost the rule's own documentation: `manager.service.data.count` stood as the flagship *violating* example here and in two tests, and is a chain the rule's own exemption principle says should never have fired. The violating examples below now end in a member of the object graph, which is what the rule is actually about.
+
+> **Note on `start` and `end`:** These are `lowerBound` and `upperBound` under the names LSP and SourceKit give them. A `Range`'s bounds were already exempt as "standard Range value accessors"; a protocol that spells the same two fields `start` and `end` was not, so `diag.range.start.file` was reported and `chunk.lineRange.lowerBound` was not. Measured over the 26-repo corpus the exemption removes **five findings and moves nothing else** — all five are constructors flattening a nested source range into flat wire fields, which is what the rule's own note below calls "what a DTO is *for*".
 
 > **Note on the URL members:** `absoluteURL` and `standardizedFileURL` are URL-to-URL normalisations and `lastPathComponent` is URL-to-String. In `sources.absoluteURL.standardizedFileURL.path` the object-graph coupling is `sources.absoluteURL` — one hop — and every component after it operates on a normalised value. Foundation's URL API is written as a chain by design; treating each normalisation as a hop into someone's internals mistakes a value pipeline for an object graph.
 
@@ -148,6 +150,10 @@ items.sorted { $0.category.name.count < $1.category.name.count }
 
 // Method-call chain — outermost member is a function call target
 let filtered = structNode.memberBlock.members.contains { $0.name == target }
+
+// Range bounds, under either spelling
+let startLine = diagnostic.range.start.line
+let endLine = diagnostic.range.end.line
 
 // Value-transform terminal at depth 3 — .capitalized, .lowerBound, .isEmpty
 let label = violation.severity.rawValue.capitalized

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/LawOfDemeterVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/LawOfDemeterVisitor.swift
@@ -50,6 +50,7 @@ class LawOfDemeterVisitor: BasePatternVisitor {
     /// - `node.extendedType.description.trimmingCharacters` — description converts to String
     /// - `status.color.opacity` — color maps enum to a SwiftUI Color value
     /// - `range.lowerBound` / `range.upperBound` — standard Range value accessors
+    /// - `range.start` / `range.end` — the same two bounds, as LSP and SourceKit spell them
     /// - `memberAccess.declName.baseName.text` — SwiftSyntax token text accessor
     /// - `node.body.statements.isEmpty` — collection membership test
     /// - `report.totals.regions.count` — a scalar count, on the same footing as `isEmpty`
@@ -57,7 +58,7 @@ class LawOfDemeterVisitor: BasePatternVisitor {
     private static let valueTransformMembers: Set<String> = [
         "rawValue", "hashValue", "capitalized", "uppercased", "lowercased",
         "description", "debugDescription", "trimmedDescription",
-        "color", "lowerBound", "upperBound",
+        "color", "lowerBound", "upperBound", "start", "end",
         // SwiftSyntax token/trivia accessors
         "text", "baseName", "tokenKind",
         // Scalar terminals — a number or a flag, not another object to traverse

--- a/Tests/CoreTests/Architecture/ArchitectureLawOfDemeterTests.swift
+++ b/Tests/CoreTests/Architecture/ArchitectureLawOfDemeterTests.swift
@@ -510,6 +510,21 @@ struct LawOfDemeterValueTerminalTests {
         """).isEmpty)
     }
 
+    @Test("a range's bounds are exempt under either spelling")
+    func rangeBoundsAreExempt() {
+        // `lowerBound` and `upperBound` were already exempt as Range value accessors. LSP and
+        // SourceKit spell the same two fields `start` and `end`, and the coupling in
+        // `diag.range.start` is one hop either way.
+        #expect(analyze("""
+        struct DiagnosticDTO {
+            init(from diag: Diagnostic) {
+                self.file = diag.range.start.file
+                self.endLine = diag.range.end.line
+            }
+        }
+        """).isEmpty)
+    }
+
     @Test("lastPathComponent is a URL-to-String terminal")
     func lastPathComponentIsExempt() {
         #expect(analyze("""


### PR DESCRIPTION
Second rule finding from working the Law of Demeter backlog. After #177, five findings remained in SwiftAssist and they were all one shape:

```swift
self.file      = diag.range.start.file
self.startLine = diag.range.start.line
self.endLine   = diag.range.end.line
```

`lowerBound` and `upperBound` are already exempt as "standard Range value accessors". LSP and SourceKit spell a range's two bounds `start` and `end`. Same two fields, same one hop to the range, opposite answers — so `chunk.lineRange.lowerBound` was waved through and `diag.range.start.file` was reported.

All five sites are constructors flattening a nested source range into flat wire fields. That is the shape this rule's own documentation already calls "what a DTO is *for*" — it was recorded there five runs ago as *eleven findings for zero problems* and never acted on.

## Measured

26-repo corpus, `--categories architecture --include-nested-packages`, measured with and without the two members and nothing else changing:

| | SwiftAssist | every other repo |
|---|---|---|
| without | 5 | unchanged |
| with | **0** | **unchanged** |

Five findings removed, nothing else moved.

## What a reviewer should scrutinise

- **`start` and `end` are commoner words than `lowerBound` and `upperBound`.** That is the real risk, and it is why this was measured over 1.8m lines' worth of habits before shipping rather than argued from the names. If a chain like `a.b.start.c` in some other codebase is genuine coupling, this exempts it. The corpus says that shape does not occur here.
- **They are intermediates, not just terminals**, so `diag.range.start.file` is exempt at depth 3 and `x.y.start.z.w` is exempt at depth 4 as well. That follows `lowerBound`'s existing treatment; if you think the range members should be terminal-only, that is a real difference and worth saying.

## Note for the maintainer

This branch was cut from a working tree that already contained in-progress work on `ComparatorName.swift`, `ComparatorNameTests.swift`, `ComparatorNameCorpusProbe.swift` and `PureClosureCandidateVisitor.swift` (uncommitted, not mine, left untouched and unstaged). One test in that work — `ComparatorName — derived from the keys compared / "a computed key gets no name"` — currently fails on `swift test`. It is unrelated to this change: `swift test --filter LawOfDemeter` is 36 green, and nothing here touches that visitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSPQgvroTfRr7mKnQEQxe7