### PR TITLE
Rename the catalog's contains(_:), which was silencing 49 closure candidates

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ConcreteTypeUsageVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ConcreteTypeUsageVisitor.swift
@@ -260,7 +260,7 @@ class ConcreteTypeUsageVisitor: BasePatternVisitor {
             // The nominal form is if anything better than the alias: it can carry named
             // factories, and `DateProvider.system` is the one place in its package allowed to
             // read a clock. Requires the project-wide closure-wrapper prescan.
-            Exemption { self.knownClosureWrapperTypes.contains($0) },
+            Exemption { self.knownClosureWrapperTypes.wraps($0) },
 
             // An `Equatable` type is a value, and a value is substituted by constructing a
             // different one. Nothing in this corpus that is genuinely a dependency conforms:

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/ClosureWrapperTypeCollector.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/ClosureWrapperTypeCollector.swift
@@ -49,7 +49,21 @@ public struct ClosureWrapperTypeCatalog: Sendable, Equatable {
         self.names = names
     }
 
-    public func contains(_ name: String) -> Bool { names.contains(name) }
+    /// Whether `name` is one of them.
+    ///
+    /// **Named `wraps` rather than `contains` on purpose, and the reason is measured.** While it
+    /// was `contains(_:)`, that labelled name entered `knownProjectFunctions` — and
+    /// `PureClosureCandidateVisitor`'s forwarding check suppresses any single-expression closure
+    /// calling a project-declared name, keying on the *member* name plus labels. So a one-line
+    /// method here silenced every closure in the package that calls `.contains(…)`:
+    /// `{ stylingModifierNames.contains($0) }`, `{ $0.description.contains("#Preview") }`, and 47
+    /// others. **The closure census went 249 → 200 because of this method's name**, measured both
+    /// ways.
+    ///
+    /// The rename is a workaround and is recorded as one — the defect is that the forwarding check
+    /// resolves a callee by bare name through a member access, which `PackagePurityJoin` in this
+    /// same package already refuses to do and documents at length. Filed as SwiftProjectLint#185.
+    public func wraps(_ name: String) -> Bool { names.contains(name) }
 
     public var isEmpty: Bool { names.isEmpty }
 

--- a/Tests/CoreTests/Architecture/ConcreteTypeUsageSeamTests.swift
+++ b/Tests/CoreTests/Architecture/ConcreteTypeUsageSeamTests.swift
@@ -70,7 +70,7 @@ struct ConcreteTypeUsageSeamTests {
     @Test("a property typed with a closure wrapper is not reported")
     func closureWrapperIsNotReported() {
         let built = catalog(providerSource)
-        #expect(built.contains("DateProvider"))
+        #expect(built.wraps("DateProvider"))
         #expect(issues(providerSource, wrappers: built).isEmpty)
     }
 
@@ -90,7 +90,7 @@ struct ConcreteTypeUsageSeamTests {
         // every real instance of this shape fail to qualify — which is exactly what a first,
         // cruder version of the detector did.
         let built = catalog(providerSource)
-        #expect(built.contains("DateProvider"))
+        #expect(built.wraps("DateProvider"))
     }
 
     @Test("two closures is not a wrapper")
@@ -103,7 +103,7 @@ struct ConcreteTypeUsageSeamTests {
             let save: @Sendable (Data) -> Void
         }
         """)
-        #expect(!built.contains("EditingService"))
+        #expect(!built.wraps("EditingService"))
     }
 
     @Test("a struct holding a value is not a wrapper")
@@ -111,7 +111,7 @@ struct ConcreteTypeUsageSeamTests {
         let built = catalog("""
         struct SnapshotManager { let root: URL }
         """)
-        #expect(!built.contains("SnapshotManager"))
+        #expect(!built.wraps("SnapshotManager"))
     }
 
     @Test("a non-final class is not a wrapper")
@@ -121,7 +121,7 @@ struct ConcreteTypeUsageSeamTests {
         let built = catalog("""
         class DiffLoader { let load: () -> Data }
         """)
-        #expect(!built.contains("DiffLoader"))
+        #expect(!built.wraps("DiffLoader"))
     }
 
     // MARK: - The file-local type


### PR DESCRIPTION
A one-line method name was moving the corpus.

`ClosureWrapperTypeCatalog.contains(_:)` → `wraps(_:)`. While it was
`contains(_:)`, that labelled name sat in `knownProjectFunctions`, and
`PureClosureCandidateVisitor`'s forwarding check — *"it merely forwards to a
function the reader already extracted"* — suppressed every single-expression
closure in the package calling `.contains(…)`, across ~35 files nobody had
touched.

**Measured both ways**, same tree, binary built either side: closure census
**249** named `wraps`, **200** named `contains`. A control run of the new binary
over the *previous* tree returns 242, which is how I know the rule itself did not
change and the source I added did.

This is a workaround, and the declaration says so. The defect is filed as #185:
`labelledName(of:)` accepts a `MemberAccessExprSyntax` and keys on the member's
base name, so `set.contains(x)` and `myCatalog.contains(x)` are the same key.
`PackagePurityJoin` — same package, same question — restricts itself to free-shape
callees and explains why at length. The obvious fix is not obviously right, because
the rule's own motivating example is a member call (`{ search.matches(name: $0.name) }`),
so #185 carries three candidate approaches and no measurement.

Renaming rather than reverting because `wraps` is the better name regardless: the
catalog answers whether a type *is* a closure wrapper, not whether a collection
holds something.

## What a reviewer should scrutinise

- **That this is worth a rename at all.** The alternative reading is that
  suppressing `{ stylingModifierNames.contains($0) }` is *correct* — a trivial
  predicate forwarding to `Set.contains` may hide no law worth stating. I do not
  think that saves it: whether those 49 are reported currently depends on whether
  some unrelated file happens to declare a function called `contains`, which is not
  a property of the closures.
- **That the next collision is unguarded.** `map`, `filter`, `first` would each do
  the same thing, silently, and the only symptom is a census that fell. Nothing in
  this PR prevents that; #185 is where that gets fixed.

## Checks

`swift test` 3611 passing · `swiftlint` byte-identical to `main` · one repository's
closure census restored 200 → 249, no other rule or repository affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuwumNGy4BgJk7CNm8DV4R