### PR TITLE
Suggest a name for the comparator the pure-closure rule finds

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ComparatorName.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ComparatorName.swift
@@ -1,0 +1,263 @@
+import SwiftSyntax
+
+/// Derives a name for a comparator closure from the keys it compares.
+///
+/// The rule has always known a closure is a comparator — it reads that off the
+/// call it is passed to, `sorted` / `min` / `max` / `partition`. What it could
+/// not say is *which* comparator, so the finding asked a reader to invent a name
+/// for every one of them. On a corpus with 82, that is the whole cost of acting.
+///
+/// The name is a function of the compared key paths and their operators:
+///
+/// ```swift
+/// if lhs.location != rhs.location { return lhs.location < rhs.location }
+/// return lhs.typeName < rhs.typeName          // → byLocationThenTypeName
+///
+/// lhs.total != rhs.total ? lhs.total > rhs.total : lhs.template < rhs.template
+///                                             // → byTotalDescendingThenTemplate
+///
+/// ($0.name, $0.parameterCount) < ($1.name, $1.parameterCount)
+///                                             // → byNameThenParameterCount
+/// ```
+///
+/// The third spelling is worth calling out: Swift's tuple `<` is lexicographic,
+/// so a tuple comparison *is* a multi-key comparator written as one expression.
+/// It carries no `!=` guard and no `&&`, so a search for either shape misses it
+/// entirely — on the corpus this was measured against, 14 comparators were
+/// spelled that way.
+///
+/// **Deliberately silent rather than wrong.** A derived name is only worth
+/// printing when it describes the whole comparator, so anything this cannot
+/// account for — a key reached through a call or a subscript, a third clause it
+/// did not recognise —
+/// returns `nil` and the finding falls back to its existing wording. A suggestion
+/// a reader has to check is worse than none, because checking it costs what
+/// inventing the name would have.
+///
+/// **A single-key ascending comparator returns `nil` too**, and that is not a
+/// limitation. `$0.key < $1.key` inherits irreflexivity, asymmetry and
+/// transitivity from the field's own `Comparable` conformance and cannot violate
+/// them, and `ascendingByKey` says nothing the four-token closure did not. The
+/// names worth writing belong to exactly the comparators whose laws are worth
+/// checking: the multi-key ones, where a tiebreak exists and incomparability is
+/// reachable.
+enum ComparatorName {
+
+    /// A single ordering clause: the key path compared, and which way.
+    private struct Key {
+        /// Dotted, because a key is often nested — `identity.normalized`, not
+        /// `normalized`. The last component alone would collide across the two
+        /// `identity.normalized` / `entry.identityHash` comparators that sit in
+        /// the same corpus, and would name the key by less than the code reads.
+        let property: String
+        let descending: Bool
+        /// Source offset, because the name is order-sensitive —
+        /// `byLocationThenTypeName` and `byTypeNameThenLocation` are different
+        /// comparators — and a syntax walk does not visit in source order. A
+        /// ternary's branches are reached after the sequence that contains them.
+        let position: Int
+    }
+
+    /// The suggested name, or `nil` when the body is not a shape this can
+    /// account for in full.
+    static func derived(from closure: ClosureExprSyntax) -> String? {
+        guard let (lhs, rhs) = parameterNames(of: closure) else { return nil }
+        let keys = clauses(in: closure, lhs: lhs, rhs: rhs)
+        guard keys.count >= 2 else { return nil }
+        var name = "by"
+        for (index, key) in keys.enumerated() {
+            if index > 0 { name += "Then" }
+            name += key.property.split(separator: ".")
+                .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+                .joined()
+            if key.descending { name += "Descending" }
+        }
+        return name
+    }
+
+    /// `{ lhs, rhs in … }` — both parameters must be named for the body to be
+    /// readable at all. A shorthand `$0` / `$1` body is handled by treating those
+    /// as the two names.
+    private static func parameterNames(of closure: ClosureExprSyntax) -> (String, String)? {
+        guard let signature = closure.signature else { return ("$0", "$1") }
+        guard case let .simpleInput(parameters)? = signature.parameterClause,
+              parameters.count == 2 else { return nil }
+        let names = parameters.map { $0.name.text }
+        return (names[0], names[1])
+    }
+
+    /// Every `lhs.x < rhs.x` style comparison in the body, in source order.
+    ///
+    /// Order matters and is the reason this walks statements rather than
+    /// collecting matches: `byLocationThenTypeName` and `byTypeNameThenLocation`
+    /// are different comparators.
+    private static func clauses(
+        in closure: ClosureExprSyntax, lhs: String, rhs: String
+    ) -> [Key] {
+        var keys: [Key] = []
+        var seen: Set<String> = []
+        let collector = ComparisonCollector(lhs: lhs, rhs: rhs, viewMode: .sourceAccurate)
+        collector.walk(closure.statements)
+        guard collector.isAccountedFor else { return [] }
+        for key in collector.keys.sorted(by: { $0.position < $1.position })
+            where !seen.contains(key.property) {
+            seen.insert(key.property)
+            keys.append(key)
+        }
+        return keys
+    }
+
+    /// Walks a comparator body collecting `lhs.p <op> rhs.p` comparisons.
+    ///
+    /// `isAccountedFor` is the honesty check: any binary operator it does not
+    /// recognise, or a comparison whose two sides are not the same property on
+    /// the two parameters, means the derived name would describe less than the
+    /// comparator does — so nothing is suggested.
+    private final class ComparisonCollector: SyntaxVisitor {
+        private let lhs: String
+        private let rhs: String
+        fileprivate var keys: [Key] = []
+        fileprivate var isAccountedFor = true
+
+        init(lhs: String, rhs: String, viewMode: SyntaxTreeViewMode) {
+            self.lhs = lhs
+            self.rhs = rhs
+            super.init(viewMode: viewMode)
+        }
+
+        override func visit(_ node: InfixOperatorExprSyntax) -> SyntaxVisitorContinueKind {
+            record(left: node.leftOperand, op: node.operator, right: node.rightOperand)
+            return .visitChildren
+        }
+
+        override func visit(_ node: SequenceExprSyntax) -> SyntaxVisitorContinueKind {
+            // An unfolded tree — what `Parser.parse` produces, and what every
+            // visitor here walks — spells `a < b` as a flat element list rather
+            // than an `InfixOperatorExpr`. A ternary flattens into the same list
+            // alongside its condition, so this scans for operator triples instead
+            // of assuming the sequence is one comparison.
+            let elements = Array(node.elements)
+            for index in elements.indices where index > 0 && index + 1 < elements.count {
+                guard elements[index].is(BinaryOperatorExprSyntax.self) else { continue }
+                record(left: elements[index - 1], op: elements[index], right: elements[index + 1])
+            }
+            return .visitChildren
+        }
+
+        private func record(left: ExprSyntax, op: ExprSyntax, right: ExprSyntax) {
+            guard let symbol = op.as(BinaryOperatorExprSyntax.self)?.operator.text else { return }
+            switch symbol {
+            case "<", ">":
+                guard let resolved = resolve(left, right) else {
+                    isAccountedFor = false
+                    return
+                }
+                let descending = symbol == ">"
+                for key in resolved {
+                    // A swapped element reverses the operator for that key alone,
+                    // which is the whole reason direction is resolved per element
+                    // rather than read off the operator once.
+                    keys.append(Key(property: key.path,
+                                    descending: descending != key.isSwapped,
+                                    position: key.position))
+                }
+
+            case "!=", "==":
+                // The guard half of a tiebreak — carries no ordering of its own,
+                // but still has to be readable, or the name would describe less
+                // than the comparator does.
+                if resolve(left, right) == nil { isAccountedFor = false }
+
+            default:
+                isAccountedFor = false
+            }
+        }
+
+        /// One key recovered from a comparison, before its direction is known.
+        private struct Resolved {
+            let path: String
+            /// The two sides were written in the opposite order — see `keyPair`.
+            let isSwapped: Bool
+            let position: Int
+        }
+
+        /// The keys a single comparison orders by: one for `lhs.p < rhs.p`, and
+        /// as many as the tuple is wide for `(lhs.a, lhs.b) < (rhs.a, rhs.b)`.
+        ///
+        /// Swift's tuple `<` is lexicographic, which makes it a complete multi-key
+        /// comparator written as one expression — the idiomatic spelling, and one
+        /// a search for `!=` tiebreaks or `&&` chains never sees. `nil` when any
+        /// element fails to resolve, because a name that covers some of a tuple
+        /// covers none of the comparator.
+        private func resolve(_ left: ExprSyntax, _ right: ExprSyntax) -> [Resolved]? {
+            guard let leftTuple = left.as(TupleExprSyntax.self),
+                  let rightTuple = right.as(TupleExprSyntax.self) else {
+                return keyPair(left, right).map { [$0] }
+            }
+            let leftElements = Array(leftTuple.elements)
+            let rightElements = Array(rightTuple.elements)
+            guard leftElements.count == rightElements.count else { return nil }
+            var resolved: [Resolved] = []
+            for (leftElement, rightElement) in zip(leftElements, rightElements) {
+                guard let key = keyPair(leftElement.expression, rightElement.expression) else {
+                    return nil
+                }
+                resolved.append(key)
+            }
+            return resolved
+        }
+
+        /// `lhs.p` against `rhs.p` for the same key path `p`, in either order.
+        ///
+        /// The swapped order is a real idiom rather than a mistake. This, from the
+        /// corpus, orders by value **descending** and then by key **ascending**,
+        /// using a single `>`:
+        ///
+        /// ```swift
+        /// rows.sorted(by: { ($0.value, $1.key) > ($1.value, $0.key) })
+        /// ```
+        ///
+        /// Only the second element is swapped, so direction cannot be taken from
+        /// the operator and applied to the tuple as a whole. Reading it that way
+        /// yields `byValueDescendingThenKeyDescending` — a confident, wrong name,
+        /// which costs a reader more than no name at all.
+        private func keyPair(_ left: ExprSyntax, _ right: ExprSyntax) -> Resolved? {
+            let position = left.position.utf8Offset
+            if let leftPath = path(of: left, rootedAt: lhs),
+               let rightPath = path(of: right, rootedAt: rhs),
+               leftPath == rightPath {
+                return Resolved(path: leftPath.joined(separator: "."),
+                                isSwapped: false, position: position)
+            }
+            if let leftPath = path(of: left, rootedAt: rhs),
+               let rightPath = path(of: right, rootedAt: lhs),
+               leftPath == rightPath {
+                return Resolved(path: leftPath.joined(separator: "."),
+                                isSwapped: true, position: position)
+            }
+            return nil
+        }
+
+        /// The member chain from a parameter: `lhs.identity.normalized` reads as
+        /// `["identity", "normalized"]`. `nil` when the expression is anything
+        /// else — a call, a subscript, a literal, or a chain off some other root.
+        ///
+        /// A tuple position is refused even though it orders perfectly well.
+        /// `lhs.1.timestamp < rhs.1.timestamp` is a valid key, but `by1Timestamp`
+        /// is not a name anyone would have written, and a bad name costs a reader
+        /// what inventing a good one would have. Silence is the better answer.
+        private func path(of expr: ExprSyntax, rootedAt parameter: String) -> [String]? {
+            var components: [String] = []
+            var current = expr
+            while let access = current.as(MemberAccessExprSyntax.self) {
+                let component = access.declName.baseName.text
+                guard let initial = component.first, !initial.isNumber else { return nil }
+                components.insert(component, at: 0)
+                guard let base = access.base else { return nil }
+                current = base
+            }
+            guard current.trimmedDescription == parameter, !components.isEmpty else { return nil }
+            return components
+        }
+    }
+}

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/PureClosureCandidateVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/PureClosureCandidateVisitor.swift
@@ -67,14 +67,26 @@ final class PureClosureCandidateVisitor: BasePatternVisitor {
             return .visitChildren
         }
 
