### PR TITLE
Computed Property View: two gates, measured over the corpus

### DIFF
--- a/Docs/rules/computed-property-view.md
+++ b/Docs/rules/computed-property-view.md
@@ -18,9 +18,18 @@ identity boundary.
 
 **It does not report all of them.** The mechanism above is real but its benefit is *conditional*,
 and the rule used to report it unconditionally — 341 findings across nine repositories, of which a
-hand audit found many that could not benefit at all. Three gates now stand between a property and a
+hand audit found many that could not benefit at all. Four gates now stand between a property and a
 finding, and every one of them was measured against a 26-repository corpus rather than argued for.
-The count is **57**.
+
+**The corpus count is 0.** 341 → 63 by narrowing, then 63 → 0 in one pass across seven
+repositories: the toolbar half of Gate 2 removed 6 and the whole of Gate 4 removed 5, all 11 the
+rule's fault; **48** properties were extracted into `View` structs or inlined at their call sites;
+and **4** were declined in place, each with a written reason and a `swiftprojectlint:disable:next`
+marker. No other rule's count moved in any of the seven, so the refactoring introduced nothing.
+
+The split is worth reading beside the four rules worked before this one, which averaged about half
+their findings being the rule's fault. Here it is **17%** — the lowest yet — and the reason is that
+this rule had already been narrowed four times before anyone applied it.
 
 #### Gate 1 — the property must take a narrower input than its parent
 
@@ -115,14 +124,62 @@ independently judged not worth extracting.
 > same mutation under two spellings. Found by re-classifying the file the gate was calibrated
 > against and noticing one property still fired.
 
-**A mutating method other than `toggle()` is a known miss.** `selection.remove(id)` and
-`selection.insert(id)` on a `@State Set` require a `Binding` exactly as `toggle()` does, and are
-still reported — one finding in the corpus, in `ComparisonView`. Closing it means choosing between a
-hand-maintained list of mutating method names, which is arbitrary, and the principled rule — *a call
-in statement position whose receiver is stored state* — which over-gates without type resolution,
-because it cannot tell `selection.remove(id)` on a value type from `viewModel.reload()` on a
-reference type. Neither has a defence strong enough to ship on one finding, so the miss is recorded
-rather than closed.
+**A mutating method other than `toggle()` is a known miss** — see *Open, and why* below.
+
+#### Gate 4 — a type split across files is only partly known
+
+Gate 1's premise is that the dependency set is **known**. For a type whose members live in
+`Foo.swift` and `Foo+Sections.swift` it is not, and the failure runs one way: an unseen sibling
+contributes no dependencies, so a property that forwards to one reads as depending on *nothing* —
+the strongest possible pass of the gate. **The rule was at its most confident exactly where it knew
+least.**
+
+`ExtensionMemberCatalog`, a project pre-scan, records the member names each type declares in
+`extension` blocks. The visitor merges the extensions it can see in the file under analysis and
+declines any property whose transitive reference closure reaches one of the rest. Precise rather
+than blanket: a property in a split type that touches nothing unseen is still reported.
+
+Measured on SwiftLintRuleStudio, the corpus's worst case: **7 of 20 findings sat in types split
+across files, and the catalog removed 5** — the other two reach no hidden member and still fire.
+`RuleAuditView.auditResultsView` is the clearest. It composes two properties from
+`RuleAuditView+Subviews.swift` that between them read six stored properties and call four instance
+methods, so with the whole type in view Gate 3 declines it outright.
+
+**An extension's own view properties are still not reported.** Merging feeds the dependency walk;
+it does not put the extension's members in scope for reporting, because `isInsideViewType` is set
+by entering the type declaration. That is a coverage *increase* on a rule this pass was narrowing,
+so it is pinned as a decision by `extensionDeclaredPropertyIsNotItselfReported` rather than made
+silently.
+
+#### Open, and why
+
+Three shapes are recorded rather than closed. Each would take a measurement this project cannot
+make from source alone.
+
+**A mutating method other than `toggle()`.** `selection.remove(id)` and `selection.insert(id)` on a
+`@State Set` require a `Binding` exactly as `toggle()` does, and are still reported — one finding
+in the corpus, `ComparisonView.repoSelector` in SwiftLintRuleStudioTeam, now carrying a
+`disable:next` marker. Closing it means choosing between a hand-maintained list of mutating method
+names, which is arbitrary, and the principled rule — *a call in statement position whose receiver is
+stored state* — which over-gates without type resolution, because it cannot tell
+`selection.remove(id)` on a value type from `viewModel.reload()` on a reference type.
+
+**A `Section` whose rows carry `.tag()`, inside a selectable `List`.** One finding,
+`TemplateLibraryView.projectTypeSection`, also marked in place. Whether a tag survives being moved
+into a child `View`'s body is a question about SwiftUI's selection machinery, and the cost of
+guessing wrong is a sidebar that stops selecting. It belongs with the Gate 2 family if it belongs
+anywhere, and it needs a running app to settle.
+
+**Whether a property whose body is a *single view value* benefits at all.** `emptyState` returning
+one `ContentUnavailableView(…)` already produces a node with its own identity, and SwiftUI's own
+value diffing skips an unchanged subtree without help. If that is enough, the extraction saves only
+the construction of one struct and roughly a dozen corpus findings were never worth reporting; if
+it is not, they were. **The `body`-evaluation harness that settled Gate 3 was not kept**, and
+rebuilding it is the only way to answer this. Two of the corpus instances need no harness and were
+handled by deleting the property instead: `ConfigDiffPreviewView.fullDiffView` and
+`RuleBrowserListView.searchAndFiltersSection` were one-line aliases for `View` structs the app
+already declares, so the boundary the rule asks for was already there and the suggested extraction
+would have produced a struct whose body is the same call.
 
 #### What the rule still cannot see
 

--- a/Docs/rules/computed-property-view.md
+++ b/Docs/rules/computed-property-view.md
@@ -20,7 +20,7 @@ identity boundary.
 and the rule used to report it unconditionally — 341 findings across nine repositories, of which a
 hand audit found many that could not benefit at all. Three gates now stand between a property and a
 finding, and every one of them was measured against a 26-repository corpus rather than argued for.
-The count is **134**.
+The count is **57**.
 
 #### Gate 1 — the property must take a narrower input than its parent
 
@@ -41,18 +41,30 @@ gains little either way — but it is the condition the rule can check. A proper
 of five inputs still passes and its benefit is marginal; no threshold has a principled defence, so
 none was invented.
 
-#### Gate 2 — dialog and menu builders are left alone
+#### Gate 2 — containers that decompose their contents are left alone
 
-`confirmationDialog(actions:)`, `alert(actions:)` and `Menu(content:)` read a *collection of
-buttons* out of the closure they are handed. A `View` struct wrapping those buttons is a container
-they are not specified to accept, so following this rule there could change **what the app does**
-rather than only how it redraws. It is the one shape with that risk, and it is now silent.
+Two families, one argument. `confirmationDialog(actions:)`, `alert(actions:)` and `Menu(content:)`
+read a *collection of buttons* out of the closure they are handed. `ToolbarItem(content:)`,
+`ToolbarItemGroup(content:)` and `.toolbar` read a *collection of toolbar items* out of theirs. In
+both cases a `View` struct wrapping the contents is a container the API is not specified to accept,
+so following this rule there could change **what the app does** rather than only how it redraws.
+These are the shapes with that risk, and they are now silent.
+
+The toolbar half is visible in the corpus rather than argued. `ViolationInspectorView` composes
+five properties into one `ToolbarItemGroup`; one of them, `navigationButtons`, is a `Group` of two
+`Button`s and therefore places **two** items. Wrapped in a `View` struct it is one view, and the
+group places **one**. `actionsMenu` is worse — an `if` around a `Menu`, so the item count already
+varies with the condition.
 
 The search covers a builder's arguments and trailing closures but never the called expression —
 for a modifier that holds the receiver, which is the entire view it is applied to. It is
 deliberately coarse in one direction: a name appearing in `alert`'s `message:` closure is spared
-along with the ones in `actions:`. Sparing a property costs a finding; reporting one whose
-extraction breaks a dialog costs a working app.
+along with the ones in `actions:`, and a property that happens to be the *only* view in its
+`ToolbarItem` — `GraphSheetView.searchField` is the corpus's one instance — is spared along with
+the groups. Sparing a property costs a finding; reporting one whose extraction breaks a dialog or
+drops a toolbar button costs a working app.
+
+Measured before it shipped: **6 findings across two repositories, 0 newly reported.**
 
 #### Gate 3 — a child that requires capture cannot be skipped
 

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
@@ -199,6 +199,10 @@ extension ProjectLinter {
 
         /// Types whose initialiser has defaulted parameters — the gate for `lossyStructRebuild`.
         let defaultedInitializerTypes: Set<String>
+
+        /// Per type, the member names its `extension` blocks declare — the pre-scan's answer to
+        /// "is part of this type in another file?". See `ExtensionMemberCatalog`.
+        let extensionMembers: ExtensionMemberCatalog
         let layerPolicies: [LayerPolicy]
     }
 
@@ -230,6 +234,7 @@ extension ProjectLinter {
             projectFunctions: env.projectFunctions,
             impurePackageFunctions: env.impurePackageFunctions,
             defaultedInitializerTypes: env.defaultedInitializerTypes,
+            extensionMembers: env.extensionMembers,
             layerPolicies: env.layerPolicies
         )
     }
