### PR TITLE
Concrete Type Usage: four exemptions from one pass of applying it

### DIFF
--- a/Docs/rules/concrete-type-usage.md
+++ b/Docs/rules/concrete-type-usage.md
@@ -23,8 +23,90 @@ The following patterns are exempt because they do not represent real coupling is
 - **Enum types** — a project-wide pre-scan identifies all declared enums; enum-typed parameters and properties are exempt because enums are value types and cannot be protocol-abstracted in the same way as a service class
 - **Actor types** — a project-wide pre-scan identifies all declared actors; actor-typed parameters and properties are exempt because an actor's serial-executor isolation contract is load-bearing in Swift 6 strict concurrency. Protocol-abstracting an actor strips that contract from every call site — the caller loses the compiler-enforced `await` requirement and the guarantee of serialized access
 - **Init parameters mirroring a flagged stored property** — when a stored property is flagged, its matching initializer parameter represents the same coupling point and is suppressed to avoid duplicate reports
+- **AppKit and UIKit classes** — recognised by the `NS`/`UI` prefix convention rather than enumerated, and only when the project does not declare a type of that name
+- **`private` / `fileprivate` types** — a protocol around one could only be conformed to in the file that declares it
+- **Closure wrapper types** — a `struct` or `final class` whose only stored property is a closure is already the seam
+- **`Equatable` types** — a value is substituted by constructing a different one
 
 Replacing `APIService` with `APIServiceProtocol` — or using `some NetworkProtocol` — resolves the issue.
