### PR TITLE
Tell a total kernel from a dependency, for both twins at once

### DIFF
--- a/Docs/rules/concrete-type-usage.md
+++ b/Docs/rules/concrete-type-usage.md
@@ -181,18 +181,27 @@ class MyViewModel {
   shape the function-`typealias` exemption already used, and the entry stood for two sweeps because
   nobody asked whether the nominal form of an exempt shape was also exempt.
 
-- **A stateless, effect-free type is still reported.** Seven of the remaining findings name a type
-  that holds nothing a test could not supply: `PromptBuilder` and `ThinkingAnalyzer` have no stored
-  properties at all, and `EffectAnnotationParser` stores only a value struct of attribute-name sets
-  it is meant to be reconfigured with. Asking for a protocol in front of a pure function is the
-  opposite of what this sweep is for.
+- **~~A stateless, effect-free type is still reported.~~** Closed by the pure-kernel exemption,
+  which is SwiftProjectLint#163 and is shared with `DirectInstantiation` — see
+  `CleanInstanceMethodCatalog.isPureKernel(_:)`. It removed four: `PromptBuilder` at three sites
+  and `ThinkingAnalyzer` at one.
 
-  This is **SwiftProjectLint#163**, filed against `DirectInstantiation` and applying equally here.
-  The discriminator is stated there and both cheap approximations are already refuted by
-  measurement: *value type* is wrong (`CacheManager` is a struct doing file I/O) and *no-argument
-  initializer* is wrong (`AntiPatternStore()` talks to disk). The real test needs the purity oracle
-  the project already runs — `PackagePurityJoin` and `CleanInstanceMethodCatalog` — and no rule
-  consults it. Deliberately not built here: it is a fourth prescan and it belongs to that issue's
-  scope rather than to a pass of applying this rule.
+  **It removed two more that it should not have, and that is the part worth keeping.** The first
+  implementation asked whether any stored property was a closure or an existential — a denylist —
+  and exempted `PluginPermissionGrantsStore`, which stores a `UserDefaults`, and
+  `PersistenceController`, which stores a SwiftData `ModelContainer`. Neither is a closure, an
+  existential, or service-suffixed, so no denylist available here would have caught either.
+
+  The method-cleanliness clause did not catch them either. `UserDefaults` *is* one of the purity
+  oracle's side-effect markers, but `PluginPermissionGrantsStore.load()` reads
+  `defaults.data(forKey: key)` — the stored property's **name**, never its type. **A dependency
+  held as storage does not spell its own type in the method that uses it**, so a body-scanning
+  oracle cannot see it. The storage test is positive for that reason: a kernel may hold only
+  values, and an unrecognised stored type disqualifies.
+
+- **`EffectAnnotationParser` is still reported, and the exemption was expected to reach it.** It
+  stores one `AttributeRecognition` value struct and its methods parse syntax, so it looked like a
+  kernel; the oracle refutes at least one of its methods. Whether that refusal is right has not
+  been checked, and the three findings stand until it is.
 
 ---

--- a/Docs/rules/direct-instantiation.md
+++ b/Docs/rules/direct-instantiation.md
@@ -87,4 +87,29 @@ final class ProjectParser {
 }
 ```
 
+
+### A type that holds nothing a test could supply
+
+Constructing one is not a coupling point. A test that wants different behaviour from
+`PromptBuilder` passes different arguments, not a different instance — there is no state for a
+second instance to hold differently and no effect for a double to intercept.
+
+`CleanInstanceMethodCatalog.isPureKernel(_:)` decides it, shared with `ConcreteTypeUsage`, which
+asks the same question from the declared type rather than the construction site. Three conditions:
+every method is a function of its inputs under the purity fixpoint this project already resolved,
+no stored property is mutable, and every stored property is a value — a stdlib value type, a
+project enum, or a collection or optional of one.
+
+**Both cheap approximations were measured and refused.** *Value type* fails on `CacheManager`, a
+`public struct` doing file I/O. *No-argument initializer* fails on `AntiPatternStore()` and
+`SourceKitClient()`, which take no arguments and talk to disk and to `sourcekitd`.
+
+**And the storage test is positive rather than negative for a measured reason.** Asked as a
+denylist — is any stored property a closure or an existential? — it produced two false exemptions
+on its first corpus run, including a type storing `UserDefaults`. That type's method reads
+`defaults.data(forKey:)`, the property's name; the type appears only in the declaration. A
+dependency held as storage does not name itself where it is used, so the oracle that reads bodies
+cannot see it and only the declaration can.
+
+
 ---

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter.swift
@@ -294,7 +294,9 @@ public final class ProjectLinter: ProjectAnalyzerProtocol {
                 functionTypeAliases: collectTypes(FunctionTypeAliasCollector.self, from: filePaths),
                 spiMembers: collectTypes(SPIMemberCollector.self, from: filePaths),
                 underscoredMembers: collectTypes(UnderscoredMemberCollector.self, from: filePaths),
-                cleanInstanceMethods: CleanInstanceMethodCatalog.build(from: parsed),
+                cleanInstanceMethods: CleanInstanceMethodCatalog.build(
+                    from: parsed, enumTypes: collectTypes(EnumTypeCollector.self, from: filePaths)
+                ),
                 extensionMembers: ExtensionMemberCatalog.build(from: parsed),
                 closureWrapperTypes: ClosureWrapperTypeCatalog.build(from: parsed),
                 impurePackageFunctions: PackagePurityJoin(sources: parsed).settledImpureNames

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ConcreteTypeUsageVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ConcreteTypeUsageVisitor.swift
@@ -273,6 +273,17 @@ class ConcreteTypeUsageVisitor: BasePatternVisitor {
             // covers all three spellings and the inline and `extension` forms alike.
             Exemption { self.knownEquatableTypes.contains($0) },
 
+            // A type that holds nothing a test could not supply. `PromptBuilder` has no stored
+            // properties and one pure method; `EffectAnnotationParser` stores a single value
+            // struct of attribute-name sets its own documentation says to reconfigure. A protocol
+            // in front of either is a seam around a pure function — the opposite of what this
+            // sweep is for.
+            //
+            // The oracle that decides this was already running project-wide with no rule
+            // consulting it (SwiftProjectLint#163). It is shared with `DirectInstantiation`,
+            // which asks the same question from the construction site.
+            Exemption { self.knownCleanInstanceMethods.isPureKernel($0) },
+
             // Protocol types — already an abstraction. A protocol used as a bare existential
             // (`let provider: ResourceMetricsProvider`) is not a concrete dependency, but the
             // name-based check above only recognises the `Protocol`/`Type`/`Interface` naming

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/DirectInstantiationVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/DirectInstantiationVisitor.swift
@@ -50,6 +50,12 @@ class DirectInstantiationVisitor: BasePatternVisitor {
         guard ServiceTypeSuffix.matches(typeName),
               !MockTypeName.matches(typeName) else { return nil }
 
+        // A type that holds nothing a test could not supply has nothing to inject: a test that
+        // wants different behaviour passes different arguments, not a different instance. See
+        // `CleanInstanceMethodCatalog.isPureKernel(_:)` and SwiftProjectLint#163 — the issue this
+        // closes, filed against this rule, and answered for both twins at once.
+        if knownCleanInstanceMethods.isPureKernel(typeName) { return nil }
+
         // A `private` or `fileprivate` type cannot be injected: no caller outside the file
         // that declares it can name the type, so there is nowhere for a substitute to come
         // from and no test that could supply one. Taking the advice would mean *widening*

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/CleanInstanceMethodCatalog.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/CleanInstanceMethodCatalog.swift
@@ -42,13 +42,81 @@ public struct CleanInstanceMethodCatalog: Sendable, Equatable {
 
     private let methodsByType: [String: Set<String>]
 
+    /// Types that hold nothing a test could not supply. See ``isPureKernel(_:)``.
+    private let pureKernelTypes: Set<String>
+
     /// The catalog a caller with no pre-scan gets: nothing is clean, so every callee stays refused
     /// and behaviour matches the analyzer as it was before the catalog existed.
     public static let empty = Self(methodsByType: [:])
 
-    public init(methodsByType: [String: Set<String>]) {
+    public init(methodsByType: [String: Set<String>], pureKernelTypes: Set<String> = []) {
         self.methodsByType = methodsByType
+        self.pureKernelTypes = pureKernelTypes
     }
+
+    /// Whether `typeName` holds nothing a test could not supply — no mutable or collaborator
+    /// storage, and every method a function of its inputs.
+    ///
+    /// **This is the discriminator `DirectInstantiation` and `ConcreteTypeUsage` both need and
+    /// neither had** (SwiftProjectLint#163). Both rules ask whether a dependency can be
+    /// substituted; a type like this has nothing to substitute, because a test that wants
+    /// different behaviour passes different arguments rather than a different instance. Reporting
+    /// one asks the author to put a protocol seam in front of the pure function they were trying
+    /// to extract — the opposite of what the sweep those rules belong to is for.
+    ///
+    /// **Neither cheap approximation works, and both were measured before this was written.**
+    /// *Value type* is refuted by `CacheManager`, a `public struct` that does file I/O.
+    /// *No-argument initializer* is refuted by `AntiPatternStore()` and `SourceKitClient()`, which
+    /// take no arguments and talk to disk and to `sourcekitd`. The distinction is semantic, and
+    /// the oracle that decides it was already running project-wide with no rule consulting it.
+    ///
+    /// Three conditions, and the first does nearly all the work:
+    ///
+    /// 1. **Every method is clean** — the same fixpoint this catalog already resolves. This is
+    ///    what refutes the counterexamples above without inspecting a single stored property:
+    ///    `CacheManager`'s methods reach the file system, so they are refuted, so the type is not
+    ///    a kernel whatever its declaration says.
+    /// 2. **No mutable stored property.** A `var` is state, and state is the thing a second
+    ///    instance would hold differently.
+    /// 3. **Every stored property is a value** — a stdlib value type or a project enum.
+    ///
+    /// **Condition (3) is a positive test, and it has to be.** The first version of this asked
+    /// the opposite question — is any stored property a closure or an existential? — and produced
+    /// two false exemptions out of six on its first corpus run.
+    /// `PluginPermissionGrantsStore` stores a `UserDefaults`, and `PersistenceController` a
+    /// SwiftData `ModelContainer`; neither is a closure, an existential, or service-suffixed, so
+    /// every denylist available here waved both through.
+    ///
+    /// Condition (1) did not save them either, and the reason is worth keeping: `UserDefaults`
+    /// *is* one of the purity oracle's side-effect markers, but
+    /// `PluginPermissionGrantsStore.load()` reads `defaults.data(forKey: key)` — the **stored
+    /// property's name**, never its type. A dependency held as storage does not spell its own
+    /// type in the method that uses it, so a body-scanning oracle cannot see it. The marker was
+    /// real and the code that had the effect never named it.
+    ///
+    /// So a kernel may only hold values, and anything else disqualifies by default. That is
+    /// deliberately conservative: for a rule whose purpose is finding seams, a false exemption
+    /// costs a seam nobody is told about, and a missed one costs a finding.
+    ///
+    /// Actors are excluded outright: an actor's isolation contract is load-bearing, which is the
+    /// same reason `ConcreteTypeUsage` exempts them from the other direction.
+    public func isPureKernel(_ typeName: String) -> Bool {
+        pureKernelTypes.contains(typeName)
+    }
+
+    /// Stdlib types whose values a test constructs directly. A stored property of one of these is
+    /// data the caller already supplies, not a collaborator it would want to replace.
+    ///
+    /// Collections, optionals and tuples are recognised by syntax rather than by name, so the list
+    /// carries only the nominal leaves.
+    static let stdlibValueTypes: Set<String> = [
+        "String", "Substring", "Character", "Bool",
+        "Int", "Int8", "Int16", "Int32", "Int64",
+        "UInt", "UInt8", "UInt16", "UInt32", "UInt64",
+        "Double", "Float", "CGFloat", "Decimal",
+        "URL", "Data", "UUID", "Date", "TimeInterval", "Range", "ClosedRange",
+        "IndexSet", "IndexPath", "Locale", "TimeZone", "Calendar"
+    ]
 
     /// The clean method names declared on `typeName`, or none for a free function.
     public func cleanMethods(on typeName: String?) -> Set<String> {
@@ -61,7 +129,9 @@ public struct CleanInstanceMethodCatalog: Sendable, Equatable {
     // MARK: - Building
 
     /// Resolves the catalog over every parsed source in the project.
-    public static func build(from sources: [SourceFileSyntax]) -> Self {
+    public static func build(
+        from sources: [SourceFileSyntax], enumTypes: Set<String> = []
+    ) -> Self {
         var types: [String: TypeMembers] = [:]
 
         for source in sources {
@@ -72,7 +142,29 @@ public struct CleanInstanceMethodCatalog: Sendable, Equatable {
             }
         }
 
-        return Self(methodsByType: resolve(types))
+        let clean = resolve(types)
+        return Self(
+            methodsByType: clean,
+            pureKernelTypes: kernels(in: types, given: clean, enumTypes: enumTypes)
+        )
+    }
+
+    /// The types that hold nothing a test could not supply. See ``isPureKernel(_:)``.
+    private static func kernels(
+        in types: [String: TypeMembers],
+        given clean: [String: Set<String>],
+        enumTypes: Set<String>
+    ) -> Set<String> {
+        var found: Set<String> = []
+        for (name, members) in types where !members.isActor {
+            guard members.declaredStorage.allSatisfy({ storage in
+                !storage.isMutable && storage.isValue(givenEnums: enumTypes)
+            }) else { continue }
+            let cleanHere = clean[name] ?? []
+            guard members.methods.keys.allSatisfy({ cleanHere.contains($0) }) else { continue }
+            found.insert(name)
+        }
+        return found
     }
 
     /// Promotes method names until a pass promotes nothing new.
@@ -133,9 +225,30 @@ public struct CleanInstanceMethodCatalog: Sendable, Equatable {
 
     /// Everything one type declares, merged across its primary declaration and every extension of
     /// it, in every file.
+    /// One stored property, as the kernel test reads it — mutability, and whether the declared
+    /// type is a seam in its own right.
+    struct DeclaredStorage: Sendable, Equatable {
+        let isMutable: Bool
+        /// The declared type's base name, or `nil` when the declaration has no annotation or the
+        /// spelling is one this does not read. `nil` disqualifies: an unread type is not a type
+        /// known to be a value.
+        let typeName: String?
+        /// Set for a spelling that is a value by construction — a tuple, or a collection or
+        /// optional of one. Collections are values whatever they contain, because replacing the
+        /// contents is what constructing a different one means.
+        let isSyntacticValue: Bool
+
+        func isValue(givenEnums enums: Set<String>) -> Bool {
+            if isSyntacticValue { return true }
+            guard let typeName else { return false }
+            return stdlibValueTypes.contains(typeName) || enums.contains(typeName)
+        }
+    }
+
     private struct TypeMembers {
         var isValueType = false
         var isActor = false
+        var declaredStorage: [DeclaredStorage] = []
         var storedProperties: [String: StoredProperty] = [:]
         /// Keyed by name, because a call site names a method rather than a signature. Overloads
         /// therefore accumulate under one key and are judged together.
@@ -145,6 +258,7 @@ public struct CleanInstanceMethodCatalog: Sendable, Equatable {
             // An extension never repeats `struct`, so the kind is whichever declaration stated it.
             isValueType = isValueType || other.isValueType
             isActor = isActor || other.isActor
+            declaredStorage += other.declaredStorage
             storedProperties.merge(other.storedProperties) { _, new in new }
             methods.merge(other.methods) { existing, new in existing + new }
         }
@@ -194,6 +308,7 @@ public struct CleanInstanceMethodCatalog: Sendable, Equatable {
             gathered.isValueType = isValueType
             gathered.isActor = isActor
             gathered.storedProperties = StoredProperty.declared(in: members)
+            gathered.declaredStorage = Self.declaredStorage(in: members)
 
             for member in members {
                 guard let function = member.decl.as(FunctionDeclSyntax.self) else { continue }
@@ -201,6 +316,64 @@ public struct CleanInstanceMethodCatalog: Sendable, Equatable {
             }
 
             types[name, default: TypeMembers()].absorb(gathered)
+        }
+
+        /// The type's actual storage, which `StoredProperty.declared(in:)` deliberately does not
+        /// report: that one promotes *derived computed properties* so a pure getter counts as a
+        /// readable value, which is right for the access analysis and wrong for asking what the
+        /// type holds.
+        static func declaredStorage(in members: MemberBlockItemListSyntax) -> [DeclaredStorage] {
+            var storage: [DeclaredStorage] = []
+            for member in members {
+                guard let variable = member.decl.as(VariableDeclSyntax.self) else { continue }
+                // A `static` member belongs to the type, not to an instance of it, so it is not
+                // storage a second instance could hold differently.
+                if variable.modifiers.contains(where: { $0.name.tokenKind == .keyword(.static) }) {
+                    continue
+                }
+                let isMutable = variable.bindingSpecifier.tokenKind == .keyword(.var)
+                for binding in variable.bindings where binding.accessorBlock == nil {
+                    let type = binding.typeAnnotation?.type
+                    storage.append(DeclaredStorage(
+                        isMutable: isMutable,
+                        typeName: type.flatMap(nominalName),
+                        isSyntacticValue: type.map(isSyntacticValue) ?? false
+                    ))
+                }
+            }
+            return storage
+        }
+
+        /// A spelling that is a value however it is filled: an array, a dictionary, a set, a
+        /// tuple, or an optional of one.
+        static func isSyntacticValue(_ type: TypeSyntax) -> Bool {
+            if type.is(ArrayTypeSyntax.self) || type.is(DictionaryTypeSyntax.self) { return true }
+            if let tuple = type.as(TupleTypeSyntax.self) {
+                return tuple.elements.count != 1
+                    || tuple.elements.first.map { isSyntacticValue($0.type) } ?? false
+            }
+            if let optional = type.as(OptionalTypeSyntax.self) {
+                return isSyntacticValue(optional.wrappedType)
+            }
+            if let identifier = type.as(IdentifierTypeSyntax.self),
+               ["Array", "Set", "Dictionary", "Optional"].contains(identifier.name.text) {
+                return true
+            }
+            return false
+        }
+
+        /// The base name of a nominal type, or `nil` for a spelling this does not read —
+        /// a closure, an existential, an opaque type. `nil` disqualifies by design.
+        static func nominalName(_ type: TypeSyntax) -> String? {
+            if let identifier = type.as(IdentifierTypeSyntax.self) { return identifier.name.text }
+            if let attributed = type.as(AttributedTypeSyntax.self) {
+                return nominalName(attributed.baseType)
+            }
+            if let optional = type.as(OptionalTypeSyntax.self) {
+                return nominalName(optional.wrappedType)
+            }
+            if let member = type.as(MemberTypeSyntax.self) { return member.name.text }
+            return nil
         }
 
         /// `Foo` from `Foo`, `Foo<Bar>`, or `Foo.Baz` — the shallow unwrapping an extended type

--- a/Tests/CoreTests/Engine/PureKernelTypeTests.swift
+++ b/Tests/CoreTests/Engine/PureKernelTypeTests.swift
@@ -1,0 +1,202 @@
+import Foundation
+import SwiftParser
+@testable import SwiftProjectLintVisitors
+import SwiftSyntax
+import Testing
+
+/// A type that holds nothing a test could not supply has nothing to substitute.
+///
+/// `DirectInstantiation` and `ConcreteTypeUsage` both ask whether a dependency can be replaced, and
+/// neither could tell a dependency from a total kernel — the thing the sweep they belong to exists
+/// to produce. Reporting one asks the author to put a protocol seam in front of the pure function
+/// they were extracting. SwiftProjectLint#163.
+///
+/// **Both cheap approximations are refuted by the corpus and both are pinned below.** *Value type*
+/// fails on a `struct` that does file I/O; *no-argument initializer* fails on a type that takes no
+/// arguments and talks to disk.
+///
+/// **And the first implementation of the real test was wrong in a way only the corpus showed.** It
+/// asked whether any stored property was a closure or an existential — a denylist — and produced
+/// two false exemptions out of six on its first run: `PluginPermissionGrantsStore`, which stores a
+/// `UserDefaults`, and `PersistenceController`, which stores a SwiftData `ModelContainer`. Neither
+/// is a closure, an existential, or service-suffixed.
+///
+/// The method-cleanliness clause did not save them either, and that is the part worth remembering:
+/// `UserDefaults` *is* one of the purity oracle's side-effect markers, but
+/// `PluginPermissionGrantsStore.load()` reads `defaults.data(forKey: key)` — the stored property's
+/// **name**, never its type. A dependency held as storage does not spell its own type in the method
+/// that uses it, so a body-scanning oracle cannot see it. The storage test is therefore positive:
+/// a kernel may hold only values, and anything unrecognised disqualifies.
+@Suite("A type that holds nothing a test could supply is not a dependency")
+struct PureKernelTypeTests {
+
+    private func catalog(_ source: String, enums: Set<String> = []) -> CleanInstanceMethodCatalog {
+        let parsed = [Parser.parse(source: source)]
+        return CleanInstanceMethodCatalog.build(from: parsed, enumTypes: enums)
+    }
+
+    // MARK: - What qualifies
+
+    @Test("a stateless type with one pure method is a kernel")
+    func statelessPureTypeQualifies() {
+        // `PromptBuilder`, reduced: no stored properties, one function of its arguments.
+        let built = catalog("""
+        public struct PromptBuilder: Sendable {
+            public init() {}
+            public func build(from context: String, request: String) -> String {
+                context + "\\n" + request
+            }
+        }
+        """)
+        #expect(built.isPureKernel("PromptBuilder"))
+    }
+
+    @Test("a type storing only values is a kernel")
+    func valueStorageQualifies() {
+        let built = catalog("""
+        struct Recognition: Sendable {
+            let names: Set<String>
+            let limit: Int
+            func matches(_ name: String) -> Bool { names.contains(name) }
+        }
+        """)
+        #expect(built.isPureKernel("Recognition"))
+    }
+
+    // MARK: - The two approximations the issue refutes
+
+    @Test("a value type that does file IO is not a kernel")
+    func effectfulStructIsNotAKernel() {
+        // *Value type* as the discriminator, refuted. `CacheManager` is the corpus instance.
+        let built = catalog("""
+        public struct CacheManager {
+            let root: String
+            func purge() { FileManager.default.removeItem(atPath: root) }
+        }
+        """)
+        #expect(!built.isPureKernel("CacheManager"))
+    }
+
+    @Test("a no-argument type that talks to disk is not a kernel")
+    func noArgumentInitIsNotEnough() {
+        // *No-argument initializer* as the discriminator, refuted.
+        let built = catalog("""
+        struct AntiPatternStore {
+            init() {}
+            func load() -> String { FileManager.default.currentDirectoryPath }
+        }
+        """)
+        #expect(!built.isPureKernel("AntiPatternStore"))
+    }
+
+    // MARK: - The two false exemptions the first implementation produced
+
+    @Test("a type storing UserDefaults is not a kernel")
+    func storedCollaboratorDisqualifiesEvenWhenUnnamedInBodies() {
+        // `PluginPermissionGrantsStore`, reduced, and the sharper of the two: `UserDefaults` is a
+        // side-effect marker the oracle knows, and `load()` never writes that word — it reads
+        // `defaults`, the property's name. Only the declaration says what `defaults` is.
+        let built = catalog("""
+        struct PluginPermissionGrantsStore {
+            private let defaults: UserDefaults
+            private let key: String
+            func load() -> Data? { defaults.data(forKey: key) }
+        }
+        """)
+        #expect(!built.isPureKernel("PluginPermissionGrantsStore"))
+    }
+
+    @Test("a type storing a framework container is not a kernel, even with no methods at all")
+    func storedContainerDisqualifiesWithNoMethods() {
+        // `PersistenceController`, reduced. Every method being clean is vacuously true when there
+        // are none, so condition (1) cannot decide this one and only the storage test can.
+        let built = catalog("""
+        struct PersistenceController {
+            static let shared = PersistenceController()
+            let container: ModelContainer
+        }
+        """)
+        #expect(!built.isPureKernel("PersistenceController"))
+    }
+
+    // MARK: - The clauses, separately
+
+    @Test("a mutable stored property disqualifies")
+    func mutableStorageDisqualifies() {
+        let built = catalog("""
+        final class Counter {
+            var count: Int = 0
+            func peek() -> Int { count }
+        }
+        """)
+        #expect(!built.isPureKernel("Counter"))
+    }
+
+    @Test("a stored closure disqualifies")
+    func storedClosureDisqualifies() {
+        // The seam is already there and the type is its holder.
+        let built = catalog("""
+        struct DateProvider {
+            let make: () -> Date
+        }
+        """)
+        #expect(!built.isPureKernel("DateProvider"))
+    }
+
+    @Test("a stored existential disqualifies")
+    func storedExistentialDisqualifies() {
+        let built = catalog("""
+        struct Loader {
+            let reader: any SourceFileReading
+        }
+        """)
+        #expect(!built.isPureKernel("Loader"))
+    }
+
+    @Test("an actor is never a kernel")
+    func actorIsNeverAKernel() {
+        // Its isolation contract is load-bearing, which is the same reason `ConcreteTypeUsage`
+        // exempts actors from the other direction.
+        let built = catalog("""
+        actor Registry {
+            func names() -> [String] { [] }
+        }
+        """)
+        #expect(!built.isPureKernel("Registry"))
+    }
+
+    @Test("a stored enum is a value")
+    func storedEnumIsAValue() {
+        // Enums are values and the project-wide enum prescan is what says so; without it the
+        // storage test would refuse every configured kernel.
+        let built = catalog("""
+        struct Policy {
+            let mode: Mode
+            func describe() -> String { "\\(mode)" }
+        }
+        """, enums: ["Mode"])
+        #expect(built.isPureKernel("Policy"))
+
+        // The control: the same type with no prescan is not a kernel, because an unrecognised
+        // stored type disqualifies by design rather than by accident.
+        #expect(!catalog("""
+        struct Policy {
+            let mode: Mode
+            func describe() -> String { "\\(mode)" }
+        }
+        """).isPureKernel("Policy"))
+    }
+
+    @Test("collections and optionals of values are values")
+    func syntacticValuesQualify() {
+        let built = catalog("""
+        struct Plan {
+            let steps: [String]
+            let index: [String: Int]
+            let note: String?
+            func count() -> Int { steps.count }
+        }
+        """)
+        #expect(built.isPureKernel("Plan"))
+    }
+}

--- a/Tests/CoreTests/ProjectLinterTests.swift
+++ b/Tests/CoreTests/ProjectLinterTests.swift
@@ -595,9 +595,15 @@ struct ProjectLinterNestedPackageTests {
             var token = ""
         }
         """)
+        // The control has state on purpose. It used to be `final class PlainService { func run() { } }`
+        // — no storage, one empty method — which is a *pure kernel* under the exemption added for
+        // SwiftProjectLint#163, so the control started passing the rule for a reason that had
+        // nothing to do with what this test is about. A service that holds something a second
+        // instance would hold differently is what "still flagged" is supposed to mean.
         writeFile(at: "\(root)/Sources/Root/PlainService.swift", """
         final class PlainService {
-            func run() { }
+            var callCount = 0
+            func run() { callCount += 1 }
         }
         """)
         writeFile(at: "\(root)/Sources/Root/Coordinator.swift", """

--- a/mutants/README.md
+++ b/mutants/README.md
@@ -12,6 +12,17 @@ construction.
 
 ## Run
 
+**Rebuild before measuring anything with the binary afterwards.** The runner reverts each mutant's
+*source* and moves on, so the build products left behind belong to the **last mutant**, not to
+`main`. A corpus measurement taken straight after a run is a measurement of that mutant.
+
+This is not hypothetical: a sweep run immediately after `kernel-storage-test-inverted-to-denylist`
+reported two repositories lower than the truth — exactly that mutant's two false exemptions — and
+the number was one step from being published. It was caught only because the shortfall matched the
+mutant's own documented effect. `rm -f .build/build.db && swift build --product CLI` first, or copy
+the binary *before* running the corpus.
+
+
 ```sh
 mutants/run-mutants.sh                       # all mutants
 mutants/run-mutants.sh kernel-threshold-too-high

--- a/mutants/README.md
+++ b/mutants/README.md
@@ -111,3 +111,23 @@ uppercase letter. The second is subtler — counting a computed property as stor
 `var now: Date { make() }` disqualify the very type the exemption was written for, so the catalog
 comes back empty and every finding returns. A first, cruder version of the detector did exactly
 that.
+
+### The pure-kernel discriminator
+
+One mutant, and it reproduces a mistake that actually shipped into a corpus run before the
+measurement caught it.
+
+| id | shape | expected | killer |
+|---|---|---|---|
+| `kernel-storage-test-inverted-to-denylist` | detector-recall | killed | `storedCollaboratorDisqualifiesEvenWhenUnnamedInBodies` |
+
+`isPureKernel(_:)` asks whether every stored property is a **value** — a positive test. The mutant
+turns it back into the denylist the first implementation used: only spellings the walker cannot
+read disqualify. That exempts a type storing `UserDefaults` and one storing a SwiftData
+`ModelContainer`, which is exactly what the first corpus run produced — two false exemptions out of
+six.
+
+Worth having because the failure is invisible from the rule's output *and* from the purity oracle.
+`UserDefaults` is one of the oracle's own side-effect markers, and the method that uses it reads
+`defaults.data(forKey:)` — the property's name, never its type. A dependency held as storage does
+not name itself where it is used.

--- a/mutants/manifest.json
+++ b/mutants/manifest.json
@@ -81,6 +81,14 @@
       "expected": "killed",
       "test": "closureWrapperIsNotReported",
       "label": "the closure-wrapper collector counts computed properties as storage \u2014 `var now: Date { make() }` is the wrapper's whole point, so every real instance stops qualifying and the exemption reaches nothing"
+    },
+    {
+      "id": "kernel-storage-test-inverted-to-denylist",
+      "patch": "patches/kernel-storage-test-inverted-to-denylist.patch",
+      "shape": "detector-recall",
+      "expected": "killed",
+      "test": "storedCollaboratorDisqualifiesEvenWhenUnnamedInBodies",
+      "label": "the pure-kernel storage test becomes a denylist (only unreadable spellings disqualify) \u2014 the first implementation, which exempted a type storing UserDefaults and one storing a SwiftData ModelContainer"
     }
   ]
 }