+        // A comparator whose keys this can read gets a name in the suggestion.
+        // Silent for every other shape — see `ComparatorName` for why a name a
+        // reader has to check is worse than no name at all.
+        let suggestedName = operation.kind == .comparator
+            ? ComparatorName.derived(from: closure)
+            : nil
+        let suggestion = suggestedName.map {
+            "Lift it into `static func \($0)(_ lhs: …, _ rhs: …) -> Bool` and pass it by name. "
+                + "The name states the whole ordering, including the tiebreak the closure body "
+                + "makes you read four lines to find."
+        } ?? "Lift it into a named function. Anything it captures becomes a parameter, "
+            + "and what is left is a pure function you can generate inputs for."
+
         addIssue(
             severity: .info,
             message: "The closure passed to `\(operation.name)` is pure — a property-based-test "
                 + "candidate with no name to test. \(operation.law)",
             filePath: getFilePath(for: Syntax(closure)),
             lineNumber: getLineNumber(for: Syntax(closure)),
-            suggestion: "Lift it into a named function. Anything it captures becomes a parameter, "
-                + "and what is left is a pure function you can generate inputs for.",
+            suggestion: suggestion,
             ruleName: .pureClosureCandidate,
             symbol: enclosingDeclarationName(of: node) ?? operation.name,
             role: operation.kind.seedRole
@@ -150,7 +162,7 @@ final class PureClosureCandidateVisitor: BasePatternVisitor {
 private struct CollectionOperation {
 
     /// What the closure *is*, which is what decides whether naming it buys anything.
-    enum Kind {
+    enum Kind: Equatable {
         case comparator
         case predicate
         case transform

--- a/Tests/CoreTests/Testability/ComparatorNameTests.swift
+++ b/Tests/CoreTests/Testability/ComparatorNameTests.swift
@@ -1,0 +1,223 @@
+import Foundation
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+/// The suggestion is only worth printing when it describes the **whole**
+/// comparator. Half of these tests are cases where it must stay silent, because
+/// a name a reader has to verify costs what inventing one would have.
+@Suite("ComparatorName — derived from the keys compared")
+struct ComparatorNameTests {
+
+    private func closure(
+        _ body: String, signature: String = "lhs, rhs in "
+    ) throws -> ClosureExprSyntax {
+        let tree = Parser.parse(source: "let _ = xs.sorted { \(signature)\(body) }")
+        final class Finder: SyntaxVisitor {
+            var found: ClosureExprSyntax?
+            override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
+                if found == nil { found = node }
+                return .skipChildren
+            }
+        }
+        let finder = Finder(viewMode: .sourceAccurate)
+        finder.walk(tree)
+        return try #require(finder.found)
+    }
+
+    /// The shorthand spelling, which the corpus uses far more than named
+    /// parameters. It must be parsed *without* a signature — wrapping a `$0`
+    /// body in `{ lhs, rhs in … }` makes every key unresolvable, which silently
+    /// turns a silence test into a test of nothing.
+    private func shorthandClosure(_ body: String) throws -> ClosureExprSyntax {
+        try closure(body, signature: "")
+    }
+
+    // MARK: - The shapes it should name
+
+    @Test("a tuple comparison is a multi-key comparator and is named as one")
+    func tupleTwoKeys() throws {
+        let sut = try shorthandClosure("return ($0.name, $0.parameterCount) < ($1.name, $1.parameterCount)")
+        #expect(ComparatorName.derived(from: sut) == "byNameThenParameterCount")
+    }
+
+    @Test("tuple elements may be nested, and there may be more than two")
+    func tupleThreeNestedKeys() throws {
+        let sut = try closure("""
+            return (lhs.location.file, lhs.location.line, lhs.typeName)
+                 < (rhs.location.file, rhs.location.line, rhs.typeName)
+            """)
+        #expect(ComparatorName.derived(from: sut)
+                == "byLocationFileThenLocationLineThenTypeName")
+    }
+
+    /// Taken verbatim from `CensusRenderer`. Only the *second* element is
+    /// swapped, so this orders by value descending and key ascending under a
+    /// single `>`. Reading the direction off the operator once would name it
+    /// `byValueDescendingThenKeyDescending` — confident and wrong.
+    @Test("a swapped tuple element reverses that key alone")
+    func swappedTupleElement() throws {
+        let sut = try shorthandClosure("return ($0.value, $1.key) > ($1.value, $0.key)")
+        #expect(ComparatorName.derived(from: sut) == "byValueDescendingThenKey")
+    }
+
+
+    /// Every multi-key comparator this rule found silent on the real corpus was
+    /// silent for one reason: a nested key. Because a single unaccounted clause
+    /// silences the whole closure, one `identity.normalized` cost the entire name.
+    @Test("a nested key is named by its whole path, not its last component")
+    func nestedKeyPath() throws {
+        let sut = try closure("""
+            if lhs.score != rhs.score { return lhs.score > rhs.score }
+            return lhs.identity.normalized < rhs.identity.normalized
+            """)
+        #expect(ComparatorName.derived(from: sut) == "byScoreDescendingThenIdentityNormalized")
+    }
+
+    @Test("both keys may be nested")
+    func twoNestedKeys() throws {
+        let sut = try closure("""
+            if lhs.members.count != rhs.members.count { return lhs.members.count > rhs.members.count }
+            return lhs.shape.canonicalLabelKey < rhs.shape.canonicalLabelKey
+            """)
+        #expect(ComparatorName.derived(from: sut) == "byMembersCountDescendingThenShapeCanonicalLabelKey")
+    }
+
+
+    @Test("a guard-style tiebreak names both keys in order")
+    func guardStyleTwoKeys() throws {
+        let sut = try closure("""
+            if lhs.location != rhs.location { return lhs.location < rhs.location }
+            return lhs.typeName < rhs.typeName
+            """)
+        #expect(ComparatorName.derived(from: sut) == "byLocationThenTypeName")
+    }
+
+    @Test("a descending primary is named as such")
+    func descendingPrimary() throws {
+        let sut = try closure("""
+            if lhs.total != rhs.total { return lhs.total > rhs.total }
+            return lhs.template < rhs.template
+            """)
+        #expect(ComparatorName.derived(from: sut) == "byTotalDescendingThenTemplate")
+    }
+
+    @Test("the ternary spelling names the same keys as the guard spelling")
+    func ternarySpelling() throws {
+        let sut = try closure(
+            "lhs.value != rhs.value ? lhs.value > rhs.value : lhs.key < rhs.key")
+        #expect(ComparatorName.derived(from: sut) == "byValueDescendingThenKey")
+    }
+
+    @Test("three keys are all named, in source order")
+    func threeKeys() throws {
+        let sut = try closure("""
+            if lhs.file != rhs.file { return lhs.file < rhs.file }
+            if lhs.line != rhs.line { return lhs.line < rhs.line }
+            return lhs.column < rhs.column
+            """)
+        #expect(ComparatorName.derived(from: sut) == "byFileThenLineThenColumn")
+    }
+
+    // MARK: - The shapes it must decline
+
+    /// **Not a limitation.** A single ascending key inherits its law from the
+    /// field's own `Comparable` conformance and cannot violate it, and
+    /// `ascendingByKey` says nothing `$0.key < $1.key` did not.
+    @Test("a single key gets no name")
+    func singleKeyIsSilent() throws {
+        #expect(ComparatorName.derived(from: try closure("return lhs.key < rhs.key")) == nil)
+    }
+
+    /// This case used to assert silence, under the heading "a computed key gets
+    /// no name". That heading was wrong twice over. The code never tested
+    /// computedness — it cannot, from syntax — and `byNameCount` is precisely the
+    /// name a reader would have written, so withholding it helped nobody. What
+    /// the old test actually pinned was a limitation of the deriver, phrased as
+    /// though it were a principle.
+    @Test("a computed key is named like any other — computedness is not visible to syntax")
+    func computedKeyIsNamed() throws {
+        let sut = try closure("""
+            if lhs.name.count != rhs.name.count { return lhs.name.count < rhs.name.count }
+            return lhs.id < rhs.id
+            """)
+        #expect(ComparatorName.derived(from: sut) == "byNameCountThenId")
+    }
+
+    /// The boundary that does hold, and unlike computedness is decidable from
+    /// syntax: a key reached through a **call** is not named. The call may be
+    /// costly, may not be a projection of the value at all, and its name reads as
+    /// an action rather than a key.
+    @Test("a key reached through a call gets no name")
+    func calledKeyIsSilent() throws {
+        let sut = try closure("""
+            if lhs.name.trimmed() != rhs.name.trimmed() { return lhs.name.trimmed() < rhs.name.trimmed() }
+            return lhs.id < rhs.id
+            """)
+        #expect(ComparatorName.derived(from: sut) == nil)
+    }
+
+    @Test("a subscripted key gets no name")
+    func subscriptedKeyIsSilent() throws {
+        let sut = try closure("""
+            if lhs.tags[0] != rhs.tags[0] { return lhs.tags[0] < rhs.tags[0] }
+            return lhs.id < rhs.id
+            """)
+        #expect(ComparatorName.derived(from: sut) == nil)
+    }
+
+    @Test("an unrecognised operator gets no name")
+    func unrecognisedOperatorIsSilent() throws {
+        let sut = try closure("""
+            if lhs.rank ~= rhs.rank { return lhs.rank < rhs.rank }
+            return lhs.id < rhs.id
+            """)
+        #expect(ComparatorName.derived(from: sut) == nil)
+    }
+
+    /// The two sides must be the *same* property on the two parameters. A
+    /// comparator relating different fields is doing something a two-key name
+    /// would misdescribe.
+    @Test("comparing different properties gets no name")
+    func crossPropertyIsSilent() throws {
+        let sut = try closure("""
+            if lhs.start != rhs.end { return lhs.start < rhs.end }
+            return lhs.id < rhs.id
+            """)
+        #expect(ComparatorName.derived(from: sut) == nil)
+    }
+
+    /// A tuple position orders perfectly well — this comparator is correct — but
+    /// `by1TimestampThen0` is not a name anyone would have written, so the rule
+    /// says nothing rather than something a reader has to undo.
+    @Test("a tuple-position key stays silent even though it orders")
+    func tuplePositionKey() throws {
+        let sut = try closure("""
+            if lhs.1.timestamp != rhs.1.timestamp { return lhs.1.timestamp < rhs.1.timestamp }
+            return lhs.0 < rhs.0
+            """)
+        #expect(ComparatorName.derived(from: sut) == nil)
+    }
+
+    @Test("a tuple element reached through a call gets no name")
+    func tupleWithCallElement() throws {
+        let sut = try shorthandClosure("return (origin($0), $0.typeName) < (origin($1), $1.typeName)")
+        #expect(ComparatorName.derived(from: sut) == nil)
+    }
+
+    /// A name covering part of a tuple covers none of the comparator, so one
+    /// unreadable element silences the whole thing rather than naming the rest.
+    @Test("one unreadable tuple element silences the whole comparator")
+    func tupleWithSubscriptElement() throws {
+        let sut = try shorthandClosure("return ($0.name, tierRank[$0.tier] ?? 0) < ($1.name, tierRank[$1.tier] ?? 0)")
+        #expect(ComparatorName.derived(from: sut) == nil)
+    }
+
+    /// A parenthesised single key is still a single key — the parentheses are a
+    /// one-element tuple to the parser, and must not make it look multi-key.
+    @Test("a parenthesised single key stays silent")
+    func parenthesisedSingleKey() throws {
+        #expect(ComparatorName.derived(from: try shorthandClosure("return ($0.name) < ($1.name)")) == nil)
+    }
+}


### PR DESCRIPTION
## What changed

The pure-closure rule already knew a closure was a comparator — it reads that off the call it is passed to — but not *which* comparator, so every finding ended with "lift it into a named function" and left the naming to the reader. On a corpus with 86 comparators, inventing the name is the whole cost of acting.

`ComparatorName` derives the name from the compared key paths and their directions. The guard, ternary and tuple spellings all yield the same name.

## Measured, not projected

On SwiftInferProperties: **20 of 86** comparators get a name. That ratio understates it — 62 of the 66 silences are single-key closures, silent by design. Against the multi-key population it is **20 of 24**, and the four misses are genuinely unnameable (a tuple position, two keys reached through calls, a subscript, a ternary projection).

Both intermediate figures came from running it over the corpus rather than reading the code, and both times the corpus contradicted my estimate: nested keys accounted for every miss in the first round, tuple spellings for most of the second.

## What a reviewer should scrutinise

**Direction is resolved per tuple element, not read off the operator.** This is the case I would most want a second pair of eyes on. From `CensusRenderer`:

```swift
rows.sorted(by: { ($0.value, $1.key) > ($1.value, $0.key) })
```

Only the *second* element is swapped, so this orders by value descending and key **ascending** under a single `>`. An implementation that applied the operator to the tuple as a whole would emit `byValueDescendingThenKeyDescending` — confident and wrong, which is worse than silence. That source line is pinned verbatim as a test.

**The silence cases are load-bearing and easy to get falsely green.** A test asserting `== nil` passes for any reason, including a broken harness. Two of them here were doing exactly that: bodies written with `$0`/`$1` were being parsed inside a `{ lhs, rhs in … }` wrapper, so nothing resolved and the deriver returned nil for a reason unrelated to what the test claimed. Fixed with a separate `shorthandClosure` helper — worth checking the remaining silence tests fail when they should.

**One prior test was rewritten rather than satisfied.** `a computed key gets no name` asserted that `lhs.name.count` yields nothing. Its title claimed a principle about computed keys, but its assertion message stated the actual content: *a key reached through a member chain is not a property this can name* — an implementation limitation written up as a design decision. Computedness is not visible to syntax and was never tested; the boundary that is decidable, and now asserted, is that calls and subscripts stay silent while chains do not.

## Verification

Full suite green: 3,574 tests in 429 suites. Each commit builds and passes on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)