### PR TITLE
Inject the pre-scan catalogs the per-file path was dropping

### DIFF
--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
@@ -203,6 +203,12 @@ extension ProjectLinter {
         /// Per type, the member names its `extension` blocks declare — the pre-scan's answer to
         /// "is part of this type in another file?". See `ExtensionMemberCatalog`.
         let extensionMembers: ExtensionMemberCatalog
+        let cleanInstanceMethods: CleanInstanceMethodCatalog
+
+        /// Which framework allowlists the heuristic effect inferrer applies. `nil` means all of
+        /// them, which is also the visitor's default — so this being dropped was invisible until
+        /// somebody set it.
+        let enabledFrameworkAllowlists: Set<String>?
         let layerPolicies: [LayerPolicy]
     }
 
@@ -235,6 +241,8 @@ extension ProjectLinter {
             impurePackageFunctions: env.impurePackageFunctions,
             defaultedInitializerTypes: env.defaultedInitializerTypes,
             extensionMembers: env.extensionMembers,
+            cleanInstanceMethods: env.cleanInstanceMethods,
+            enabledFrameworkAllowlists: env.enabledFrameworkAllowlists,
             layerPolicies: env.layerPolicies
         )
     }
@@ -263,6 +271,8 @@ extension ProjectLinter {
         impurePackageFunctions: Set<String> = [],
         defaultedInitializerTypes: Set<String> = [],
         extensionMembers: ExtensionMemberCatalog = .empty,
+        cleanInstanceMethods: CleanInstanceMethodCatalog = .empty,
+        enabledFrameworkAllowlists: Set<String>? = nil,
         layerPolicies: [LayerPolicy] = []
     ) -> (file: ProjectFile, issues: [LintIssue], parsedAST: SourceFileSyntax)? {
         guard !Task.isCancelled else { return nil }
@@ -294,6 +304,8 @@ extension ProjectLinter {
         det.knownImpurePackageFunctions = impurePackageFunctions
         det.knownDefaultedInitializerTypes = defaultedInitializerTypes
         det.knownExtensionMembers = extensionMembers
+        det.knownCleanInstanceMethods = cleanInstanceMethods
+        det.enabledFrameworkAllowlists = enabledFrameworkAllowlists
         det.layerPolicies = layerPolicies
 
         let rawIssues: [LintIssue]

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
@@ -127,7 +127,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
                 categories: effectiveRules != nil ? nil : categories,
                 ruleIdentifiers: effectiveRules,
                 collected: collected,
-                layerPolicies: effectiveConfiguration.architecturalLayers
+                configuration: effectiveConfiguration
             )
         )
         var issues = perFile.issues
@@ -334,7 +334,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         categories: [PatternCategory]?,
         ruleIdentifiers: [RuleIdentifier]?,
         collected: CollectedTypes,
-        layerPolicies: [LayerPolicy]
+        configuration: LintConfiguration
     ) -> FileAnalysisEnvironment {
         FileAnalysisEnvironment(
             projectRoot: projectRoot,
@@ -358,7 +358,9 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
             impurePackageFunctions: collected.impurePackageFunctions,
             defaultedInitializerTypes: collected.defaultedInitializers,
             extensionMembers: collected.extensionMembers,
-            layerPolicies: layerPolicies
+            cleanInstanceMethods: collected.cleanInstanceMethods,
+            enabledFrameworkAllowlists: configuration.enabledFrameworkAllowlists,
+            layerPolicies: configuration.architecturalLayers
         )
     }
 