--- a/mutants/patches/kernel-storage-test-inverted-to-denylist.patch
+++ b/mutants/patches/kernel-storage-test-inverted-to-denylist.patch
@@ -1,0 +1,21 @@
+diff --git a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/CleanInstanceMethodCatalog.swift b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/CleanInstanceMethodCatalog.swift
+--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/CleanInstanceMethodCatalog.swift
++++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/CleanInstanceMethodCatalog.swift
+@@ -158,7 +158,7 @@
+         var found: Set<String> = []
+         for (name, members) in types where !members.isActor {
+             guard members.declaredStorage.allSatisfy({ storage in
+-                !storage.isMutable && storage.isValue(givenEnums: enumTypes)
++                !storage.isMutable && !storage.isCollaboratorDenylisted
+             }) else { continue }
+             let cleanHere = clean[name] ?? []
+             guard members.methods.keys.allSatisfy({ cleanHere.contains($0) }) else { continue }
+@@ -237,6 +237,8 @@
+         /// optional of one. Collections are values whatever they contain, because replacing the
+         /// contents is what constructing a different one means.
+         let isSyntacticValue: Bool
++
++        var isCollaboratorDenylisted: Bool { typeName == nil }
+ 
+         func isValue(givenEnums enums: Set<String>) -> Bool {
+             if isSyntacticValue { return true }


### PR DESCRIPTION
Closes #163.

`DirectInstantiation` and `ConcreteTypeUsage` both ask whether a dependency can be
substituted, and neither could tell a dependency from a type that holds nothing a
test could supply. A test wanting different behaviour from `PromptBuilder` passes
different arguments, not a different instance. Reporting one asks the author to put
a protocol seam in front of the pure function they were extracting — the opposite
of what the sweep these rules belong to is for.

`CleanInstanceMethodCatalog.isPureKernel(_:)` decides it, on the purity fixpoint
that catalog already resolved. The oracle was running project-wide with no rule
consulting it, which is the shape #163 named and the same shape as the
`ContinuousClock` correction one rule over.

Three conditions: every method is a function of its inputs, no stored property is
mutable, and every stored property is a value.

## The first implementation was wrong, and only the corpus showed it

I built the storage clause as the **denylist** #163 proposed — is any stored
property service-like, an existential, or a closure? — and it produced **two false
exemptions out of six** on its first run:

- `PluginPermissionGrantsStore`, which stores a `UserDefaults`
- `PersistenceController`, which stores a SwiftData `ModelContainer`

Neither is a closure, an existential, or service-suffixed. **No denylist available
here would have caught either**, including the one the issue itself specified.

**And the method-cleanliness clause did not catch them, which is the part worth
keeping.** `UserDefaults` *is* one of the purity oracle's own side-effect markers.
But `PluginPermissionGrantsStore.load()` reads `defaults.data(forKey: key)` — the
stored property's **name**, never its type. A dependency held as storage does not
spell its own type in the method that uses it, so an oracle that reads bodies
cannot see it and only the declaration can.

So the storage test is positive: a kernel may hold only values — a stdlib value
type, a project enum, or a collection or optional of one — and an unrecognised
stored type disqualifies. Conservative on purpose: for a rule that exists to find
seams, a false exemption costs a seam nobody hears about and a missed one costs a
finding.

## What a reviewer should scrutinise

- **The stdlib value list is the one hand-maintained thing here.** Everything else
  is a declaration or an oracle verdict. A stored `Measurement` or `Locale`-shaped
  type not on the list disqualifies its owner — conservative, but it means the
  exemption reaches less than it could and will need names added.
- **`EffectAnnotationParser` is still reported and I expected it not to be.** It
  stores one value struct and its methods parse syntax, so it looked like a kernel;
  the oracle refutes at least one method. **Whether that refusal is correct I have
  not checked** — the doc says so and the three findings stand until someone does.
- **An end-to-end fixture changed, and check that I changed the right thing.** Its
  control was `final class PlainService { func run() { } }` — no storage, one empty
  method, which *is* a pure kernel — so the control had started passing for a
  reason unrelated to what that test is about. It holds state now, with the reason
  written in. The alternative reading is that the gate is too broad; I do not think
  so, but the fixture is where you would see it first.
- **The `enumTypes` argument to `build(from:)` defaults to empty**, so a caller
  that forgets it gets a stricter catalog rather than a wrong one. That direction
  is deliberate.

## Corpus

Concrete Type Usage **22 → 18**; the exemption removes four (`PromptBuilder` at
three sites, `ThinkingAnalyzer` at one). `Direct Instantiation` was already 0 and
stays 0 — so this issue, filed against that rule, lands entirely on its twin, and
its own eleven findings had gone by other means.

**The first version of this number was 16 and would have been published.** It was
measured with a binary copied straight after `mutants/run-mutants.sh`, which
reverts each mutant's source but leaves the last mutant's build products — and the
last mutant is the denylist one. Two repositories came back one low, matching that
mutant's two documented false exemptions exactly. That hazard is now recorded in
`mutants/README.md`; the numbers above are from a rebuilt binary.

## Checks

`swift test` 3611 passing · `swiftlint` byte-identical to `main` ·
`tools/check-doc-drift.py` clean · `mutants/run-mutants.sh` **11/11**, the new one
reproducing the denylist mistake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuwumNGy4BgJk7CNm8DV4R