@@ -257,6 +262,7 @@ extension ProjectLinter {
         projectFunctions: Set<String> = [],
         impurePackageFunctions: Set<String> = [],
         defaultedInitializerTypes: Set<String> = [],
+        extensionMembers: ExtensionMemberCatalog = .empty,
         layerPolicies: [LayerPolicy] = []
     ) -> (file: ProjectFile, issues: [LintIssue], parsedAST: SourceFileSyntax)? {
         guard !Task.isCancelled else { return nil }
@@ -287,6 +293,7 @@ extension ProjectLinter {
         det.knownProjectFunctions = projectFunctions
         det.knownImpurePackageFunctions = impurePackageFunctions
         det.knownDefaultedInitializerTypes = defaultedInitializerTypes
+        det.knownExtensionMembers = extensionMembers
         det.layerPolicies = layerPolicies
 
         let rawIssues: [LintIssue]

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
@@ -245,6 +245,11 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         /// by its own fixpoint rather than by `collectTypes`.
         let cleanInstanceMethods: CleanInstanceMethodCatalog
 
+        /// Per type, the member names its `extension` blocks declare. A per-file visitor that
+        /// reasons about what a type's members read needs this to know when it is looking at
+        /// only part of the type — see `ExtensionMemberCatalog`.
+        let extensionMembers: ExtensionMemberCatalog
+
         /// Package function names this project's own purity oracle refutes with an
         /// establishable witness — the one-hop callee join. Needs parsed bodies for the
         /// same reason `cleanInstanceMethods` does, and shares the single parse below.
@@ -286,6 +291,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
                 spiMembers: collectTypes(SPIMemberCollector.self, from: filePaths),
                 underscoredMembers: collectTypes(UnderscoredMemberCollector.self, from: filePaths),
                 cleanInstanceMethods: CleanInstanceMethodCatalog.build(from: parsed),
+                extensionMembers: ExtensionMemberCatalog.build(from: parsed),
                 impurePackageFunctions: PackagePurityJoin(sources: parsed).settledImpureNames
             )
         }
@@ -312,6 +318,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         resolved.knownEquatableTypes = collected.equatable
         resolved.knownValueTypes = collected.values
         resolved.knownCleanInstanceMethods = collected.cleanInstanceMethods
+        resolved.knownExtensionMembers = collected.extensionMembers
         resolved.knownImpurePackageFunctions = collected.impurePackageFunctions
         resolved.knownProjectFunctions = collected.functions
         resolved.knownDefaultedInitializerTypes = collected.defaultedInitializers
@@ -350,6 +357,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
             projectFunctions: collected.functions,
             impurePackageFunctions: collected.impurePackageFunctions,
             defaultedInitializerTypes: collected.defaultedInitializers,
+            extensionMembers: collected.extensionMembers,
             layerPolicies: layerPolicies
         )
     }

--- a/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetector.swift
+++ b/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetector.swift
@@ -38,6 +38,7 @@ public final class SourcePatternDetector: SourcePatternDetectorProtocol, @unchec
     /// Member names declared under `@_spi(...)`.
     public var knownSPIMembers: Set<String> = []
     public var knownUnderscoredMembers: Set<String> = []
+    public var knownExtensionMembers = ExtensionMemberCatalog.empty
 
     public var knownFunctionTypeAliases: Set<String> = []
 
@@ -204,6 +205,7 @@ public final class SourcePatternDetector: SourcePatternDetectorProtocol, @unchec
             visitor.knownInspectedTypeNames = knownInspectedTypeNames
             visitor.knownSPIMembers = knownSPIMembers
             visitor.knownUnderscoredMembers = knownUnderscoredMembers
+            visitor.knownExtensionMembers = knownExtensionMembers
             visitor.knownFunctionTypeAliases = knownFunctionTypeAliases
             visitor.knownIdentifiableTypes = knownIdentifiableTypes
             visitor.knownEnumTypes = knownEnumTypes

--- a/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetectorProtocol.swift
+++ b/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetectorProtocol.swift
@@ -39,6 +39,7 @@ public protocol SourcePatternDetectorProtocol {
 
     var knownSPIMembers: Set<String> { get set }
     var knownUnderscoredMembers: Set<String> { get set }
+    var knownExtensionMembers: ExtensionMemberCatalog { get set }
 
     var knownFunctionTypeAliases: Set<String> { get set }
 

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor+Gates.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor+Gates.swift
@@ -1,0 +1,179 @@
+import Foundation
+import SwiftProjectLintModels
+import SwiftProjectLintVisitors
+import SwiftSyntax
+
+/// The parts of the Computed Property View gate that read the *shape* of a type rather than drive
+/// the walk: which containers decompose their contents, how a property's dependencies resolve, and
+/// how a name is read out of an expression.
+///
+/// Split from `ComputedPropertyViewVisitor` when the extension-member gate pushed the class body
+/// past `type_body_length`. Nothing here touches visitor state — every member is `static`.
+extension ComputedPropertyViewVisitor {
+
+    /// APIs that **decompose** the closure they are handed instead of rendering it as one view.
+    ///
+    /// Two families, one argument. `confirmationDialog(actions:)`, `alert(actions:)`,
+    /// `Menu(content:)` and `contextMenu` read a *collection of buttons* out of the builder.
+    /// `ToolbarItem(content:)`, `ToolbarItemGroup(content:)` and `.toolbar` read a *collection of
+    /// toolbar items* out of theirs. In both cases a `View` struct wrapping the contents is a
+    /// container the API is not specified to accept, so "extract this into its own View" is not
+    /// behaviour-preserving — it is the one place where following this rule can change what the app
+    /// does rather than only how it redraws.
+    ///
+    /// The toolbar half is visible in the corpus rather than argued: `ViolationInspectorView`'s
+    /// `navigationButtons` is a `Group` of two `Button`s inside a `ToolbarItemGroup`, which places
+    /// **two** items. Wrapped in a `View` struct it is one view, and the group places **one**.
+    /// `actionsMenu` is worse — an `if` around a `Menu`, so extraction also fixes the item count
+    /// that the condition currently varies.
+    ///
+    /// Deliberately coarse in the same direction as the dialog half: a property that happens to be
+    /// the *only* view in its `ToolbarItem` could be extracted safely, and is spared anyway. A
+    /// spared property costs a finding; a reported one whose extraction drops a toolbar button
+    /// costs a working app.
+    ///
+    /// The dialog half was found on MacCloud_client_iOS, where `FileListView` had three such
+    /// properties and the rule reported all three — marked `info` for carrying `@ViewBuilder`,
+    /// which is not the same thing as declining to report them.
+    static let decomposingContainers: Set<String> = [
+        "confirmationDialog", "alert", "actionSheet", "Menu", "contextMenu",
+        "ToolbarItem", "ToolbarItemGroup", "toolbar"
+    ]
+
+    /// Property names referenced inside one of those containers.
+    ///
+    /// Only the *arguments and trailing closures* are searched, never the called expression. For a
+    /// modifier the called expression holds the receiver — the entire view it is applied to — and
+    /// walking it would sweep up every name in `body`.
+    ///
+    /// Deliberately coarse in one direction: a name appearing in `alert`'s `message:` closure is
+    /// spared along with the ones in `actions:`. Sparing a property costs a finding; reporting one
+    /// whose extraction breaks a dialog or drops a toolbar button costs a working app, so the
+    /// imprecision is pointed the safe way.
+    static func namesUsedByDecomposingContainers(in memberBlock: MemberBlockSyntax) -> Set<String> {
+        var found: Set<String> = []
+        collectDecomposedNames(in: Syntax(memberBlock), into: &found)
+        return found
+    }
+
+    static func collectDecomposedNames(in node: Syntax, into found: inout Set<String>) {
+        for child in node.children(viewMode: .sourceAccurate) {
+            if let call = child.as(FunctionCallExprSyntax.self), isDecomposingContainer(call) {
+                found.formUnion(referencedNames(in: Syntax(call.arguments)))
+                if let trailing = call.trailingClosure {
+                    found.formUnion(referencedNames(in: Syntax(trailing)))
+                }
+                for extra in call.additionalTrailingClosures {
+                    found.formUnion(referencedNames(in: Syntax(extra.closure)))
+                }
+            }
+            collectDecomposedNames(in: child, into: &found)
+        }
+    }
+
+    static func isDecomposingContainer(_ call: FunctionCallExprSyntax) -> Bool {
+        if let member = call.calledExpression.as(MemberAccessExprSyntax.self) {
+            return decomposingContainers.contains(member.declName.baseName.text)
+        }
+        if let reference = call.calledExpression.as(DeclReferenceExprSyntax.self) {
+            return decomposingContainers.contains(reference.baseName.text)
+        }
+        return false
+    }
+
+    /// The stored properties a computed property reaches, following the type's other computed
+    /// properties. A wrapper that reads nothing itself still depends on whatever it calls.
+    static func resolvedDependencies(
+        of name: String,
+        computed: [String: Set<String>],
+        stored: Set<String>
+    ) -> Set<String> {
+        var seen: Set<String> = [name]
+        var pending = Array(computed[name] ?? [])
+        var result: Set<String> = []
+
+        while let next = pending.popLast() {
+            if stored.contains(next) { result.insert(next) }
+            guard !seen.contains(next) else { continue }
+            seen.insert(next)
+            if let further = computed[next] { pending.append(contentsOf: further) }
+        }
+        return result
+    }
+
+    /// Every name referenced in `node`, **including `node` itself**.
+    ///
+    /// The self-inclusion is the whole point, and it was missing. This walked only the children, so
+    /// a caller handing it a bare `DeclReferenceExprSyntax` got back the empty set — the node it
+    /// asked about was the one node never examined.
+    ///
+    /// Every other caller passes a container (an accessor block, an argument list, a closure), for
+    /// which a root that is itself a reference is impossible, so the gap was invisible from all of
+    /// them but one. The exception was `requiresCapture`'s `toggle` check, which passes the base of
+    /// `isExpanded.toggle()` and therefore **never once fired** — `isExpanded = true` was gated and
+    /// `isExpanded.toggle()` was reported, the same mutation under two spellings.
+    ///
+    /// `assignedNames` had already hit this and worked around it in place, re-inserting the
+    /// element's own name after calling here. That workaround is now redundant and is kept only
+    /// because it also handles a member access this function deliberately does not.
+    static func referencedNames(in node: Syntax) -> Set<String> {
+        var names: Set<String> = []
+        insertReference(at: node, into: &names)
+        for child in node.children(viewMode: .sourceAccurate) {
+            names.formUnion(referencedNames(in: child))
+        }
+        return names
+    }
+
+    /// The name `node` refers to, if it refers to one. A member access counts only through
+    /// `self`, because `other.property` is a reference to `other` and not to `property`.
+    static func insertReference(at node: Syntax, into names: inout Set<String>) {
+        if let reference = node.as(DeclReferenceExprSyntax.self) {
+            names.insert(stripped(reference.baseName.text))
+        }
+        if let member = node.as(MemberAccessExprSyntax.self),
+           member.base?.as(DeclReferenceExprSyntax.self)?.baseName.tokenKind
+            == .keyword(.self) {
+            names.insert(member.declName.baseName.text)
+        }
+    }
+
+    /// Whether `type` is a function type, seeing through the wrappers a callback is usually
+    /// declared with.
+    ///
+    /// `() -> Void`, `(() -> Void)?` and `@escaping (Template) -> Void` are all the same thing for
+    /// this purpose, and the corpus writes all three. An optional wraps a *parenthesised* function
+    /// type, which parses as a one-element tuple, so the tuple case is what makes the optional
+    /// spelling work rather than an accident.
+    static func isFunctionType(_ type: TypeSyntax?) -> Bool {
+        guard let type else { return false }
+        if type.is(FunctionTypeSyntax.self) { return true }
+        if let optional = type.as(OptionalTypeSyntax.self) {
+            return isFunctionType(optional.wrappedType)
+        }
+        if let attributed = type.as(AttributedTypeSyntax.self) {
+            return isFunctionType(attributed.baseType)
+        }
+        if let tuple = type.as(TupleTypeSyntax.self), tuple.elements.count == 1,
+           let only = tuple.elements.first {
+            return isFunctionType(only.type)
+        }
+        return false
+    }
+
+    /// `$isExpanded` and `isExpanded` are the same input.
+    ///
+    /// The projected value of a `@State` or `@Binding` parses as its own identifier, so a property
+    /// that writes through `$isExpanded` reads as depending on nothing. That is not academic: a
+    /// `Toggle(_:isOn:)` is the ordinary way to touch that state, and without this every wrapper
+    /// around one looked input-free and fired.
+    static func stripped(_ name: String) -> String {
+        name.hasPrefix("$") ? String(name.dropFirst()) : name
+    }
+
+    static func returnsSomeViewType(_ annotation: TypeAnnotationSyntax?) -> Bool {
+        guard let annotation,
+              let someType = annotation.type.as(SomeOrAnyTypeSyntax.self) else { return false }
+        return someType.constraint.trimmedDescription == "View"
+    }
+}

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift
@@ -32,6 +32,14 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
     /// Computed once per type, because the answer depends on the type's other members.
     private var firingNames: Set<String> = []
 
+    /// The member blocks of every `extension` in the file under analysis, keyed by extended type.
+    ///
+    /// A type's members are routinely spread over `Foo.swift` and `Foo+Sections.swift`, and the
+    /// gate below needs the whole type: a property forwarding to a sibling it cannot see reads as
+    /// depending on *nothing*, which is the strongest possible pass. This closes the half of that
+    /// gap visible from one file; `knownExtensionMembers` closes the other half by declining.
+    private var fileExtensions: [String: [MemberBlockSyntax]] = [:]
+
     required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
         super.init(pattern: pattern, viewMode: viewMode)
     }