--- a/Tests/CoreTests/Engine/PrescanCatalogInjectionTests.swift
+++ b/Tests/CoreTests/Engine/PrescanCatalogInjectionTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+
+/// Every catalog the pre-scan builds has to reach the visitors that read it.
+///
+/// `ProjectLinter` builds a detector, primes it with every pre-scan catalog, and then reads **one
+/// field** off it:
+///
+/// ```swift
+/// let registry = Self.configuredDetector(detector, collected: …, configuration: …).registry
+/// ```
+///
+/// Every `resolved.knownX = …` in `configuredDetector` goes with the detector. The per-file path
+/// builds a *fresh* `SourcePatternDetector` inside `analyzeFile` and primes it from
+/// `FileAnalysisEnvironment`, so a catalog set only in `configuredDetector` is set nowhere that
+/// matters.
+///
+/// Two were, and nothing noticed. `knownCleanInstanceMethods` — the per-type catalog of sibling
+/// methods that are themselves functions of their inputs, whose own header explains that it exists
+/// *because* a type's methods are spread across files and "is built once in the project pre-scan
+/// and injected" — was built and never injected. `PureFunctionCandidateVisitor` read it and always
+/// got `.empty`. Measured over four repositories when it was wired through: **+93 candidates, 0
+/// lost.** `enabledFrameworkAllowlists` was the same shape and inert only because `nil` (the
+/// visitor's default) happens to mean the same as the config's default; setting the option would
+/// have been silently ignored for every per-file rule.
+///
+/// **No assertion about a rule's output would have caught either.** The linter reports fewer
+/// candidates, correctly formatted, with no error anywhere — the failure is a catalog that is built
+/// and then dropped, which looks exactly like a corpus that has fewer candidates in it.
+///
+/// So this test is structural, in the same spirit as
+/// `UpwardInferenceFileOrderTests.testNoVisitorReadsFileCacheValues`: it reads the two functions'
+/// source and asserts that what one primes, the other primes too. A per-catalog behavioural test
+/// would pin the two instances; this pins the shape.
+@Suite("Every pre-scan catalog reaches the per-file detector")
+struct PrescanCatalogInjectionTests {
+
+    @Test("what configuredDetector primes, analyzeFile primes too")
+    func everyCatalogIsInjectedPerFile() throws {
+        let primedOnce = try assignedFields(
+            in: "Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift",
+            after: "var resolved = detector ?? SourcePatternDetector()",
+            receiver: "resolved."
+        )
+        let primedPerFile = try assignedFields(
+            in: "Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/"
+                + "ProjectLinter+FileAnalysis.swift",
+            after: "let det = SourcePatternDetector(registry: registry)",
+            receiver: "det."
+        )
+
+        // A guard on the reader rather than on the code: if either function is renamed or
+        // restructured this test would otherwise pass by finding nothing.
+        #expect(
+            primedOnce.count >= 15,
+            Comment(rawValue: "found \(primedOnce.count) fields — has configuredDetector moved?")
+        )
+        #expect(
+            primedPerFile.count >= 15,
+            Comment(rawValue: "found \(primedPerFile.count) fields — has analyzeFile moved?")
+        )
+
+        let dropped = primedOnce.subtracting(primedPerFile)
+        let explanation = "primed in configuredDetector and dropped before any visitor sees it: "
+            + "\(dropped.sorted()). Add each to FileAnalysisEnvironment, thread it through both "
+            + "analyzeFile overloads, and assign it beside the others."
+        #expect(dropped.isEmpty, Comment(rawValue: explanation))
+    }
+
+    /// The run of assignments made on `receiver` immediately after `anchor`.
+    ///
+    /// Anchored on the line that creates the detector rather than on the enclosing `func`, because
+    /// `analyzeFile` is overloaded and the convenience wrapper assigns nothing — matching the
+    /// declaration by name found the wrong one and read back an empty set, which is a test that
+    /// passes by looking in the wrong place.
+    private func assignedFields(
+        in relativePath: String, after anchor: String, receiver: String
+    ) throws -> Set<String> {
+        let url = Self.repositoryRoot.appendingPathComponent(relativePath)
+        let text = try String(contentsOf: url, encoding: .utf8)
+        let lines = text.components(separatedBy: "\n")
+        let start = try #require(
+            lines.firstIndex { $0.contains(anchor) },
+            Comment(rawValue: "anchor not found in \(relativePath): \(anchor)")
+        )
+
+        var fields: Set<String> = []
+        for line in lines[(start + 1)...] {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty || trimmed.hasPrefix("//") { continue }
+            guard trimmed.hasPrefix(receiver), let equals = trimmed.firstIndex(of: "=") else {
+                // The assignments are one contiguous run in both functions. The first line that is
+                // not one of them ends it, so a later `det.` write elsewhere cannot creep in.
+                break
+            }
+            let name = trimmed[trimmed.index(trimmed.startIndex, offsetBy: receiver.count)..<equals]
+            fields.insert(name.trimmingCharacters(in: .whitespaces))
+        }
+        return fields
+    }
+
+    private static var repositoryRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // Engine
+            .deletingLastPathComponent()   // CoreTests
+            .deletingLastPathComponent()   // Tests
+            .deletingLastPathComponent()   // repository root
+    }
+}