+
+### Four exemptions added after one pass of applying the rule
+
+The rule ran at 41 findings across ten repositories. Reading all of them found four shapes where
+the advice has no reachable end state, and **`ConcreteTypeUsage` had reported every one of them
+while its own twin already knew better about two.** Each was measured over the corpus before
+shipping; together they took the rule **41 → 22**, with nothing else moving.
+
+#### AppKit and UIKit classes (7)
+
+The system-type list above is hand-maintained because Swift 3 dropped the `NS` prefix from
+Foundation, so there is no convention left to read `FileManager` and `URLSession` off. AppKit and
+UIKit kept theirs, so their classes can be recognised by the rule that generates them rather than
+added one name per sweep.
+
+`NSLayoutManager` is a system type in exactly the sense `FileManager` is; it was reported only
+because nobody had hit it before. And most of the corpus's instances are worse than merely
+unabstractable — they are **parameters of protocol requirements**, where the signature is not the
+author's to change at all: a `UIImagePickerControllerDelegate` callback, an
+`NSLayoutManagerDelegate` glyph hook, a `UIViewControllerRepresentable`'s `updateUIViewController`.
+
+**Restricted to `NS` and `UI` deliberately.** The obvious generalisation — every Apple two-letter
+prefix — is refuted by this corpus: `CLIToolCommandRunner` begins with `CL` followed by an
+uppercase letter, so a CoreLocation prefix would have silenced it for a reason that has nothing to
+do with why it should be silent. That case is pinned as a test. The gate is also paired with
+`knownLocalTypeNames`, so a project declaring its own `UIStateManager` keeps the finding: **the
+declaration decides, not the spelling.**
+
+#### `private` and `fileprivate` types (1)
+
+No caller outside the declaring file can name the type, so a protocol around it could only ever be
+conformed to there and no test could supply an alternative conformer. Taking the advice means
+*widening* the access level in order to abstract it.
+
+**`DirectInstantiation` has had this exemption for two sweeps.** The two rules fire on the same
+seam from opposite ends — the construction site and the declared type — and this was the third
+vocabulary one had and the other did not, after `ServiceTypeSuffix` and `MockTypeName`. The walk
+now lives in `FileLocalTypeCollector`, shared, which is the only thing that stops a fourth.
+
+The shape it reaches is the single-use accumulator: `ToolInvocation`'s `private struct Builder`,
+eight optional fields and no methods, filled by a parsing loop and read once by the initializer
+that owns it.
+
+#### Closure wrapper types (8)
+
+A `typealias` for a function type has been exempt for a while, on the reasoning that a property
+typed with it is injected by handing in another closure. The same argument holds for the nominal
+form, and the corpus prefers the nominal form:
+
+```swift
+public struct DateProvider: Sendable {
+    private let make: @Sendable () -> Date
+    public static let system = Self { Date() }
+    public var now: Date { make() }
+}
+```
+
+A test substitutes it by writing `DateProvider { fixedInstant }` — the same substitution the alias
+offers, plus a named production default the alias cannot carry.
+
+**These are seams this sweep itself asked for.** `DateProvider` and `IDProvider` exist because
+*Non-Injected Nondeterminism* reported the inline clock and id reads they replaced; its own header
+says *"this one is the seam they were moved to"*. Reporting them asked a reader to undo a repair
+the same sweep had requested, one rule over.
+
+Exactly one stored property, and it must be function-typed. `static` members are factories over the
+type rather than its content, and computed properties are not storage — `var now: Date { make() }`
+is the wrapper's whole point and must not disqualify it. Two closures is a small protocol wearing a
+struct, and the advice starts being worth hearing again.
+
+#### `Equatable` types (2)
+
+A value is substituted by constructing a different one. Nothing in this corpus that is genuinely a
+dependency conforms — a service is identified, not compared — so what the suffix list catches
+instead are records that merely *end* in a service word:
+`struct EnumCaseGenerator: Sendable, Equatable { let caseName: String }` describes an enum case and
+generates nothing. `Hashable` and `Comparable` both refine `Equatable`, so the existing prescan
+covers all three spellings and the inline and `extension` forms alike.
 
 ### Non-Violating Examples
 ```swift
@@ -93,8 +175,24 @@ class MyViewModel {
   reported: the declaration that would exempt it is out of scope. Measured — `CLIToolCommandRunner`
   is exempt inside LintStudioUI, which declares it, and still flagged in SwiftLintRuleStudio, which
   imports it. Same boundary as `unused-protocol-abstraction`'s, for the same reason.
-- **A value type used as a seam still reads as concrete.** A `struct DateProvider` wrapping a
-  closure is an injection point, but the rule sees a concrete nominal type and asks for a protocol.
-  That is advice worth refusing rather than a defect the rule can detect.
+- **~~A value type used as a seam still reads as concrete.~~** Closed by the closure-wrapper
+  exemption above. The limitation was recorded as *"advice worth refusing rather than a defect the
+  rule can detect"* — which was wrong on the second half. It is detectable, by the same prescan
+  shape the function-`typealias` exemption already used, and the entry stood for two sweeps because
+  nobody asked whether the nominal form of an exempt shape was also exempt.
+
+- **A stateless, effect-free type is still reported.** Seven of the remaining findings name a type
+  that holds nothing a test could not supply: `PromptBuilder` and `ThinkingAnalyzer` have no stored
+  properties at all, and `EffectAnnotationParser` stores only a value struct of attribute-name sets
+  it is meant to be reconfigured with. Asking for a protocol in front of a pure function is the
+  opposite of what this sweep is for.
+
+  This is **SwiftProjectLint#163**, filed against `DirectInstantiation` and applying equally here.
+  The discriminator is stated there and both cheap approximations are already refuted by
+  measurement: *value type* is wrong (`CacheManager` is a struct doing file I/O) and *no-argument
+  initializer* is wrong (`AntiPatternStore()` talks to disk). The real test needs the purity oracle
+  the project already runs — `PackagePurityJoin` and `CleanInstanceMethodCatalog` — and no rule
+  consults it. Deliberately not built here: it is a fourth prescan and it belongs to that issue's
+  scope rather than to a pass of applying this rule.
 
 ---

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
@@ -203,6 +203,7 @@ extension ProjectLinter {
         /// Per type, the member names its `extension` blocks declare — the pre-scan's answer to
         /// "is part of this type in another file?". See `ExtensionMemberCatalog`.
         let extensionMembers: ExtensionMemberCatalog
+        let closureWrapperTypes: ClosureWrapperTypeCatalog
         let cleanInstanceMethods: CleanInstanceMethodCatalog
 
         /// Which framework allowlists the heuristic effect inferrer applies. `nil` means all of
@@ -241,6 +242,7 @@ extension ProjectLinter {
             impurePackageFunctions: env.impurePackageFunctions,
             defaultedInitializerTypes: env.defaultedInitializerTypes,
             extensionMembers: env.extensionMembers,
+            closureWrapperTypes: env.closureWrapperTypes,
             cleanInstanceMethods: env.cleanInstanceMethods,
             enabledFrameworkAllowlists: env.enabledFrameworkAllowlists,
             layerPolicies: env.layerPolicies
@@ -271,6 +273,7 @@ extension ProjectLinter {
         impurePackageFunctions: Set<String> = [],
         defaultedInitializerTypes: Set<String> = [],
         extensionMembers: ExtensionMemberCatalog = .empty,
+        closureWrapperTypes: ClosureWrapperTypeCatalog = .empty,
         cleanInstanceMethods: CleanInstanceMethodCatalog = .empty,
         enabledFrameworkAllowlists: Set<String>? = nil,
         layerPolicies: [LayerPolicy] = []
@@ -304,6 +307,7 @@ extension ProjectLinter {
         det.knownImpurePackageFunctions = impurePackageFunctions
         det.knownDefaultedInitializerTypes = defaultedInitializerTypes
         det.knownExtensionMembers = extensionMembers
+        det.knownClosureWrapperTypes = closureWrapperTypes
         det.knownCleanInstanceMethods = cleanInstanceMethods
         det.enabledFrameworkAllowlists = enabledFrameworkAllowlists
         det.layerPolicies = layerPolicies

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
@@ -250,6 +250,10 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         /// only part of the type — see `ExtensionMemberCatalog`.
         let extensionMembers: ExtensionMemberCatalog
 
+        /// Value types whose whole content is one closure — already a seam. See
+        /// `ClosureWrapperTypeCatalog`.
+        let closureWrapperTypes: ClosureWrapperTypeCatalog
+
         /// Package function names this project's own purity oracle refutes with an
         /// establishable witness — the one-hop callee join. Needs parsed bodies for the
         /// same reason `cleanInstanceMethods` does, and shares the single parse below.
@@ -292,6 +296,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
                 underscoredMembers: collectTypes(UnderscoredMemberCollector.self, from: filePaths),
                 cleanInstanceMethods: CleanInstanceMethodCatalog.build(from: parsed),
                 extensionMembers: ExtensionMemberCatalog.build(from: parsed),
+                closureWrapperTypes: ClosureWrapperTypeCatalog.build(from: parsed),
                 impurePackageFunctions: PackagePurityJoin(sources: parsed).settledImpureNames
             )
         }
@@ -319,6 +324,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
         resolved.knownValueTypes = collected.values
         resolved.knownCleanInstanceMethods = collected.cleanInstanceMethods
         resolved.knownExtensionMembers = collected.extensionMembers
+        resolved.knownClosureWrapperTypes = collected.closureWrapperTypes
         resolved.knownImpurePackageFunctions = collected.impurePackageFunctions
         resolved.knownProjectFunctions = collected.functions
         resolved.knownDefaultedInitializerTypes = collected.defaultedInitializers
@@ -358,6 +364,7 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
             impurePackageFunctions: collected.impurePackageFunctions,
             defaultedInitializerTypes: collected.defaultedInitializers,
             extensionMembers: collected.extensionMembers,
+            closureWrapperTypes: collected.closureWrapperTypes,
             cleanInstanceMethods: collected.cleanInstanceMethods,
             enabledFrameworkAllowlists: configuration.enabledFrameworkAllowlists,
             layerPolicies: configuration.architecturalLayers

--- a/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetector.swift
+++ b/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetector.swift
@@ -39,6 +39,7 @@ public final class SourcePatternDetector: SourcePatternDetectorProtocol, @unchec
     public var knownSPIMembers: Set<String> = []
     public var knownUnderscoredMembers: Set<String> = []
     public var knownExtensionMembers = ExtensionMemberCatalog.empty
+    public var knownClosureWrapperTypes = ClosureWrapperTypeCatalog.empty
 
     public var knownFunctionTypeAliases: Set<String> = []
 
@@ -206,6 +207,7 @@ public final class SourcePatternDetector: SourcePatternDetectorProtocol, @unchec
             visitor.knownSPIMembers = knownSPIMembers
             visitor.knownUnderscoredMembers = knownUnderscoredMembers
             visitor.knownExtensionMembers = knownExtensionMembers
+            visitor.knownClosureWrapperTypes = knownClosureWrapperTypes
             visitor.knownFunctionTypeAliases = knownFunctionTypeAliases
             visitor.knownIdentifiableTypes = knownIdentifiableTypes
             visitor.knownEnumTypes = knownEnumTypes

--- a/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetectorProtocol.swift
+++ b/Packages/SwiftProjectLintRegistry/Sources/SwiftProjectLintRegistry/SourcePatternDetectorProtocol.swift
@@ -40,6 +40,7 @@ public protocol SourcePatternDetectorProtocol {
     var knownSPIMembers: Set<String> { get set }
     var knownUnderscoredMembers: Set<String> { get set }
     var knownExtensionMembers: ExtensionMemberCatalog { get set }
+    var knownClosureWrapperTypes: ClosureWrapperTypeCatalog { get set }
 
     var knownFunctionTypeAliases: Set<String> { get set }
 

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ConcreteTypeUsageVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ConcreteTypeUsageVisitor.swift
@@ -19,13 +19,50 @@ class ConcreteTypeUsageVisitor: BasePatternVisitor {
     /// Whether the visitor is currently inside an initializer body.
     private var isInsideInitializer: Bool = false
 
+    /// Names of the types this file declares `private` or `fileprivate`, gathered in one pass
+    /// before any finding is reported. No project-wide prescan is needed and none would help:
+    /// a file-local type is unreachable outside its own file, so the declaration is always here
+    /// if it is anywhere.
+    private var fileLocalTypes: Set<String> = []
+
     /// Foundation / system types that are concrete by design and cannot
     /// reasonably be protocol-abstracted.
+    ///
+    /// Hand-maintained because Swift 3 dropped the `NS` prefix from Foundation, so there is no
+    /// convention left to read these off. `appKitOrUIKitPrefixes` covers the two frameworks that
+    /// kept theirs.
     private static let systemConcreteTypes: Set<String> = [
         "FileManager", "NotificationCenter", "UserDefaults",
         "URLSession", "ProcessInfo", "Bundle",
         "UNUserNotificationCenter", "NSWorkspace"
     ]
+
+    /// AppKit and UIKit kept their prefixes, so their class names can be recognised by
+    /// convention rather than enumerated.
+    ///
+    /// This is the list above, expressed as the rule that generates it. `NSLayoutManager` is a
+    /// system type of exactly the kind `FileManager` is; it was reported only because nobody had
+    /// hit it before and added it by hand. Growing a list one name per sweep is the arbitrary
+    /// half of the choice this rule already refuses elsewhere.
+    ///
+    /// **Restricted to `NS` and `UI` deliberately.** The obvious generalisation — every Apple
+    /// two-letter prefix — is refuted by this corpus: `CLIToolCommandRunner` begins with `CL`
+    /// followed by an uppercase letter, so a `CoreLocation` prefix would have silenced it for a
+    /// reason that has nothing to do with why it should be silent. Two prefixes cover every
+    /// instance the corpus has; the rest can be added when something needs them.
+    ///
+    /// Paired with `knownLocalTypeNames`, so a project that declares its own `UIStateManager`
+    /// keeps the finding. The declaration is what decides, not the spelling.
+    private static let appKitOrUIKitPrefixes = ["NS", "UI"]
+
+    private func isPlatformFrameworkType(_ name: String) -> Bool {
+        guard !knownLocalTypeNames.contains(name) else { return false }
+        return Self.appKitOrUIKitPrefixes.contains { prefix in
+            name.count > prefix.count
+                && name.hasPrefix(prefix)
+                && name[name.index(name.startIndex, offsetBy: prefix.count)].isUppercase
+        }
+    }
 
     /// Type-name suffixes that indicate a DI container or composition root,
     /// where holding concrete types is the whole point.
@@ -40,6 +77,15 @@ class ConcreteTypeUsageVisitor: BasePatternVisitor {
 
     override func setFilePath(_ filePath: String) {
         self.currentFilePath = filePath
+    }
+
+    // MARK: - File-local access-level pre-pass
+
+    override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
+        let collector = FileLocalTypeCollector(viewMode: .sourceAccurate)
+        collector.walk(node)
+        fileLocalTypes = collector.names
+        return .visitChildren
     }
 
     // MARK: - Scope tracking
@@ -124,6 +170,12 @@ class ConcreteTypeUsageVisitor: BasePatternVisitor {
     }
 
     /// Returns the name if it's service-like and not a protocol indicator, else nil.
+    ///
+    /// The exemptions are a table rather than a ladder of `if`s. They grew past
+    /// `cyclomatic_complexity` when the seam gates were added, and a ladder of nine independent
+    /// early returns has no ordering to read anyway — every one of them is "this is not a
+    /// concrete dependency", and none depends on another having run first. Each reason carries
+    /// the argument for it, because the argument is the part worth keeping.
     private func qualifying(_ name: String) -> String? {
         guard name.first?.isUppercase == true,
               ServiceTypeSuffix.matches(name),
@@ -132,43 +184,102 @@ class ConcreteTypeUsageVisitor: BasePatternVisitor {
               !name.hasSuffix("Interface")
         else { return nil }
 
-        // A `typealias` for a function type is already the seam. `CLIToolCommandRunner =
-        // @Sendable ([String], Data?) async throws -> (Data, Data, Int32)` is a closure: a
-        // property typed with it is injected by handing in another closure, which is what a
-        // test does. Asking for a protocol around it replaces a working seam with a heavier
-        // one. Requires the project-wide typealias prescan.
-        if knownFunctionTypeAliases.contains(name) { return nil }
+        let exempt = exemptions.contains { $0.applies(name) }
+        return exempt ? nil : name
+    }
 