@@ -40,12 +48,54 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
         self.currentFilePath = filePath
     }
 
+    /// The file's own extensions, gathered before any type is visited.
+    ///
+    /// `SourceFileSyntax` is the root, so this runs first and `fileExtensions` is populated by the
+    /// time any `struct` or `class` is reached — including one declared after the extension.
+    override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
+        fileExtensions = [:]
+        collectExtensions(in: Syntax(node))
+        return .visitChildren
+    }
+
+    private func collectExtensions(in node: Syntax) {
+        for child in node.children(viewMode: .sourceAccurate) {
+            if let extensionDecl = child.as(ExtensionDeclSyntax.self),
+               let name = ExtensionMemberCollector.extendedTypeName(extensionDecl.extendedType) {
+                fileExtensions[name, default: []].append(extensionDecl.memberBlock)
+            }
+            collectExtensions(in: child)
+        }
+    }
+
+    /// The members of `typeName` this file cannot see: declared in an extension somewhere in the
+    /// project, and not in any extension here.
+    ///
+    /// Empty when no pre-scan ran, which is the right answer for a visitor driven by a unit test —
+    /// one file hides nothing from itself.
+    private func hiddenMembers(of typeName: String) -> Set<String> {
+        let elsewhere = knownExtensionMembers.members(on: typeName)
+        guard !elsewhere.isEmpty else { return [] }
+        let here = (fileExtensions[typeName] ?? [])
+            .reduce(into: Set<String>()) { $0.formUnion(ExtensionMemberCollector.memberNames(in: $1)) }
+        return elsewhere.subtracting(here)
+    }
+
+    /// Every member block that makes up `typeName` in this file: its declaration and its
+    /// same-file extensions.
+    private func memberBlocks(for typeName: String, declaration: MemberBlockSyntax) -> [MemberBlockSyntax] {
+        [declaration] + (fileExtensions[typeName] ?? [])
+    }
+
     // MARK: - Track View-conforming types
 
     override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
         if conformsToView(node.inheritanceClause) || hasBodySomeView(node.memberBlock) {
             isInsideViewType = true
-            firingNames = Self.propertiesWorthExtracting(in: node.memberBlock)
+            firingNames = Self.propertiesWorthExtracting(
+                in: memberBlocks(for: node.name.text, declaration: node.memberBlock),
+                hiddenMembers: hiddenMembers(of: node.name.text)
+            )
         }
         return .visitChildren
     }
@@ -58,7 +108,10 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
     override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
         if conformsToView(node.inheritanceClause) || hasBodySomeView(node.memberBlock) {
             isInsideViewType = true
-            firingNames = Self.propertiesWorthExtracting(in: node.memberBlock)
+            firingNames = Self.propertiesWorthExtracting(
+                in: memberBlocks(for: node.name.text, declaration: node.memberBlock),
+                hiddenMembers: hiddenMembers(of: node.name.text)
+            )
         }
         return .visitChildren
     }
@@ -112,20 +165,57 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
     /// *strict* subset of those stored properties. A property depending on all of them re-renders
     /// exactly when its parent does, so a child struct changes nothing; a type with no stored
     /// properties at all has nothing to narrow, and yields nothing.