--- a/mutants/README.md
+++ b/mutants/README.md
@@ -76,3 +76,20 @@ The third is the one worth having. It is the over-gate that the *fix* for an und
 introduce: `hiddenMembers` stops subtracting the extensions visible in the file being analysed, so
 every type with a same-file extension goes silent. Nothing about the rule's output looks wrong —
 it simply reports less — which is the character of every finding in this shape.
+
+### Engine wiring
+
+One mutant in a third shape, and the only one here that is not about a detector's
+judgement at all.
+
+| id | shape | expected | killer |
+|---|---|---|---|
+| `prescan-catalog-built-then-dropped` | engine-wiring | killed | `everyCatalogIsInjectedPerFile` |
+
+It removes one assignment, so a catalog the pre-scan spent real time building never
+reaches the visitor that reads it. **Nothing about the output looks wrong** — the linter
+reports fewer property-test candidates, correctly formatted, with no error anywhere, which
+is indistinguishable from a corpus that has fewer candidates in it. That is why its killer
+is a structural test over the two functions' source rather than an assertion about any
+finding: it is the one bug shape in this corpus that no assertion about a rule's output
+could catch.

--- a/mutants/manifest.json
+++ b/mutants/manifest.json
@@ -57,6 +57,14 @@
       "expected": "killed",
       "test": "sameFileExtensionIsMerged",
       "label": "hiddenMembers stops subtracting the extensions in the file under analysis \u2014 every type with a same-file extension goes silent, an over-gate introduced by the fix for an under-gate"
+    },
+    {
+      "id": "prescan-catalog-built-then-dropped",
+      "patch": "patches/prescan-catalog-built-then-dropped.patch",
+      "shape": "engine-wiring",
+      "expected": "killed",
+      "test": "everyCatalogIsInjectedPerFile",
+      "label": "the pre-scan's clean-instance-method catalog is built and then never assigned to the per-file detector \u2014 the linter reports fewer property-test candidates, correctly formatted, with no error anywhere"
     }
   ]
 }

--- a/mutants/patches/prescan-catalog-built-then-dropped.patch
+++ b/mutants/patches/prescan-catalog-built-then-dropped.patch
@@ -1,0 +1,11 @@
+diff --git a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
+--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
++++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
+@@ -304,7 +304,6 @@
+         det.knownImpurePackageFunctions = impurePackageFunctions
+         det.knownDefaultedInitializerTypes = defaultedInitializerTypes
+         det.knownExtensionMembers = extensionMembers
+-        det.knownCleanInstanceMethods = cleanInstanceMethods
+         det.enabledFrameworkAllowlists = enabledFrameworkAllowlists
+         det.layerPolicies = layerPolicies
+ 


### PR DESCRIPTION
Two catalogs the pre-scan spends real time building never reached the visitors
that read them. Found while wiring a third one for #180, where I flagged it and
left it; this is the measurement I owed and the fix.

## The shape

`ProjectLinter` builds a detector, primes it with every pre-scan catalog, and then
reads **one field** off it:

```swift
let registry = Self.configuredDetector(detector, collected: …, configuration: …).registry
```