-        // System types that are concrete by design
-        if Self.systemConcreteTypes.contains(name) { return nil }
+    /// One reason a service-like name is not a concrete dependency.
+    private struct Exemption {
+        let applies: (String) -> Bool
+    }
 
-        // Mock/stub/fake types. Shared with `DirectInstantiation` via `MockTypeName`.
-        if MockTypeName.matches(name) { return nil }
+    private var exemptions: [Exemption] {
+        [
+            // A `typealias` for a function type is already the seam. `CLIToolCommandRunner =
+            // @Sendable ([String], Data?) async throws -> (Data, Data, Int32)` is a closure: a
+            // property typed with it is injected by handing in another closure, which is what a
+            // test does. Asking for a protocol around it replaces a working seam with a heavier
+            // one. Requires the project-wide typealias prescan.
+            Exemption { self.knownFunctionTypeAliases.contains($0) },
 
-        // Enum types — value types that cannot meaningfully be protocol-abstracted
-        // in the same way as a service class. Requires the project-wide enum prescan.
-        if knownEnumTypes.contains(name) { return nil }
+            // Foundation types that are concrete by design.
+            Exemption { Self.systemConcreteTypes.contains($0) },
 
-        // Actor types — their isolation contract is load-bearing in Swift 6 strict
-        // concurrency. Protocol-abstracting an actor loses the serial executor guarantee
-        // at every call site. Requires the project-wide actor prescan.
-        if knownActorTypes.contains(name) { return nil }
+            // AppKit / UIKit classes, recognised by the prefix convention rather than by name.
+            // `NSLayoutManager` and `UIImagePickerController` are system types in exactly the
+            // sense the list above means, and most of the corpus's instances are worse than
+            // merely unabstractable: they are parameters of protocol requirements — a
+            // `UIImagePickerControllerDelegate` callback, a `UIViewControllerRepresentable`'s
+            // `updateUIViewController` — where the signature is not the author's to change.
+            Exemption { self.isPlatformFrameworkType($0) },
 
-        // @Observable / ObservableObject types — protocol-abstracting a SwiftUI
-        // observation model severs change tracking: through `any SomeProtocol` the view
-        // can no longer see the concrete observable storage and stops re-rendering. The
-        // concrete type is load-bearing. Requires the project-wide observable prescan.
-        if knownObservableTypes.contains(name) { return nil }
+            // Mock/stub/fake types. Shared with `DirectInstantiation` via `MockTypeName`.
+            Exemption { MockTypeName.matches($0) },
 
-        // Protocol types — already an abstraction. A protocol used as a bare
-        // existential (`let provider: ResourceMetricsProvider`) is not a concrete
-        // dependency, but the name-based check above only recognises the
-        // `Protocol`/`Type`/`Interface` naming conventions. The project-wide protocol
-        // prescan catches the rest, so we don't tell users to "prefer a protocol
-        // abstraction" for something that already is one.
-        if knownProtocolTypes.contains(name) { return nil }
+            // Enum types — value types that cannot meaningfully be protocol-abstracted in the
+            // same way as a service class. Requires the project-wide enum prescan.
+            Exemption { self.knownEnumTypes.contains($0) },
 
-        return name
+            // Actor types — their isolation contract is load-bearing in Swift 6 strict
+            // concurrency. Protocol-abstracting an actor loses the serial executor guarantee at
+            // every call site. Requires the project-wide actor prescan.
+            Exemption { self.knownActorTypes.contains($0) },
+
+            // @Observable / ObservableObject types — protocol-abstracting a SwiftUI observation
+            // model severs change tracking: through `any SomeProtocol` the view can no longer see
+            // the concrete observable storage and stops re-rendering. The concrete type is
+            // load-bearing. Requires the project-wide observable prescan.
+            Exemption { self.knownObservableTypes.contains($0) },
+
+            // A `private` or `fileprivate` type cannot be substituted: no caller outside the file
+            // that declares it can name the type, so a protocol around it could only ever be
+            // conformed to there, and no test could supply an alternative conformer. Taking the
+            // advice would mean *widening* the access level in order to abstract it — exporting
+            // an implementation detail to make it substitutable, which is the opposite trade from
+            // the one the rule offers.
+            //
+            // `DirectInstantiation` — this rule's twin, firing on the same seam from the
+            // construction site rather than the declared type — has had this exemption since the
+            // shape was found there. The two share `ServiceTypeSuffix` and `MockTypeName` for the
+            // same reason and after the same kind of mistake; this was the third vocabulary one
+            // of them had and the other did not, which is why the walk now lives in
+            // `FileLocalTypeCollector` rather than in either.
+            //
+            // The shape it reaches is the single-use accumulator: `ToolInvocation`'s
+            // `private struct Builder`, eight optional fields and no methods, filled by a parsing
+            // loop and read once by the initializer that owns it.
+            Exemption { self.fileLocalTypes.contains($0) },
+
+            // A value type whose whole content is one closure is already the seam, exactly as a
+            // `typealias` for a function type is. `struct DateProvider { let make: () -> Date }`
+            // is substituted by handing in another closure — `DateProvider { fixedInstant }` —
+            // and its own header says so: *"this one is the seam they were moved to"*. Asking for
+            // a protocol around it replaces a working seam with a heavier one, and would undo the
+            // repair `Non-Injected Nondeterminism` asked for in the first place.
+            //
+            // The nominal form is if anything better than the alias: it can carry named
+            // factories, and `DateProvider.system` is the one place in its package allowed to
+            // read a clock. Requires the project-wide closure-wrapper prescan.
+            Exemption { self.knownClosureWrapperTypes.contains($0) },
+
+            // An `Equatable` type is a value, and a value is substituted by constructing a
+            // different one. Nothing in this corpus that is genuinely a dependency conforms:
+            // a service is identified, not compared. What the suffix list catches instead are
+            // records that merely *end* in a service word —
+            // `struct EnumCaseGenerator: Sendable, Equatable { let caseName: String }` describes
+            // an enum case and generates nothing; `ComposedGenerator` wraps a plan value.
+            //
+            // `Hashable` and `Comparable` both refine `Equatable`, so the prescan's set already
+            // covers all three spellings and the inline and `extension` forms alike.
+            Exemption { self.knownEquatableTypes.contains($0) },
+
+            // Protocol types — already an abstraction. A protocol used as a bare existential
+            // (`let provider: ResourceMetricsProvider`) is not a concrete dependency, but the
+            // name-based check above only recognises the `Protocol`/`Type`/`Interface` naming
+            // conventions. The project-wide protocol prescan catches the rest, so we don't tell
+            // users to "prefer a protocol abstraction" for something that already is one.
+            Exemption { self.knownProtocolTypes.contains($0) }
+        ]
     }
 
     // MARK: - Property wrapper detection

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/DirectInstantiationVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/DirectInstantiationVisitor.swift
@@ -145,7 +145,7 @@ class DirectInstantiationVisitor: BasePatternVisitor {
     // MARK: - File-local access-level pre-pass
 
     override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
-        let collector = PrivateTypeDeclarationCollector(viewMode: .sourceAccurate)
+        let collector = FileLocalTypeCollector(viewMode: .sourceAccurate)
         collector.walk(node)
         privatelyDeclaredTypes = collector.names
         if isMainSwiftFile { insideEntryPoint += 1 }
@@ -474,45 +474,6 @@ class DirectInstantiationVisitor: BasePatternVisitor {
     /// function rather than the condition written twice.
     private static func isDebugBlock(_ node: IfConfigDeclSyntax) -> Bool {
         node.clauses.contains { $0.condition?.description.contains("DEBUG") == true }
-    }
-}
-
-/// Collects the names of every type a single file declares `private` or `fileprivate`.
-///
-/// A separate walk rather than bookkeeping inside the main visit, because the declaration can
-/// follow the use: `AmbientStateReads.occur` builds its `Checker` on line 26 and the
-/// `private final class Checker` sits on line 34, so a visitor that learned the access level
-/// as it went would have already reported the construction by the time it read the
-/// declaration.
-private final class PrivateTypeDeclarationCollector: SyntaxVisitor {
-
-    private(set) var names: Set<String> = []
-
-    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-        record(node.name.text, node.modifiers)
-        return .visitChildren
-    }
-
-    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-        record(node.name.text, node.modifiers)
-        return .visitChildren
-    }
-
-    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-        record(node.name.text, node.modifiers)
-        return .visitChildren
-    }
-
-    override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
-        record(node.name.text, node.modifiers)
-        return .visitChildren
-    }
-
-    private func record(_ name: String, _ modifiers: DeclModifierListSyntax) {
-        let isFileLocal = modifiers.contains {
-            $0.name.tokenKind == .keyword(.private) || $0.name.tokenKind == .keyword(.fileprivate)
-        }
-        if isFileLocal { names.insert(name) }
     }
 }
 

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/FileLocalTypeCollector.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/FileLocalTypeCollector.swift
@@ -1,0 +1,47 @@
+import SwiftSyntax
+
+/// Collects the names of every type a single file declares `private` or `fileprivate`.
+///
+/// A separate walk rather than bookkeeping inside the main visit, because the declaration can
+/// follow the use: `AmbientStateReads.occur` builds its `Checker` on line 26 and the
+/// `private final class Checker` sits on line 34, so a visitor that learned the access level
+/// as it went would have already reported the construction by the time it read the
+/// declaration.
+///
+/// **Shared by `DirectInstantiation` and `ConcreteTypeUsage`**, which fire on the same seam from
+/// opposite ends — the construction site and the declared type. This is the third vocabulary the
+/// two have had to be told about separately: `ServiceTypeSuffix` was the first and `MockTypeName`
+/// the second, and each time the rule that lacked it reported something its twin already knew was
+/// not a finding. Keeping the walk here rather than in one of them is the only thing that stops a
+/// fourth.
+final class FileLocalTypeCollector: SyntaxVisitor {
+
+    private(set) var names: Set<String> = []
+
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+        record(node.name.text, node.modifiers)
+        return .visitChildren
+    }
+
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        record(node.name.text, node.modifiers)
+        return .visitChildren
+    }
+
+    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+        record(node.name.text, node.modifiers)
+        return .visitChildren
+    }
+
+    override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+        record(node.name.text, node.modifiers)
+        return .visitChildren
+    }
+
+    private func record(_ name: String, _ modifiers: DeclModifierListSyntax) {
+        let isFileLocal = modifiers.contains {
+            $0.name.tokenKind == .keyword(.private) || $0.name.tokenKind == .keyword(.fileprivate)
+        }
+        if isFileLocal { names.insert(name) }
+    }
+}

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/BasePatternVisitor.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/BasePatternVisitor.swift
@@ -97,6 +97,11 @@ open class BasePatternVisitor: SyntaxVisitor, PatternVisitorProtocol {
     /// file hides nothing from itself.
     public var knownExtensionMembers = ExtensionMemberCatalog.empty
 
+    /// Value types whose entire content is a single closure — already an injection seam.
+    /// Built by `ClosureWrapperTypeCatalog.build` in the pre-scan; empty in unit tests that
+    /// drive a visitor directly, which correctly reads as "nothing is a closure wrapper".
+    public var knownClosureWrapperTypes = ClosureWrapperTypeCatalog.empty
+
     /// Functions **this project declares**, as bare names and labelled names (`matches(name:)`).
     /// Built by `DeclaredFunctionCollector` in `ProjectLinter`'s pre-scan.
     ///

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/ClosureWrapperTypeCollector.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/ClosureWrapperTypeCollector.swift
@@ -1,0 +1,124 @@
+import SwiftSyntax
+
+/// Collects value types whose entire content is a single closure — the nominal spelling of a
+/// function `typealias`, and an injection seam already.
+///
+/// ## Why this exists
+///
+/// `ConcreteTypeUsage` already exempts a property typed with a function `typealias`:
+/// `CLIToolCommandRunner = @Sendable ([String]) async throws -> Data` names a closure, so a
+/// property typed with it is injected by handing in another closure, and asking for a protocol
+/// around it replaces a working seam with a heavier one.
+///
+/// The same argument holds for the nominal form, and the corpus prefers the nominal form:
+///
+/// ```swift
+/// public struct DateProvider: Sendable {
+///     private let make: @Sendable () -> Date
+///     public static let system = Self { Date() }
+/// }
+/// ```
+///
+/// A test substitutes it by writing `DateProvider { fixedInstant }`. That is the same
+/// substitution the alias offers, plus something the alias cannot do: a named production
+/// default, which is why `DateProvider.system` can be *the one place in its package allowed to
+/// read a clock*.
+///
+/// **These are seams the sweep itself asked for.** `DateProvider` and `IDProvider` exist because
+/// `Non-Injected Nondeterminism` reported the inline clock and id reads they replaced. Reporting
+/// the replacement as a concrete dependency asks a reader to undo the repair — the two rules
+/// disagreeing about the same line, one run apart.
+///
+/// ## What counts
+///
+/// A `struct` or `final class` with **exactly one stored property**, whose declared type is a
+/// function type. Computed properties are not stored and do not count; neither do `static`
+/// members, which is what lets a type carry `.system` and `.random` factories and still qualify.
+///
+/// Deliberately strict. Two closures is a small protocol wearing a struct, and the advice starts
+/// being worth hearing again; one is a named closure.
+public struct ClosureWrapperTypeCatalog: Sendable, Equatable {
+
+    private let names: Set<String>
+
+    /// The catalog a caller with no pre-scan gets: nothing is a closure wrapper, so behaviour
+    /// matches the rule as it was before the catalog existed.
+    public static let empty = Self(names: [])
+
+    public init(names: Set<String>) {
+        self.names = names
+    }
+
+    public func contains(_ name: String) -> Bool { names.contains(name) }
+
+    public var isEmpty: Bool { names.isEmpty }
+
+    /// Builds the catalog over every parsed source in the project.
+    public static func build(from sources: [SourceFileSyntax]) -> Self {
+        var found: Set<String> = []
+        for source in sources {
+            let collector = ClosureWrapperTypeCollector(viewMode: .sourceAccurate)
+            collector.walk(source)
+            found.formUnion(collector.names)
+        }
+        return Self(names: found)
+    }
+}
+
+/// Walks one file for the shape ``ClosureWrapperTypeCatalog`` describes.
+public final class ClosureWrapperTypeCollector: SyntaxVisitor {
+
+    private(set) var names: Set<String> = []
+
+    override public func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        record(node.name.text, node.memberBlock)
+        return .visitChildren
+    }
+
+    override public func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+        // A non-final class can be subclassed, which is a substitution route of its own; the
+        // exemption is about types that offer no route but the closure.
+        let isFinal = node.modifiers.contains { $0.name.tokenKind == .keyword(.final) }
+        if isFinal { record(node.name.text, node.memberBlock) }
+        return .visitChildren
+    }
+
+    private func record(_ name: String, _ memberBlock: MemberBlockSyntax) {
+        var storedTypes: [TypeSyntax] = []
+        for member in memberBlock.members {
+            guard let variable = member.decl.as(VariableDeclSyntax.self) else { continue }
+            // A `static` member is not the type's content — it is a factory over it, and
+            // `DateProvider.system` is exactly why one has to be allowed.
+            if variable.modifiers.contains(where: { $0.name.tokenKind == .keyword(.static) }) {
+                continue
+            }
+            for binding in variable.bindings {
+                // Computed properties are not storage. `var now: Date { make() }` is the
+                // wrapper's whole point and must not disqualify it.
+                guard binding.accessorBlock == nil,
+                      let type = binding.typeAnnotation?.type else { continue }
+                storedTypes.append(type)
+            }
+        }
+        guard storedTypes.count == 1, Self.isFunctionType(storedTypes[0]) else { return }
+        names.insert(name)
+    }
+
+    /// Whether `type` is a function type, seeing through the wrappers a closure is declared
+    /// with. An optional wraps a *parenthesised* function type, which parses as a one-element
+    /// tuple, so the tuple case is what makes the optional spelling work.
+    static func isFunctionType(_ type: TypeSyntax) -> Bool {
+        if type.is(FunctionTypeSyntax.self) { return true }
+        if let attributed = type.as(AttributedTypeSyntax.self) {
+            return isFunctionType(attributed.baseType)
+        }
+        if let optional = type.as(OptionalTypeSyntax.self) {
+            return isFunctionType(optional.wrappedType)
+        }
+        if let tuple = type.as(TupleTypeSyntax.self), tuple.elements.count == 1,
+           let only = tuple.elements.first {
+            return isFunctionType(only.type)
+        }
+        return false
+    }
+}