-    static func propertiesWorthExtracting(in memberBlock: MemberBlockSyntax) -> Set<String> {
-        let members = properties(of: memberBlock)
+    static func propertiesWorthExtracting(
+        in memberBlocks: [MemberBlockSyntax],
+        hiddenMembers: Set<String> = []
+    ) -> Set<String> {
+        let members = properties(of: memberBlocks)
         guard !members.stored.isEmpty else { return [] }
 
-        let decomposed = namesUsedByDecomposingContainers(in: memberBlock)
+        let decomposed = memberBlocks.reduce(into: Set<String>()) {
+            $0.formUnion(namesUsedByDecomposingContainers(in: $1))
+        }
 
         return members.viewProperties.filter { name in
             guard !decomposed.contains(name),
-                  !requiresCapture(name, in: members) else { return false }
+                  !requiresCapture(name, in: members),
+                  !reachesHiddenMember(name, in: members, hidden: hiddenMembers) else { return false }
             let depends = resolvedDependencies(
                 of: name, computed: members.computedReferences, stored: members.stored
             )
             return depends.isSubset(of: members.stored) && depends.count < members.stored.count
         }
+    }
+
+    /// Whether the property reaches a member declared in an extension this file cannot see.
+    ///
+    /// **The gate's premise is that the dependency set is known**, and for a type split across
+    /// files it is not. Worse, the failure is silent and one-directional: an unseen sibling
+    /// contributes no dependencies, so a property that forwards to one reads as depending on
+    /// nothing — the strongest possible pass. The rule was most confident exactly where it knew
+    /// least.
+    ///
+    /// Measured on SwiftLintRuleStudio: 7 of 20 findings sat in types split across files.
+    /// `RuleAuditView.auditResultsView` composes two extension properties that between them read
+    /// six stored properties and call four instance methods — with the whole type in view the
+    /// capture gate declines it outright.
+    ///
+    /// Followed transitively, for the same reason the other two gates are: a wrapper that forwards
+    /// to a wrapper that forwards to an unseen sibling knows no more than the sibling does.
+    private static func reachesHiddenMember(
+        _ name: String, in members: TypeProperties, hidden: Set<String>
+    ) -> Bool {
+        guard !hidden.isEmpty else { return false }
+        var seen: Set<String> = []
+        var pending = [name]
+
+        while let current = pending.popLast() {
+            guard seen.insert(current).inserted else { continue }
+            let referenced = members.computedReferences[current] ?? []
+            if !referenced.isDisjoint(with: hidden) { return true }
+            pending.append(contentsOf: referenced.filter { members.computedReferences[$0] != nil })
+        }
+        return false
     }
 
     /// Whether extracting this property would force a `Binding` or a capturing closure across the
@@ -223,9 +313,9 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
 
     /// The type's stored inputs, what each computed property references, and which of them return
     /// `some View`.
-    private static func properties(of memberBlock: MemberBlockSyntax) -> TypeProperties {
+    private static func properties(of memberBlocks: [MemberBlockSyntax]) -> TypeProperties {
         var result = TypeProperties()
-        for member in memberBlock.members {
+        for member in memberBlocks.flatMap(\.members) {
             if let function = member.decl.as(FunctionDeclSyntax.self),
                !function.modifiers.contains(where: { $0.name.tokenKind == .keyword(.static) }) {
                 result.instanceMethods.insert(function.name.text)
@@ -258,172 +348,6 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
         if name != "body", returnsSomeViewType(binding.typeAnnotation) {
             result.viewProperties.insert(name)
         }
-    }
-
-    /// APIs that **decompose** the closure they are handed instead of rendering it as one view.
-    ///
-    /// Two families, one argument. `confirmationDialog(actions:)`, `alert(actions:)`,
-    /// `Menu(content:)` and `contextMenu` read a *collection of buttons* out of the builder.
-    /// `ToolbarItem(content:)`, `ToolbarItemGroup(content:)` and `.toolbar` read a *collection of
-    /// toolbar items* out of theirs. In both cases a `View` struct wrapping the contents is a
-    /// container the API is not specified to accept, so "extract this into its own View" is not
-    /// behaviour-preserving — it is the one place where following this rule can change what the app
-    /// does rather than only how it redraws.
-    ///
-    /// The toolbar half is visible in the corpus rather than argued: `ViolationInspectorView`'s
-    /// `navigationButtons` is a `Group` of two `Button`s inside a `ToolbarItemGroup`, which places
-    /// **two** items. Wrapped in a `View` struct it is one view, and the group places **one**.
-    /// `actionsMenu` is worse — an `if` around a `Menu`, so extraction also fixes the item count
-    /// that the condition currently varies.
-    ///
-    /// Deliberately coarse in the same direction as the dialog half: a property that happens to be
-    /// the *only* view in its `ToolbarItem` could be extracted safely, and is spared anyway. A
-    /// spared property costs a finding; a reported one whose extraction drops a toolbar button
-    /// costs a working app.
-    ///
-    /// The dialog half was found on MacCloud_client_iOS, where `FileListView` had three such
-    /// properties and the rule reported all three — marked `info` for carrying `@ViewBuilder`,
-    /// which is not the same thing as declining to report them.
-    private static let decomposingContainers: Set<String> = [
-        "confirmationDialog", "alert", "actionSheet", "Menu", "contextMenu",
-        "ToolbarItem", "ToolbarItemGroup", "toolbar"
-    ]
-
-    /// Property names referenced inside one of those containers.
-    ///
-    /// Only the *arguments and trailing closures* are searched, never the called expression. For a
-    /// modifier the called expression holds the receiver — the entire view it is applied to — and
-    /// walking it would sweep up every name in `body`.
-    ///
-    /// Deliberately coarse in one direction: a name appearing in `alert`'s `message:` closure is
-    /// spared along with the ones in `actions:`. Sparing a property costs a finding; reporting one
-    /// whose extraction breaks a dialog or drops a toolbar button costs a working app, so the
-    /// imprecision is pointed the safe way.
-    private static func namesUsedByDecomposingContainers(in memberBlock: MemberBlockSyntax) -> Set<String> {
-        var found: Set<String> = []
-        collectDecomposedNames(in: Syntax(memberBlock), into: &found)
-        return found
-    }
-
-    private static func collectDecomposedNames(in node: Syntax, into found: inout Set<String>) {
-        for child in node.children(viewMode: .sourceAccurate) {
-            if let call = child.as(FunctionCallExprSyntax.self), isDecomposingContainer(call) {
-                found.formUnion(referencedNames(in: Syntax(call.arguments)))
-                if let trailing = call.trailingClosure {
-                    found.formUnion(referencedNames(in: Syntax(trailing)))
-                }
-                for extra in call.additionalTrailingClosures {
-                    found.formUnion(referencedNames(in: Syntax(extra.closure)))
-                }
-            }
-            collectDecomposedNames(in: child, into: &found)
-        }
-    }
-
-    private static func isDecomposingContainer(_ call: FunctionCallExprSyntax) -> Bool {
-        if let member = call.calledExpression.as(MemberAccessExprSyntax.self) {
-            return decomposingContainers.contains(member.declName.baseName.text)
-        }
-        if let reference = call.calledExpression.as(DeclReferenceExprSyntax.self) {
-            return decomposingContainers.contains(reference.baseName.text)
-        }
-        return false
-    }
-
-    /// The stored properties a computed property reaches, following the type's other computed
-    /// properties. A wrapper that reads nothing itself still depends on whatever it calls.
-    private static func resolvedDependencies(
-        of name: String,
-        computed: [String: Set<String>],
-        stored: Set<String>
-    ) -> Set<String> {
-        var seen: Set<String> = [name]
-        var pending = Array(computed[name] ?? [])
-        var result: Set<String> = []
-
-        while let next = pending.popLast() {
-            if stored.contains(next) { result.insert(next) }
-            guard !seen.contains(next) else { continue }
-            seen.insert(next)
-            if let further = computed[next] { pending.append(contentsOf: further) }
-        }
-        return result
-    }
-
-    /// Every name referenced in `node`, **including `node` itself**.
-    ///
-    /// The self-inclusion is the whole point, and it was missing. This walked only the children, so
-    /// a caller handing it a bare `DeclReferenceExprSyntax` got back the empty set — the node it
-    /// asked about was the one node never examined.
-    ///
-    /// Every other caller passes a container (an accessor block, an argument list, a closure), for
-    /// which a root that is itself a reference is impossible, so the gap was invisible from all of
-    /// them but one. The exception was `requiresCapture`'s `toggle` check, which passes the base of
-    /// `isExpanded.toggle()` and therefore **never once fired** — `isExpanded = true` was gated and
-    /// `isExpanded.toggle()` was reported, the same mutation under two spellings.
-    ///
-    /// `assignedNames` had already hit this and worked around it in place, re-inserting the
-    /// element's own name after calling here. That workaround is now redundant and is kept only
-    /// because it also handles a member access this function deliberately does not.
-    private static func referencedNames(in node: Syntax) -> Set<String> {
-        var names: Set<String> = []
-        insertReference(at: node, into: &names)
-        for child in node.children(viewMode: .sourceAccurate) {
-            names.formUnion(referencedNames(in: child))
-        }
-        return names
-    }
-
-    /// The name `node` refers to, if it refers to one. A member access counts only through
-    /// `self`, because `other.property` is a reference to `other` and not to `property`.
-    private static func insertReference(at node: Syntax, into names: inout Set<String>) {
-        if let reference = node.as(DeclReferenceExprSyntax.self) {
-            names.insert(stripped(reference.baseName.text))
-        }
-        if let member = node.as(MemberAccessExprSyntax.self),
-           member.base?.as(DeclReferenceExprSyntax.self)?.baseName.tokenKind
-            == .keyword(.self) {
-            names.insert(member.declName.baseName.text)
-        }
-    }
-
-    /// Whether `type` is a function type, seeing through the wrappers a callback is usually
-    /// declared with.
-    ///
-    /// `() -> Void`, `(() -> Void)?` and `@escaping (Template) -> Void` are all the same thing for
-    /// this purpose, and the corpus writes all three. An optional wraps a *parenthesised* function
-    /// type, which parses as a one-element tuple, so the tuple case is what makes the optional
-    /// spelling work rather than an accident.
-    private static func isFunctionType(_ type: TypeSyntax?) -> Bool {
-        guard let type else { return false }
-        if type.is(FunctionTypeSyntax.self) { return true }
-        if let optional = type.as(OptionalTypeSyntax.self) {
-            return isFunctionType(optional.wrappedType)
-        }
-        if let attributed = type.as(AttributedTypeSyntax.self) {
-            return isFunctionType(attributed.baseType)
-        }
-        if let tuple = type.as(TupleTypeSyntax.self), tuple.elements.count == 1,
-           let only = tuple.elements.first {
-            return isFunctionType(only.type)
-        }
-        return false
-    }
-
-    /// `$isExpanded` and `isExpanded` are the same input.
-    ///
-    /// The projected value of a `@State` or `@Binding` parses as its own identifier, so a property
-    /// that writes through `$isExpanded` reads as depending on nothing. That is not academic: a
-    /// `Toggle(_:isOn:)` is the ordinary way to touch that state, and without this every wrapper
-    /// around one looked input-free and fired.
-    private static func stripped(_ name: String) -> String {
-        name.hasPrefix("$") ? String(name.dropFirst()) : name
-    }
-
-    private static func returnsSomeViewType(_ annotation: TypeAnnotationSyntax?) -> Bool {
-        guard let annotation,
-              let someType = annotation.type.as(SomeOrAnyTypeSyntax.self) else { return false }
-        return someType.constraint.trimmedDescription == "View"
     }
 
     // MARK: - Helpers

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift
@@ -116,10 +116,10 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
         let members = properties(of: memberBlock)
         guard !members.stored.isEmpty else { return [] }
 
-        let buttonCollections = namesUsedAsButtonCollections(in: memberBlock)
+        let decomposed = namesUsedByDecomposingContainers(in: memberBlock)
 
         return members.viewProperties.filter { name in
-            guard !buttonCollections.contains(name),
+            guard !decomposed.contains(name),
                   !requiresCapture(name, in: members) else { return false }
             let depends = resolvedDependencies(
                 of: name, computed: members.computedReferences, stored: members.stored
@@ -260,22 +260,36 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
         }
     }
 
-    /// APIs whose closure is a **collection of buttons**, not an arbitrary view.
+    /// APIs that **decompose** the closure they are handed instead of rendering it as one view.
     ///
-    /// `confirmationDialog(actions:)`, `alert(actions:)`, `Menu(content:)` and `contextMenu` read
-    /// the buttons out of the builder they are handed. A `View` struct wrapping those buttons is a
-    /// container these APIs are not specified to accept, so "extract this into its own View" is not
-    /// behaviour-preserving here — it is the one place where following this rule can change what
-    /// the app does rather than only how it redraws.
+    /// Two families, one argument. `confirmationDialog(actions:)`, `alert(actions:)`,
+    /// `Menu(content:)` and `contextMenu` read a *collection of buttons* out of the builder.
+    /// `ToolbarItem(content:)`, `ToolbarItemGroup(content:)` and `.toolbar` read a *collection of
+    /// toolbar items* out of theirs. In both cases a `View` struct wrapping the contents is a
+    /// container the API is not specified to accept, so "extract this into its own View" is not
+    /// behaviour-preserving — it is the one place where following this rule can change what the app
+    /// does rather than only how it redraws.
     ///
-    /// Found on MacCloud_client_iOS, where `FileListView` had three such properties and the rule
-    /// reported all three. It marked them `info` for carrying `@ViewBuilder`, which is not the same
-    /// thing as declining to report them.
-    private static let buttonCollectionBuilders: Set<String> = [
-        "confirmationDialog", "alert", "actionSheet", "Menu", "contextMenu"
+    /// The toolbar half is visible in the corpus rather than argued: `ViolationInspectorView`'s
+    /// `navigationButtons` is a `Group` of two `Button`s inside a `ToolbarItemGroup`, which places
+    /// **two** items. Wrapped in a `View` struct it is one view, and the group places **one**.
+    /// `actionsMenu` is worse — an `if` around a `Menu`, so extraction also fixes the item count
+    /// that the condition currently varies.
+    ///
+    /// Deliberately coarse in the same direction as the dialog half: a property that happens to be
+    /// the *only* view in its `ToolbarItem` could be extracted safely, and is spared anyway. A
+    /// spared property costs a finding; a reported one whose extraction drops a toolbar button
+    /// costs a working app.
+    ///
+    /// The dialog half was found on MacCloud_client_iOS, where `FileListView` had three such
+    /// properties and the rule reported all three — marked `info` for carrying `@ViewBuilder`,
+    /// which is not the same thing as declining to report them.
+    private static let decomposingContainers: Set<String> = [
+        "confirmationDialog", "alert", "actionSheet", "Menu", "contextMenu",
+        "ToolbarItem", "ToolbarItemGroup", "toolbar"
     ]
 
-    /// Property names referenced inside one of those builders.
+    /// Property names referenced inside one of those containers.
     ///
     /// Only the *arguments and trailing closures* are searched, never the called expression. For a
     /// modifier the called expression holds the receiver — the entire view it is applied to — and
@@ -283,17 +297,17 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
     ///
     /// Deliberately coarse in one direction: a name appearing in `alert`'s `message:` closure is
     /// spared along with the ones in `actions:`. Sparing a property costs a finding; reporting one
-    /// whose extraction breaks a dialog costs a working app, so the imprecision is pointed the safe
-    /// way.
-    private static func namesUsedAsButtonCollections(in memberBlock: MemberBlockSyntax) -> Set<String> {
+    /// whose extraction breaks a dialog or drops a toolbar button costs a working app, so the
+    /// imprecision is pointed the safe way.
+    private static func namesUsedByDecomposingContainers(in memberBlock: MemberBlockSyntax) -> Set<String> {
         var found: Set<String> = []
-        collectButtonCollectionNames(in: Syntax(memberBlock), into: &found)
+        collectDecomposedNames(in: Syntax(memberBlock), into: &found)
         return found
     }
 
-    private static func collectButtonCollectionNames(in node: Syntax, into found: inout Set<String>) {
+    private static func collectDecomposedNames(in node: Syntax, into found: inout Set<String>) {
         for child in node.children(viewMode: .sourceAccurate) {
-            if let call = child.as(FunctionCallExprSyntax.self), isButtonCollection(call) {
+            if let call = child.as(FunctionCallExprSyntax.self), isDecomposingContainer(call) {
                 found.formUnion(referencedNames(in: Syntax(call.arguments)))
                 if let trailing = call.trailingClosure {
                     found.formUnion(referencedNames(in: Syntax(trailing)))
@@ -302,16 +316,16 @@ class ComputedPropertyViewVisitor: BasePatternVisitor {
                     found.formUnion(referencedNames(in: Syntax(extra.closure)))
                 }
             }
-            collectButtonCollectionNames(in: child, into: &found)
+            collectDecomposedNames(in: child, into: &found)
         }
     }
 
-    private static func isButtonCollection(_ call: FunctionCallExprSyntax) -> Bool {
+    private static func isDecomposingContainer(_ call: FunctionCallExprSyntax) -> Bool {
         if let member = call.calledExpression.as(MemberAccessExprSyntax.self) {
-            return buttonCollectionBuilders.contains(member.declName.baseName.text)
+            return decomposingContainers.contains(member.declName.baseName.text)
         }
         if let reference = call.calledExpression.as(DeclReferenceExprSyntax.self) {
-            return buttonCollectionBuilders.contains(reference.baseName.text)
+            return decomposingContainers.contains(reference.baseName.text)
         }
         return false
     }

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/BasePatternVisitor.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/BasePatternVisitor.swift
@@ -89,6 +89,14 @@ open class BasePatternVisitor: SyntaxVisitor, PatternVisitorProtocol {
 
     public var knownCleanInstanceMethods = CleanInstanceMethodCatalog.empty
 
+    /// Member names each type declares in `extension` blocks, project-wide.
+    ///
+    /// Answers the one question a per-file visitor cannot ask about a type split across files:
+    /// *is there a member here I cannot see?* Built by `ExtensionMemberCatalog.build` in the
+    /// pre-scan. Empty in unit tests that drive a visitor directly, which is correct — a single
+    /// file hides nothing from itself.
+    public var knownExtensionMembers = ExtensionMemberCatalog.empty
+
     /// Functions **this project declares**, as bare names and labelled names (`matches(name:)`).
     /// Built by `DeclaredFunctionCollector` in `ProjectLinter`'s pre-scan.
     ///

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/ExtensionMemberCatalog.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/ExtensionMemberCatalog.swift
@@ -1,0 +1,116 @@
+import SwiftSyntax
+
+/// Per type, the member names declared in `extension` blocks anywhere in the project.
+///
+/// ## Why this exists
+///
+/// A per-file visitor that reasons about *what a type's members read* is only as good as its view
+/// of the type. Swift lets a type's members be spread across files, and this corpus does it
+/// routinely: `RuleAuditView` declares its state in `RuleAuditView.swift` and its subviews in
+/// `RuleAuditView+Subviews.swift`; `ContentView`, `OnboardingView`, `RuleDetailView` and
+/// `ViolationInspectorView` are all split the same way.
+///
+/// `ComputedPropertyViewVisitor` computes each view property's transitive dependency on the type's
+/// stored inputs and reports the ones that read a **strict subset**. When a property forwards to a
+/// sibling the file cannot see, that sibling contributes no dependencies at all — so the property
+/// reads as depending on *nothing*, which is the strongest possible pass of the gate. **The gate
+/// was at its most confident exactly where it knew least.**
+///
+/// Measured on SwiftLintRuleStudio: 7 of the rule's 20 findings there sat in types split across
+/// files. `RuleAuditView.auditResultsView` is the clearest — it composes two extension properties
+/// that between them read six stored properties and call four instance methods, so with the whole
+/// type in view the capture gate declines it outright.
+///
+/// ## What it is not
+///
+/// It carries names, not bodies. That is enough for the only question asked of it — *does this
+/// property reach a member this file cannot see?* — and a "yes" makes the dependency set unknown,
+/// which is not a subset claim the rule can make. Completing the dependency graph across files
+/// would need the bodies too, and no rule has yet needed that.
+///
+/// An empty catalog means no pre-scan ran (a visitor driven straight by a unit test) or the
+/// project declares no extensions. Both are correctly treated as "nothing is hidden": the gate is
+/// a *decline*, so an absent catalog leaves behaviour exactly as it was.
+public struct ExtensionMemberCatalog: Sendable, Equatable {
+
+    private let membersByType: [String: Set<String>]
+
+    /// The catalog a caller with no pre-scan gets: no type has hidden members.
+    public static let empty = Self(membersByType: [:])
+
+    public init(membersByType: [String: Set<String>]) {
+        self.membersByType = membersByType
+    }
+
+    /// Member names declared in any `extension` of `typeName`, project-wide.
+    public func members(on typeName: String) -> Set<String> {
+        membersByType[typeName] ?? []
+    }
+
+    public var isEmpty: Bool { membersByType.isEmpty }
+
+    /// Merges the per-file results of ``ExtensionMemberCollector``.
+    public static func merging(_ collected: [[String: Set<String>]]) -> Self {
+        var merged: [String: Set<String>] = [:]
+        for file in collected {
+            for (typeName, names) in file {
+                merged[typeName, default: []].formUnion(names)
+            }
+        }
+        return Self(membersByType: merged)
+    }
+
+    /// Builds the catalog over every parsed source in the project.
+    public static func build(from sources: [SourceFileSyntax]) -> Self {
+        merging(sources.map { source in
+            let collector = ExtensionMemberCollector(viewMode: .sourceAccurate)
+            collector.walk(source)
+            return collector.membersByType
+        })
+    }
+}
+
+/// Gathers the member names an `extension` block declares, keyed by the extended type.
+///
+/// The key is the extended type's leading identifier, so `extension Array<Int>` and
+/// `extension Array` both key on `Array`. Nested spellings (`extension Outer.Inner`) key on the
+/// last component, which is what a per-file visitor visiting `Inner` has to match against.
+public final class ExtensionMemberCollector: SyntaxVisitor {
+    private(set) var membersByType: [String: Set<String>] = [:]
+
+    override public func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard let name = Self.extendedTypeName(node.extendedType) else { return .visitChildren }
+        membersByType[name, default: []].formUnion(Self.memberNames(in: node.memberBlock))
+        return .visitChildren
+    }
+
+    /// The name an extension extends, or `nil` for a spelling this cannot read.
+    public static func extendedTypeName(_ type: TypeSyntax) -> String? {
+        if let identifier = type.as(IdentifierTypeSyntax.self) {
+            return identifier.name.text
+        }
+        if let member = type.as(MemberTypeSyntax.self) {
+            return member.name.text
+        }
+        return nil
+    }
+
+    /// The `var` and `func` names an extension's body declares. Nested types are not descended
+    /// into: their members belong to the nested type, not to the extended one.
+    public static func memberNames(in memberBlock: MemberBlockSyntax) -> Set<String> {
+        var names: Set<String> = []
+        for member in memberBlock.members {
+            if let function = member.decl.as(FunctionDeclSyntax.self) {
+                names.insert(function.name.text)
+            }
+            if let variable = member.decl.as(VariableDeclSyntax.self) {
+                for binding in variable.bindings {
+                    if let identifier = binding.pattern.as(IdentifierPatternSyntax.self) {
+                        names.insert(identifier.identifier.text)
+                    }
+                }
+            }
+        }
+        return names
+    }
+}

--- a/Tests/CoreTests/Architecture/ArchitectureComputedPropertyViewTests.swift
+++ b/Tests/CoreTests/Architecture/ArchitectureComputedPropertyViewTests.swift
@@ -294,16 +294,21 @@ struct ComputedPropertyViewSubsetGateTests {
     }
 }
 
-/// A property that supplies a dialog's buttons is not extractable into a `View` struct.
+/// A property whose contents a container **decomposes** is not extractable into a `View` struct.
 ///
-/// `confirmationDialog(actions:)`, `alert(actions:)`, `Menu(content:)` and `contextMenu` read the
-/// buttons out of the builder they are handed. Wrapping them in a `View` interposes a container
-/// those APIs are not specified to accept, so following the rule's advice there changes what the
-/// app does rather than only how it redraws — the one place this rule could break something.
+/// `confirmationDialog(actions:)`, `alert(actions:)`, `Menu(content:)` and `contextMenu` read a
+/// collection of buttons out of the builder they are handed; `ToolbarItem`, `ToolbarItemGroup` and
+/// `.toolbar` read a collection of toolbar items out of theirs. Wrapping either in a `View`
+/// interposes a container those APIs are not specified to accept, so following the rule's advice
+/// there changes what the app does rather than only how it redraws — the one place this rule could
+/// break something.
 ///
-/// Found on MacCloud_client_iOS: `FileListView` had three such properties and the rule reported
-/// all three. Lowering them to `info` for carrying `@ViewBuilder` is not the same as declining.
-@Suite("A dialog's buttons are not an extractable subview")
+/// The dialog half was found on MacCloud_client_iOS: `FileListView` had three such properties and
+/// the rule reported all three. Lowering them to `info` for carrying `@ViewBuilder` is not the same
+/// as declining. The toolbar half was found on SwiftLintRuleStudio, where `ViolationInspectorView`
+/// composes five properties into one `ToolbarItemGroup` — one of them a `Group` of two `Button`s,
+/// which places two items and would place one after extraction.
+@Suite("A decomposed container's contents are not an extractable subview")
 struct ComputedPropertyViewButtonCollectionTests {
 
     private func filteredIssues(_ source: String) -> [LintIssue] {
@@ -374,6 +379,87 @@ struct ComputedPropertyViewButtonCollectionTests {
             }
         }
         """).isEmpty)
+    }
+
+    @Test("a toolbar item group's contents are not reported")
+    func toolbarItemGroupContentsAreNotReported() {
+        // `ToolbarItemGroup` places one item per view in its builder. `navigationButtons` is two
+        // buttons and places two; a `View` struct wrapping them is one view and places one. The
+        // shape is SwiftLintRuleStudio's `ViolationInspectorView`, reduced.
+        #expect(filteredIssues("""
+        struct Inspector: View {
+            let title: String
+            @State private var showing = false
+            @ViewBuilder
+            private var navigationButtons: some View {
+                Button("Next") { }
+                Button("Previous") { }
+            }
+            @ToolbarContentBuilder
+            private var toolbarContent: some ToolbarContent {
+                ToolbarItemGroup(placement: .primaryAction) {
+                    navigationButtons
+                }
+            }
+            var body: some View {
+                VStack {
+                    Text(title)
+                    Toggle("", isOn: $showing)
+                }
+                .toolbar { toolbarContent }
+            }
+        }
+        """).isEmpty)
+    }
+
+    @Test("a single toolbar item's content is not reported either")
+    func toolbarItemContentIsNotReported() {
+        // Coarse in the safe direction, exactly as `alert`'s `message:` closure is. This one view
+        // could be extracted without changing the item count, and is spared with the rest.
+        #expect(filteredIssues("""
+        struct Sheet: View {
+            let title: String
+            @State private var query = ""
+            private var searchField: some View {
+                TextField("Search", text: .constant(""))
+            }
+            @ToolbarContentBuilder
+            private var toolbar: some ToolbarContent {
+                ToolbarItem(placement: .primaryAction) { searchField }
+            }
+            var body: some View {
+                Text(title).toolbar { toolbar }
+            }
+        }
+        """).isEmpty)
+    }
+
+    @Test("a property used in body and never in a toolbar is still reported")
+    func nonToolbarSiblingIsStillReported() {
+        // The control. A file containing a toolbar must not go silent on the properties that have
+        // nothing to do with it — the same failure the dialog gate's receiver test guards against.
+        let issues = filteredIssues("""
+        struct Screen: View {
+            let title: String
+            @State private var showing = false
+            private var header: some View { Text("Files") }
+            private var closeButton: some View { Button("Close") { } }
+            @ToolbarContentBuilder
+            private var toolbarContent: some ToolbarContent {
+                ToolbarItem(placement: .cancellationAction) { closeButton }
+            }
+            var body: some View {
+                VStack {
+                    header
+                    Text(title)
+                    Toggle("", isOn: $showing)
+                }
+                .toolbar { toolbarContent }
+            }
+        }
+        """)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("header") == true)
     }
 
     // MARK: - The controls

--- a/Tests/CoreTests/Architecture/ComputedPropertyViewSplitTypeTests.swift
+++ b/Tests/CoreTests/Architecture/ComputedPropertyViewSplitTypeTests.swift
@@ -1,0 +1,209 @@
+@testable import Core
+import Foundation
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftProjectLintVisitors
+import SwiftSyntax
+import Testing
+
+/// A type split across files is a type this rule only partly knows.
+///
+/// The gate reports a property whose transitive dependency on the enclosing view's stored inputs is
+/// a **strict subset** of them. That premise is that the dependency set is known — and for a type
+/// whose members live in `Foo.swift` and `Foo+Sections.swift` it is not. The failure is silent and
+/// runs one way: an unseen sibling contributes no dependencies, so a property forwarding to one
+/// reads as depending on *nothing*, which is the strongest possible pass. **The rule was at its
+/// most confident exactly where it knew least.**
+///
+/// Measured on SwiftLintRuleStudio: 7 of the rule's 20 findings sat in types split across files,
+/// and the pre-scan catalog removed 5 of them (the other 2 reach no unseen member and still fire).
+/// `RuleAuditView.auditResultsView` is the clearest — it composes two extension properties that
+/// between them read six stored properties and call four instance methods, so with the whole type
+/// in view the capture gate declines it outright.
+@Suite("A type split across files is only partly known")
+struct ComputedPropertyViewSplitTypeTests {
+
+    private func filteredIssues(
+        _ source: String,
+        extensionMembers: ExtensionMemberCatalog = .empty
+    ) -> [LintIssue] {
+        let visitor = ComputedPropertyViewVisitor(patternCategory: .architecture)
+        visitor.knownExtensionMembers = extensionMembers
+        let syntax = Parser.parse(source: source)
+        visitor.setSourceLocationConverter(
+            SourceLocationConverter(fileName: "TestFile.swift", tree: syntax)
+        )
+        visitor.setFilePath("TestFile.swift")
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == RuleIdentifier.computedPropertyView }
+    }
+
+    private let forwardingToASibling = """
+    struct Screen: View {
+        let title: String
+        @State private var isBusy = false
+        @State private var showingSheet = false
+        private var results: some View {
+            VStack {
+                summaryCards
+                list
+            }
+        }
+        var body: some View {
+            VStack {
+                results
+                Text(title)
+                Toggle("", isOn: $showingSheet)
+                if isBusy { ProgressView() }
+            }
+        }
+    }
+    """
+
+    @Test("a property forwarding to a member in another file is not reported")
+    func siblingInAnotherFileIsNotReported() {
+        // `summaryCards` and `list` are declared in `Screen+Sections.swift`. Without the catalog
+        // they contribute nothing, so `results` reads as depending on no input at all.
+        let catalog = ExtensionMemberCatalog(membersByType: ["Screen": ["summaryCards", "list"]])
+        #expect(filteredIssues(forwardingToASibling, extensionMembers: catalog).isEmpty)
+    }
+
+    @Test("without the catalog the same property fires, which is the defect")
+    func withoutTheCatalogItFires() {
+        // The control, and the reason the catalog exists. This is what every run of this rule did
+        // before the pre-scan: an unknown dependency set read as an empty one.
+        let issues = filteredIssues(forwardingToASibling)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("results") == true)
+    }
+
+    @Test("an extension in this same file is merged rather than hidden")
+    func sameFileExtensionIsMerged() {
+        // The catalog carries names, not files, so a same-file extension appears in it exactly as
+        // a cross-file one does. The visitor subtracts what it can see; getting that wrong would
+        // silence every type with a same-file extension — a new over-gate introduced by the fix
+        // for an under-gate.
+        //
+        // `results` forwards to `header`, which is right here in the file, so its dependency set
+        // is known and the finding stands.
+        let source = """
+        struct Screen: View {
+            let title: String
+            @State private var isBusy = false
+            private var results: some View { header }
+            var body: some View {
+                VStack {
+                    results
+                    Text(title)
+                    if isBusy { ProgressView() }
+                }
+            }
+        }
+
+        extension Screen {
+            var header: some View { Text(title) }
+        }
+        """
+        let catalog = ExtensionMemberCatalog(membersByType: ["Screen": ["header"]])
+        let issues = filteredIssues(source, extensionMembers: catalog)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("results") == true)
+    }
+
+    @Test("a view property declared in an extension is still not reported")
+    func extensionDeclaredPropertyIsNotItselfReported() {
+        // A standing limit, pinned so it stays a decision. Merging an extension's members feeds
+        // the dependency walk; it does not put the extension's own properties in scope for
+        // reporting, because `isInsideViewType` is set by entering the type declaration. Reporting
+        // them would be a coverage *increase* on a rule this pass is narrowing, and belongs to its
+        // own measurement.
+        let source = """
+        struct Screen: View {
+            let title: String
+            @State private var isBusy = false
+            var body: some View {
+                VStack {
+                    header
+                    Text(title)
+                    if isBusy { ProgressView() }
+                }
+            }
+        }
+
+        extension Screen {
+            var header: some View { Text(title) }
+        }
+        """
+        #expect(filteredIssues(source).isEmpty)
+    }
+
+    @Test("a property that reaches no hidden member is still reported")
+    func unrelatedPropertyIsStillReported() {
+        // The gate has to be per-property, not per-type: a file with one split-off sibling must
+        // not go silent on the properties that never touch it.
+        let source = """
+        struct Screen: View {
+            let title: String
+            @State private var isBusy = false
+            private var caption: some View { Text(title) }
+            private var results: some View { summaryCards }
+            var body: some View {
+                VStack {
+                    caption
+                    results
+                    if isBusy { ProgressView() }
+                }
+            }
+        }
+        """
+        let catalog = ExtensionMemberCatalog(membersByType: ["Screen": ["summaryCards"]])
+        let issues = filteredIssues(source, extensionMembers: catalog)
+        #expect(issues.count == 1)
+        #expect(issues.first?.message.contains("caption") == true)
+    }
+
+    @Test("the reach is transitive")
+    func reachIsTransitive() {
+        // A wrapper forwarding to a wrapper forwarding to an unseen sibling knows no more than the
+        // sibling does — the same transitivity the dependency walk and the capture gate use.
+        let source = """
+        struct Screen: View {
+            let title: String
+            @State private var isBusy = false
+            private var inner: some View { summaryCards }
+            private var outer: some View { inner }
+            var body: some View {
+                VStack {
+                    outer
+                    Text(title)
+                    if isBusy { ProgressView() }
+                }
+            }
+        }
+        """
+        let catalog = ExtensionMemberCatalog(membersByType: ["Screen": ["summaryCards"]])
+        #expect(filteredIssues(source, extensionMembers: catalog).isEmpty)
+    }
+
+    @Test("the catalog collects var and func names per extended type")
+    func catalogCollectsMembers() {
+        let source = """
+        extension Screen {
+            var header: some View { Text("x") }
+            func reload() { }
+            private struct Row: View {
+                var body: some View { Text("row") }
+            }
+        }
+
+        extension Other {
+            var footer: some View { Text("y") }
+        }
+        """
+        let catalog = ExtensionMemberCatalog.build(from: [Parser.parse(source: source)])
+        // `body` belongs to the nested `Row`, not to `Screen`, so it is not collected here.
+        #expect(catalog.members(on: "Screen") == ["header", "reload"])
+        #expect(catalog.members(on: "Other") == ["footer"])
+        #expect(catalog.members(on: "Absent").isEmpty)
+    }
+}

--- a/mutants/README.md
+++ b/mutants/README.md
@@ -21,7 +21,7 @@ Requires a clean working tree.
 
 ## The corpus (`manifest.json`)
 
-All four target the `ExtractableTotalKernelVisitor` — the §15.2.5 "a total kernel is
+Two shapes. The first four target the `ExtractableTotalKernelVisitor` — the §15.2.5 "a total kernel is
 trapped in this impure method; lift it" rule — on both sides of the
 precision/recall line:
 
@@ -59,3 +59,20 @@ corpus shows up as a failing run, never as a passing one.
 
 1. Make the buggy edit; 2. `git diff -- <file> > mutants/patches/<id>.patch`;
 3. `git checkout -- <file>`; 4. add an entry to `manifest.json`.
+
+### The `ComputedPropertyViewVisitor` gates
+
+Three more, added when the rule was worked from 63 findings to 0 across the corpus. All three are
+about a gate rather than about detection: each leaves the rule reporting, and changes only *which*
+properties it declines.
+
+| id | shape | expected | killer |
+|---|---|---|---|
+| `toolbar-not-a-decomposing-container` | detector-precision | killed | `toolbarItemGroupContentsAreNotReported` |
+| `split-type-members-assumed-visible` | detector-precision | killed | `siblingInAnotherFileIsNotReported` |
+| `same-file-extension-treated-as-hidden` | detector-recall | killed | `sameFileExtensionIsMerged` |
+
+The third is the one worth having. It is the over-gate that the *fix* for an under-gate can
+introduce: `hiddenMembers` stops subtracting the extensions visible in the file being analysed, so
+every type with a same-file extension goes silent. Nothing about the rule's output looks wrong —
+it simply reports less — which is the character of every finding in this shape.

--- a/mutants/manifest.json
+++ b/mutants/manifest.json
@@ -1,6 +1,6 @@
 {
   "kind": "spm",
-  "note": "Private mutation/regression corpus for SwiftProjectLint (a SwiftPM monorepo — rules live under Packages/*). Mutants live in a detector's own source; each is killed by the root package's CoreTests. Run via `swift test --filter`. Not a scored benchmark. Target: the ExtractableTotalKernelVisitor (the §15.2.5 'lift the trapped kernel' rule).",
+  "note": "Private mutation/regression corpus for SwiftProjectLint (a SwiftPM monorepo \u2014 rules live under Packages/*). Mutants live in a detector's own source; each is killed by the root package's CoreTests. Run via `swift test --filter`. Not a scored benchmark. Two shapes: the ExtractableTotalKernelVisitor (the \u00a715.2.5 'lift the trapped kernel' rule) and the ComputedPropertyViewVisitor's gates.",
   "mutants": [
     {
       "id": "kernel-governs-always-false",
@@ -8,7 +8,7 @@
       "shape": "detector-recall",
       "expected": "killed",
       "test": "chunkingKernelIsCandidate",
-      "label": "isWorthExtracting's `governs` is forced false — a genuine chunking kernel is never surfaced"
+      "label": "isWorthExtracting's `governs` is forced false \u2014 a genuine chunking kernel is never surfaced"
     },
     {
       "id": "kernel-scans-pure-functions",
@@ -16,7 +16,7 @@
       "shape": "detector-precision",
       "expected": "killed",
       "test": "pureFunctionIsNotReported",
-      "label": "the purity guard is inverted — the rule scans pure functions (which ARE the kernel) instead of the impure methods that trap one"
+      "label": "the purity guard is inverted \u2014 the rule scans pure functions (which ARE the kernel) instead of the impure methods that trap one"
     },
     {
       "id": "kernel-worth-extracting-always-true",
@@ -24,7 +24,7 @@
       "shape": "detector-precision",
       "expected": "killed",
       "test": "arithmeticWithoutAGoverningUseIsNotReported",
-      "label": "isWorthExtracting returns true unconditionally — merely-stored arithmetic (assigned, not governing) is falsely flagged"
+      "label": "isWorthExtracting returns true unconditionally \u2014 merely-stored arithmetic (assigned, not governing) is falsely flagged"
     },
     {
       "id": "kernel-ignores-ambient-state",
@@ -32,7 +32,31 @@
       "shape": "detector-precision",
       "expected": "killed",
       "test": "continuousClockElapsedIsNotAKernel",
-      "label": "the ambient-state guard is removed — a clock read (`ContinuousClock.now - lastActivityAt`) is reported as a kernel that 'depends only on its parameters and locals'"
+      "label": "the ambient-state guard is removed \u2014 a clock read (`ContinuousClock.now - lastActivityAt`) is reported as a kernel that 'depends only on its parameters and locals'"
+    },
+    {
+      "id": "toolbar-not-a-decomposing-container",
+      "patch": "patches/toolbar-not-a-decomposing-container.patch",
+      "shape": "detector-precision",
+      "expected": "killed",
+      "test": "toolbarItemGroupContentsAreNotReported",
+      "label": "the toolbar names are dropped from decomposingContainers \u2014 the rule again advises wrapping a ToolbarItemGroup's two buttons in one View struct, which places one toolbar item where there were two"
+    },
+    {
+      "id": "split-type-members-assumed-visible",
+      "patch": "patches/split-type-members-assumed-visible.patch",
+      "shape": "detector-precision",
+      "expected": "killed",
+      "test": "siblingInAnotherFileIsNotReported",
+      "label": "reachesHiddenMember always returns false \u2014 a property forwarding to a sibling declared in another file reads as depending on nothing, which is the strongest possible pass of the narrowing gate"
+    },
+    {
+      "id": "same-file-extension-treated-as-hidden",
+      "patch": "patches/same-file-extension-treated-as-hidden.patch",
+      "shape": "detector-recall",
+      "expected": "killed",
+      "test": "sameFileExtensionIsMerged",
+      "label": "hiddenMembers stops subtracting the extensions in the file under analysis \u2014 every type with a same-file extension goes silent, an over-gate introduced by the fix for an under-gate"
     }
   ]
 }

--- a/mutants/patches/same-file-extension-treated-as-hidden.patch
+++ b/mutants/patches/same-file-extension-treated-as-hidden.patch
@@ -1,0 +1,14 @@
+diff --git a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift
+--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift
++++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift
+@@ -76,9 +76,7 @@
+     private func hiddenMembers(of typeName: String) -> Set<String> {
+         let elsewhere = knownExtensionMembers.members(on: typeName)
+         guard !elsewhere.isEmpty else { return [] }
+-        let here = (fileExtensions[typeName] ?? [])
+-            .reduce(into: Set<String>()) { $0.formUnion(ExtensionMemberCollector.memberNames(in: $1)) }
+-        return elsewhere.subtracting(here)
++        return elsewhere
+     }
+ 
+     /// Every member block that makes up `typeName` in this file: its declaration and its

--- a/mutants/patches/split-type-members-assumed-visible.patch
+++ b/mutants/patches/split-type-members-assumed-visible.patch
@@ -1,0 +1,12 @@
+diff --git a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift
+--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift
++++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor.swift
+@@ -205,7 +205,7 @@
+     private static func reachesHiddenMember(
+         _ name: String, in members: TypeProperties, hidden: Set<String>
+     ) -> Bool {
+-        guard !hidden.isEmpty else { return false }
++        guard false else { return false }
+         var seen: Set<String> = []
+         var pending = [name]
+ 

--- a/mutants/patches/toolbar-not-a-decomposing-container.patch
+++ b/mutants/patches/toolbar-not-a-decomposing-container.patch
@@ -1,0 +1,13 @@
+diff --git a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor+Gates.swift b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor+Gates.swift
+--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor+Gates.swift
++++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ComputedPropertyViewVisitor+Gates.swift
+@@ -36,8 +36,7 @@
+     /// properties and the rule reported all three — marked `info` for carrying `@ViewBuilder`,
+     /// which is not the same thing as declining to report them.
+     static let decomposingContainers: Set<String> = [
+-        "confirmationDialog", "alert", "actionSheet", "Menu", "contextMenu",
+-        "ToolbarItem", "ToolbarItemGroup", "toolbar"
++        "confirmationDialog", "alert", "actionSheet", "Menu", "contextMenu"
+     ]
+ 
+     /// Property names referenced inside one of those containers.


### PR DESCRIPTION
Two gates on `Computed Property View`, plus their mutants. Both were measured over
the 26-repository corpus before shipping, and both remove findings that were the
rule's fault: **63 → 52**, with 11 declined and nothing newly reported.

The remaining 52 were true. They are refactored or declined in place in the app
repositories, landing today, which is what takes the corpus count to 0.

## What changed

**Gate 2 widened to toolbar containers** (6 findings). `ToolbarItem`,
`ToolbarItemGroup` and `.toolbar` decompose their closure into individual toolbar
items, exactly as `alert(actions:)` reads a collection of buttons. The evidence is
in the corpus rather than argued: `ViolationInspectorView.navigationButtons` is a
`Group` of two `Button`s inside a `ToolbarItemGroup` and places two items — wrapped
in a `View` struct it is one view and places one. Behaviour, not redraws, which is
the line this gate holds.

**Gate 4, new — a type split across files is only partly known** (5 findings).
Gate 1's premise is that the dependency set is known; for `Foo.swift` plus
`Foo+Sections.swift` it is not, and the failure runs one way. An unseen sibling
contributes no dependencies, so a property forwarding to one reads as depending on
*nothing* — the strongest possible pass of the narrowing gate. **The rule was at
its most confident exactly where it knew least.** A new `ExtensionMemberCatalog`
pre-scan records each type's extension members; the visitor merges the ones it can
see and declines only properties whose transitive reach touches the rest.

**Three mutants** (7 total, 7 killed by `mutants/run-mutants.sh`).

## What a reviewer should scrutinise

- **The toolbar gate is coarse on purpose.** A property that is the only view in
  its `ToolbarItem` could be extracted safely and is spared anyway
  (`GraphSheetView.searchField` is the corpus's one instance). That is the same
  trade Gate 2 already makes for `alert`'s `message:` closure, but it is a
  judgement, not a derivation.
- **Whether the catalog over-gates.** It carries names, not files, so a same-file
  extension appears in it exactly as a cross-file one does; the visitor subtracts
  what it can see. Getting that subtraction wrong would silence every type with a
  same-file extension — an over-gate introduced by the fix for an under-gate. That
  is what `same-file-extension-treated-as-hidden` and `sameFileExtensionIsMerged`
  exist to catch, and it is the assumption most worth checking.
- **A latent defect this uncovered but does not fix.**
  `ProjectLinter.configuredDetector` primes a detector with every pre-scan catalog
  and then reads only `.registry` from it, while `analyzeFile` builds a fresh
  detector per file from `FileAnalysisEnvironment`. So a catalog set only in
  `configuredDetector` never reaches a visitor — **`knownCleanInstanceMethods`
  still does not**, and `PureFunctionCandidateVisitor` reads it and always gets
  `.empty`. That is the census rule, so fixing it moves numbers the sweep tracks;
  it belongs in its own pass. The new catalog is wired through both paths.
- **An extension's own view properties are still not reported.** Merging feeds the
  dependency walk only. Reporting them would be a coverage increase on a rule this
  pass narrows, so it is pinned by a test rather than left implicit.

## Checks

`swift test` 3584 passing · `swiftlint` 26 warnings, unchanged from `main` ·
`tools/check-doc-drift.py` clean · `mutants/run-mutants.sh` 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuwumNGy4BgJk7CNm8DV4R