Every `resolved.knownX = …` in `configuredDetector` goes with the detector. The
per-file path builds a *fresh* `SourcePatternDetector` inside `analyzeFile` and
primes it from `FileAnalysisEnvironment`, so a catalog set only in
`configuredDetector` is set nowhere that matters. Comparing the two assignment
lists: eighteen fields in one, sixteen in the other.

**`knownCleanInstanceMethods`** is the per-type catalog of sibling methods that
are themselves functions of their inputs. Its own header explains that it exists
*because* a type's methods are spread across files, and that it "is built once in
the project pre-scan and injected". It was built and never injected —
`PureFunctionCandidateVisitor` read it and always got `.empty`, so every candidate
composing a sibling call stayed refused. That is the exact refusal the catalog was
written to lift.

**`enabledFrameworkAllowlists`** is the same shape, and inert only by luck: `nil`
is the visitor's default and means "all frameworks", which is also the config's
default. Setting the option would have been silently ignored for every per-file
rule. It still reaches cross-file visitors, which is why nothing looked broken.

## Measured

Twelve repositories, the ones holding ~97% of the census. Same binary pair, same
sources, run twice:

| repository | before | after | delta |
|---|---:|---:|---:|
| SwiftInferProperties | 2017 | 2028 | +11 |
| SwiftProjectLint | 531 | 584 | **+53** |
| SwiftAssist | 300 | 321 | +21 |
| SwiftPropertyLaws | 282 | 284 | +2 |
| SwiftUMLStudio | 227 | 236 | +9 |
| SwiftLintRuleStudio | 223 | 231 | +8 |
| pbt-workbook-corpus | 179 | 180 | +1 |
| pbt-book | 138 | 138 | 0 |
| SwiftFormatRuleStudio | 114 | 115 | +1 |
| SwiftMarkdownWiki | 82 | 83 | +1 |
| SwiftLintRuleStudioTeam | 78 | 78 | 0 |
| SwiftEffectInference | 75 | 88 | +13 |
| **total** | **4246** | **4366** | **+120 (2.8%)** |

**Nothing was lost anywhere.** Spot-checking the eight gained on
SwiftLintRuleStudio: `findSimilarRuleId(_:in:)`, a function of its two parameters
whose only call is to `levenshteinDistance`; `extractRationale(from:)`, a function
of its string calling two siblings. Both were refused for calling a sibling.

## What a reviewer should scrutinise

- **This moves a number the sweep tracks.** Every census figure on the sweep page
  was measured with these catalogs dead, so the next run's rise is partly a
  measurement change and not a code change. That is the whole reason this is its
  own PR with the delta stated, rather than folded into #180.
- **The guard is structural, and that is a choice.** No assertion about a rule's
  output would have caught this: the linter reports fewer candidates, correctly
  formatted, with no error anywhere — indistinguishable from a corpus that has
  fewer candidates in it. `everyCatalogIsInjectedPerFile` reads both functions'
  source and asserts that what one primes, the other primes too. It is in the same
  spirit as `testNoVisitorReadsFileCacheValues`, and it is brittle to renaming in
  the same way — hence the `count >= 15` guards, so it fails loudly rather than
  passing by finding nothing.
- **I verified it fails on the unfixed code**, naming exactly
  `["enabledFrameworkAllowlists", "knownCleanInstanceMethods"]`. A test asserting
  a set difference is empty passes for any reason, including reading the wrong
  function — which it did on the first attempt, because `analyzeFile` is
  overloaded and the convenience wrapper assigns nothing. It is now anchored on
  the line that creates the detector.
- **`makeEnvironment` takes the configuration** rather than two more scalars,
  because adding them directly pushed it past `function_parameter_count` — and
  both values were already fields of the same configuration. That is a small
  refactor riding along; say if you would rather it did not.

## Checks

`swift test` 3585 passing · `swiftlint` 26 warnings, byte-identical to `main` ·
`tools/check-doc-drift.py` clean · `mutants/run-mutants.sh` **8/8**, including a
new `engine-wiring` shape whose mutant removes the assignment this PR adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuwumNGy4BgJk7CNm8DV4R