--- a/Tests/CoreTests/Architecture/ConcreteTypeUsageSeamTests.swift
+++ b/Tests/CoreTests/Architecture/ConcreteTypeUsageSeamTests.swift
@@ -1,0 +1,257 @@
+@testable import Core
+import Foundation
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftProjectLintVisitors
+import SwiftSyntax
+import Testing
+
+/// A type that is already a seam must not be asked to become one.
+///
+/// Two shapes, both of which the rule used to report and both of which its own exemptions already
+/// covered in another spelling.
+///
+/// **A value type whose whole content is one closure** is the nominal form of a function
+/// `typealias`, which this rule has exempted for a while. `struct DateProvider { let make: () ->
+/// Date }` is substituted by writing `DateProvider { fixedInstant }`. Worse than merely redundant:
+/// `DateProvider` and `IDProvider` *exist because* `Non-Injected Nondeterminism` reported the
+/// inline clock and id reads they replaced, so reporting them asks a reader to undo a repair the
+/// same sweep asked for, one run apart.
+///
+/// **A `private` or `fileprivate` type** cannot be substituted at all: no caller outside the file
+/// can name it, so a protocol around it could only be conformed to in that same file. Taking the
+/// advice means *widening* the access level in order to abstract it. `DirectInstantiation` — this
+/// rule's twin, firing on the same seam from the construction site — has had that exemption since
+/// the shape was found there, and the two now share the walk that finds it.
+@Suite("A type that is already a seam is not asked to become one")
+struct ConcreteTypeUsageSeamTests {
+
+    private func issues(
+        _ source: String,
+        wrappers: ClosureWrapperTypeCatalog = .empty,
+        localTypes: Set<String> = [],
+        equatableTypes: Set<String> = []
+    ) -> [LintIssue] {
+        let visitor = ConcreteTypeUsageVisitor(patternCategory: .architecture)
+        visitor.knownClosureWrapperTypes = wrappers
+        visitor.knownLocalTypeNames = localTypes
+        visitor.knownEquatableTypes = equatableTypes
+        let syntax = Parser.parse(source: source)
+        visitor.setSourceLocationConverter(
+            SourceLocationConverter(fileName: "Subject.swift", tree: syntax)
+        )
+        visitor.setFilePath("Subject.swift")
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == RuleIdentifier.concreteTypeUsage }
+    }
+
+    /// The closure-wrapper catalog one source file yields.
+    private func catalog(_ source: String) -> ClosureWrapperTypeCatalog {
+        let parsed = [Parser.parse(source: source)]
+        return ClosureWrapperTypeCatalog.build(from: parsed)
+    }
+
+    // MARK: - The closure wrapper
+
+    private let providerSource = """
+    struct DateProvider: Sendable {
+        private let make: @Sendable () -> Date
+        init(_ make: @escaping @Sendable () -> Date) { self.make = make }
+        static let system = Self { Date() }
+        var now: Date { make() }
+    }
+
+    final class Analyzer {
+        let now: DateProvider
+        init(now: DateProvider) { self.now = now }
+    }
+    """
+
+    @Test("a property typed with a closure wrapper is not reported")
+    func closureWrapperIsNotReported() {
+        let built = catalog(providerSource)
+        #expect(built.contains("DateProvider"))
+        #expect(issues(providerSource, wrappers: built).isEmpty)
+    }
+
+    @Test("without the catalog the same property fires, which is the defect")
+    func withoutTheCatalogItFires() {
+        // The control, and what every run before this one did. A test asserting a filtered list is
+        // empty passes for any reason, including a visitor that reported nothing at all.
+        let found = issues(providerSource)
+        #expect(found.count == 1)
+        #expect(found.first?.message.contains("DateProvider") == true)
+    }
+
+    @Test("a static factory and a computed property do not disqualify a wrapper")
+    func factoriesAndComputedPropertiesAreNotStorage() {
+        // `static let system` is a factory over the type, not its content, and `var now: Date`
+        // is the wrapper's whole point. Counting either as a stored property would have made
+        // every real instance of this shape fail to qualify — which is exactly what a first,
+        // cruder version of the detector did.
+        let built = catalog(providerSource)
+        #expect(built.contains("DateProvider"))
+    }
+
+    @Test("two closures is not a wrapper")
+    func twoClosuresIsNotAWrapper() {
+        // Deliberately strict: two closures is a small protocol wearing a struct, and the advice
+        // starts being worth hearing again.
+        let built = catalog("""
+        struct EditingService: Sendable {
+            let load: @Sendable () -> Data
+            let save: @Sendable (Data) -> Void
+        }
+        """)
+        #expect(!built.contains("EditingService"))
+    }
+
+    @Test("a struct holding a value is not a wrapper")
+    func aValueHolderIsNotAWrapper() {
+        let built = catalog("""
+        struct SnapshotManager { let root: URL }
+        """)
+        #expect(!built.contains("SnapshotManager"))
+    }
+
+    @Test("a non-final class is not a wrapper")
+    func openClassIsNotAWrapper() {
+        // A subclass is a substitution route of its own, so the exemption — which is about types
+        // offering no route but the closure — does not apply.
+        let built = catalog("""
+        class DiffLoader { let load: () -> Data }
+        """)
+        #expect(!built.contains("DiffLoader"))
+    }
+
+    // MARK: - The file-local type
+
+    @Test("a private type is not reported")
+    func privateTypeIsNotReported() {
+        // `ToolInvocation`'s accumulator, reduced. No caller outside this file can name `Builder`,
+        // so a protocol around it has nowhere to be conformed to.
+        #expect(issues("""
+        struct ToolInvocation {
+            private struct Builder {
+                var target: String?
+                var outputPath: String?
+            }
+            private init(builder: Builder) throws { }
+        }
+        """).isEmpty)
+    }
+
+    @Test("the declaration may follow the use")
+    func declarationMayFollowTheUse() {
+        // The reason this is a pre-pass rather than bookkeeping as the walk goes: the parameter
+        // is read before the declaration that exempts it.
+        #expect(issues("""
+        struct Owner {
+            private init(builder: Builder) throws { }
+        }
+
+        private struct Builder {
+            var target: String?
+        }
+        """).isEmpty)
+    }
+
+    @Test("an internal type of the same shape is still reported")
+    func internalTypeIsStillReported() {
+        // The control. Drop `private` and the advice becomes reachable again — a caller in another
+        // file can name the type, so a protocol has somewhere to be conformed to.
+        let found = issues("""
+        struct Owner {
+            init(builder: Builder) throws { }
+        }
+
+        struct Builder {
+            var target: String?
+        }
+        """)
+        #expect(found.count == 1)
+        #expect(found.first?.message.contains("Builder") == true)
+    }
+
+    // MARK: - The platform framework type
+
+    @Test("an AppKit or UIKit class is not reported")
+    func platformFrameworkTypeIsNotReported() {
+        // `LiveMarkdownTextEditor.Coordinator`, reduced: the parameter list of an
+        // `NSLayoutManagerDelegate` requirement, which is not the author's to change.
+        #expect(issues("""
+        final class Coordinator: NSObject, NSLayoutManagerDelegate {
+            func layoutManager(_ manager: NSLayoutManager, shouldGenerateGlyphs count: Int) -> Int {
+                count
+            }
+        }
+        """).isEmpty)
+
+        // And `CameraView`, whose `updateUIViewController` is a `UIViewControllerRepresentable`
+        // requirement — same impossibility, a different protocol.
+        #expect(issues("""
+        struct CameraView: UIViewControllerRepresentable {
+            func updateUIViewController(_ picker: UIImagePickerController, context: Context) { }
+        }
+        """).isEmpty)
+    }
+
+    @Test("a project type with a platform prefix is still reported")
+    func locallyDeclaredPrefixedTypeIsStillReported() {
+        // The declaration decides, not the spelling. A project writing its own `UIStateManager`
+        // keeps the finding, which is why the gate consults `knownLocalTypeNames` rather than
+        // trusting two letters.
+        let found = issues("""
+        final class Screen {
+            let state: UIStateManager
+            init(state: UIStateManager) { self.state = state }
+        }
+        """, localTypes: ["UIStateManager"])
+        #expect(found.count == 1)
+        #expect(found.first?.message.contains("UIStateManager") == true)
+    }
+
+    @Test("a CoreLocation-shaped prefix is not treated as a platform type")
+    func twoLetterPrefixCollisionIsPinned() {
+        // The obvious generalisation of this gate — every Apple two-letter prefix — is refuted by
+        // this corpus. `CLIToolCommandRunner` is `CL` followed by an uppercase letter and has
+        // nothing to do with CoreLocation; a wider prefix set would silence it for a reason
+        // unrelated to why it should be silent. Pinned so widening cannot happen quietly.
+        let found = issues("""
+        final class Bridge {
+            let bridgedRunner: CLIToolCommandRunner
+            init(bridgedRunner: CLIToolCommandRunner) { self.bridgedRunner = bridgedRunner }
+        }
+        """)
+        #expect(found.count == 1)
+        #expect(found.first?.message.contains("CLIToolCommandRunner") == true)
+    }
+
+    // MARK: - The value record
+
+    @Test("an Equatable type is a value, not a dependency")
+    func equatableTypeIsNotReported() {
+        // `EnumCaseGenerator` describes an enum case and generates nothing; it is caught by the
+        // suffix list and by nothing else. A value is substituted by constructing a different
+        // one, which is what its memberwise initializer is for.
+        #expect(issues("""
+        struct Derivation {
+            func render(enumCase: EnumCaseGenerator) -> String { "" }
+        }
+        """, equatableTypes: ["EnumCaseGenerator"]).isEmpty)
+    }
+
+    @Test("a non-Equatable type of the same name is still reported")
+    func nonEquatableIsStillReported() {
+        // The control. Nothing in the corpus that is genuinely a dependency conforms to
+        // `Equatable` — a service is identified, not compared — so the conformance is the whole
+        // of the signal and its absence has to restore the finding.
+        let found = issues("""
+        struct Derivation {
+            func render(enumCase: EnumCaseGenerator) -> String { "" }
+        }
+        """)
+        #expect(found.count == 1)
+        #expect(found.first?.message.contains("EnumCaseGenerator") == true)
+    }
+}

--- a/mutants/README.md
+++ b/mutants/README.md
@@ -93,3 +93,21 @@ is indistinguishable from a corpus that has fewer candidates in it. That is why 
 is a structural test over the two functions' source rather than an assertion about any
 finding: it is the one bug shape in this corpus that no assertion about a rule's output
 could catch.
+
+### The `ConcreteTypeUsage` seam exemptions
+
+Two more, from the pass that took that rule 41 → 22. Both are **recall** mutants: they widen or
+narrow an exemption so the rule reports *more*, which is the direction nobody checks. A gate that
+stops exempting looks exactly like a corpus that grew.
+
+| id | shape | expected | killer |
+|---|---|---|---|
+| `platform-prefix-set-widened` | detector-recall | killed | `twoLetterPrefixCollisionIsPinned` |
+| `computed-property-counts-as-storage` | detector-recall | killed | `closureWrapperIsNotReported` |
+
+The first is the generalisation that looks obviously right and is refuted by this corpus: every
+Apple two-letter prefix, which silences `CLIToolCommandRunner` because it begins `CL` followed by an
+uppercase letter. The second is subtler — counting a computed property as storage makes
+`var now: Date { make() }` disqualify the very type the exemption was written for, so the catalog
+comes back empty and every finding returns. A first, cruder version of the detector did exactly
+that.

--- a/mutants/manifest.json
+++ b/mutants/manifest.json
@@ -65,6 +65,22 @@
       "expected": "killed",
       "test": "everyCatalogIsInjectedPerFile",
       "label": "the pre-scan's clean-instance-method catalog is built and then never assigned to the per-file detector \u2014 the linter reports fewer property-test candidates, correctly formatted, with no error anywhere"
+    },
+    {
+      "id": "platform-prefix-set-widened",
+      "patch": "patches/platform-prefix-set-widened.patch",
+      "shape": "detector-recall",
+      "expected": "killed",
+      "test": "twoLetterPrefixCollisionIsPinned",
+      "label": "the AppKit/UIKit prefix set grows to every Apple two-letter prefix \u2014 CLIToolCommandRunner begins CL + uppercase and goes silent for a reason unrelated to why it should be silent"
+    },
+    {
+      "id": "computed-property-counts-as-storage",
+      "patch": "patches/computed-property-counts-as-storage.patch",
+      "shape": "detector-recall",
+      "expected": "killed",
+      "test": "closureWrapperIsNotReported",
+      "label": "the closure-wrapper collector counts computed properties as storage \u2014 `var now: Date { make() }` is the wrapper's whole point, so every real instance stops qualifying and the exemption reaches nothing"
     }
   ]
 }

--- a/mutants/patches/computed-property-counts-as-storage.patch
+++ b/mutants/patches/computed-property-counts-as-storage.patch
@@ -1,0 +1,13 @@
+diff --git a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/ClosureWrapperTypeCollector.swift b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/ClosureWrapperTypeCollector.swift
+--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/ClosureWrapperTypeCollector.swift
++++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/ClosureWrapperTypeCollector.swift
+@@ -95,8 +95,7 @@
+             for binding in variable.bindings {
+                 // Computed properties are not storage. `var now: Date { make() }` is the
+                 // wrapper's whole point and must not disqualify it.
+-                guard binding.accessorBlock == nil,
+-                      let type = binding.typeAnnotation?.type else { continue }
++                guard let type = binding.typeAnnotation?.type else { continue }
+                 storedTypes.append(type)
+             }
+         }

--- a/mutants/patches/platform-prefix-set-widened.patch
+++ b/mutants/patches/platform-prefix-set-widened.patch
@@ -1,0 +1,12 @@
+diff --git a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ConcreteTypeUsageVisitor.swift b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ConcreteTypeUsageVisitor.swift
+--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ConcreteTypeUsageVisitor.swift
++++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ConcreteTypeUsageVisitor.swift
+@@ -53,7 +53,7 @@
+     ///
+     /// Paired with `knownLocalTypeNames`, so a project that declares its own `UIStateManager`
+     /// keeps the finding. The declaration is what decides, not the spelling.
+-    private static let appKitOrUIKitPrefixes = ["NS", "UI"]
++    private static let appKitOrUIKitPrefixes = ["NS", "UI", "CL", "CG", "AV"]
+ 
+     private func isPlatformFrameworkType(_ name: String) -> Bool {
+         guard !knownLocalTypeNames.contains(name) else { return false }

--- a/mutants/patches/prescan-catalog-built-then-dropped.patch
+++ b/mutants/patches/prescan-catalog-built-then-dropped.patch
@@ -1,10 +1,10 @@
 diff --git a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
 --- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
 +++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
-@@ -304,7 +304,6 @@
-         det.knownImpurePackageFunctions = impurePackageFunctions
+@@ -308,7 +308,6 @@
          det.knownDefaultedInitializerTypes = defaultedInitializerTypes
          det.knownExtensionMembers = extensionMembers
+         det.knownClosureWrapperTypes = closureWrapperTypes
 -        det.knownCleanInstanceMethods = cleanInstanceMethods
          det.enabledFrameworkAllowlists = enabledFrameworkAllowlists
          det.layerPolicies = layerPolicies


### PR DESCRIPTION
One pass of reading all 41 findings across ten repositories. Four shapes came out
of it where the advice has **no reachable end state**, and the rule had reported
every one of them. **41 → 22**, measured over the corpus with the binary built
either side of each gate, and nothing else moved.

## The four

| shape | findings | why the advice cannot be taken |
|---|---:|---|
| `private` / `fileprivate` type | 1 | a protocol around it could only be conformed to in the declaring file |
| AppKit / UIKit class | 7 | a system type, and mostly a parameter of a protocol requirement |
| closure wrapper | 8 | already the seam; substituted by handing in another closure |
| `Equatable` type | 2 | a value, substituted by constructing a different one |

**The `private` one is the third vocabulary these twins have kept separately.**
`DirectInstantiation` and `ConcreteTypeUsage` fire on the same seam from opposite
ends and have twice been found holding separate copies of the same knowledge —
`ServiceTypeSuffix`, then `MockTypeName`, each time after the rule that lacked it
reported something its twin already knew was not a finding. The walk now lives in
`FileLocalTypeCollector` rather than being imported from one visitor into the
other, which is the arrangement that stops a fourth.

**The closure wrappers are seams this sweep itself asked for.** `DateProvider` and
`IDProvider` exist because *Non-Injected Nondeterminism* reported the inline clock
and id reads they replaced; `DateProvider`'s own header reads *"this one is the
seam they were moved to"*. Reporting them asked a reader to undo a repair the same
sweep had requested, one rule over.

## What a reviewer should scrutinise

- **The `NS`/`UI` prefix set, which is the only gate here that reads a name rather
  than a declaration.** The obvious generalisation — every Apple two-letter prefix
  — is refuted by this corpus: `CLIToolCommandRunner` begins `CL` followed by an
  uppercase letter, so a CoreLocation prefix would silence it for a reason
  unrelated to why it should be silent. That case is pinned as a test *and* as a
  mutant, so widening the set cannot happen quietly. The gate is also paired with
  `knownLocalTypeNames`: a project declaring its own `UIStateManager` keeps the
  finding, because the declaration decides and not the spelling.
- **"Exactly one stored property" for the closure wrapper is doing real work.**
  `static` members are factories over the type rather than its content, and
  computed properties are not storage — `var now: Date { make() }` is the
  wrapper's whole point. A cruder first version counted both and the catalog came
  back empty; that is the second mutant.
- **The `Equatable` gate rests on a claim about this corpus**, not a theorem:
  nothing here that is genuinely a dependency conforms, because a service is
  identified rather than compared. If that stops being true the gate is wrong, and
  the control test is the thing to watch.
- **The ladder became a table** because nine independent early returns tripped
  `cyclomatic_complexity`. No ordering was lost — every entry says "this is not a
  concrete dependency" and none depends on another having run first.

## What is left, and what it is waiting on

22 findings. **Seven of them are SwiftProjectLint#163's shape** — a stateless,
effect-free type that holds nothing a test could not supply. `PromptBuilder` and
`ThinkingAnalyzer` have no stored properties at all; `EffectAnnotationParser`
stores only a value struct of attribute-name sets it is meant to be reconfigured
with. That issue is filed against `DirectInstantiation`, specifies the
discriminator, and already refutes both cheap approximations by measurement. It
needs the purity oracle this project runs and no rule consults. Deliberately not
built here: it is a fourth prescan and belongs to that issue's scope.

## Checks

`swift test` 3599 passing · `swiftlint` byte-identical to `main` ·
`tools/check-doc-drift.py` clean · `mutants/run-mutants.sh` **10/10**, including
one existing patch regenerated after this branch shifted its context — the runner
reported that as `apply-failed`, which is not the same as killed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuwumNGy4BgJk7CNm8DV4R