### PR TITLE
Ask the oracle why: consume SEI's purity witness in PackagePurityJoin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -84,7 +84,7 @@ let package = Package(
         // swift-syntax exact 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "23d1dabe7501d267af5aeea26ac4a6a318083fc2"
+            revision: "1b62e764bca74e727b0080f8aeaf85663877648b"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintIdempotencyRules/Package.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // root and SwiftProjectLintVisitors pins.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "23d1dabe7501d267af5aeea26ac4a6a318083fc2"
+            revision: "1b62e764bca74e727b0080f8aeaf85663877648b"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintVisitors/Package.swift
+++ b/Packages/SwiftProjectLintVisitors/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // 602.0.0, so there is no version conflict.
         .package(
             url: "https://github.com/Joseph-Cursio/SwiftEffectInference.git",
-            revision: "23d1dabe7501d267af5aeea26ac4a6a318083fc2"
+            revision: "1b62e764bca74e727b0080f8aeaf85663877648b"
         )
     ],
     targets: [

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/PackagePurityJoin.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/PackagePurityJoin.swift
@@ -34,24 +34,58 @@ import SwiftSyntax
 /// spreading ignorance upward would retract candidates on the grounds that
 /// *something might* be impure, which is the Daikon trap through a new door.
 ///
-/// **`PurityVerdict` carries no witness** — it is `pure` / `pureButPartial` /
-/// `refuted`, and the reason is `private` to SEI. That is open-threads item 31's
-/// complaint (*"nothing can name the callee that blocked a verdict"*) arriving as
-/// a constraint on this build rather than as a wish.
+/// **SEI now publishes the reason, so the rule asks instead of inferring.**
+/// `PurityInferrer.refutation(for:)` returns a `PurityRefutation`, and the
+/// evidence/ignorance split is a `switch` over it: everything that names a
+/// construct is evidence, and `.propagatedTry` — plus `.noBody`, which names
+/// nothing because there was nothing to read — is not. The switch is exhaustive
+/// and deliberately has no `default`, so a refuter added upstream is a compile
+/// error here rather than a silent classification.
 ///
-/// So the witness is established from public API only, and soundly:
-/// **`propagatedTry` requires a `throws` clause by definition, so a callee that is
-/// `.refuted` and does NOT throw cannot be an ignorance-only refutation.** It must
-/// carry one of the evidence causes. No marker set is replicated here, which is the
-/// point — a second copy of SEI's refuters in this repo is exactly the drift
-/// `PurityInferrer`'s relocation was done to end.
+/// **What this replaced, and it is worth keeping because the shape recurs.** The
+/// first build could not ask, so it established the witness from public API by
+/// arithmetic: *`propagatedTry` requires a `throws` clause by definition, so a
+/// callee that is `.refuted` and does NOT throw cannot be ignorance-only.* Sound,
+/// and one-sided in a known direction — a **throwing** callee that also carries a
+/// marker is a genuine witness that proxy could not see, so the rule under-refuted
+/// and its own doc said so. That was open-threads item 31 arriving as a constraint
+/// on a build rather than as a wish, and closing it widened this rule with no new
+/// analysis here.
 ///
-/// The cost is real and one-sided: a *throwing* callee that also carries a marker
-/// is a genuine witness this rule cannot see, so it under-refutes. That is the safe
-/// direction for a gate that suppresses advice — the failure mode is continuing to
-/// offer a candidate, which is today's behaviour, rather than withdrawing a true
-/// one. **If SEI ever publishes the refutation reason, this rule gets wider for
-/// free**, and that is the argument for item 31 that this build supplies.
+/// No marker set is replicated here, which remains the point: a second copy of
+/// SEI's refuters in this repo is exactly the drift `PurityInferrer`'s relocation
+/// was done to end. The proxy was arithmetic over a public signature; this is a
+/// question put to the oracle.
+///
+/// ## What the widening was worth, measured, and it is not what the old doc predicted
+///
+/// The old note said *"if SEI ever publishes the refutation reason, this rule gets
+/// wider for free"*. It got wider. Wider bought nothing.
+///
+/// Over 22 corpus repositories, **settled names went 2,175 → 6,586 — 3.0×**, and
+/// the reported findings did not move by one. The control that makes that a
+/// statement rather than an absence: with the join disabled entirely the corpus
+/// reports **4,592** `pure-function-candidate` findings, and with it enabled
+/// **4,566** under *either* rule. The join suppresses 26 candidates, the same 26
+/// before and after.
+///
+/// The reason is visible in what the widening freed. The 4,411 new names are
+/// dominated by **throwing test functions** — `testLoadViolations`,
+/// `testAtomicWrite`, `anyCodableCodable` — which are throwing and carry a marker
+/// or a trap, so they are evidence, and which no production candidate calls
+/// free-shape. The two populations do not meet.
+///
+/// **So this is a correctness and clarity change, not a yield change**, and it is
+/// worth having on those terms: the rule now asks the question it means instead of
+/// deriving it from a signature, the evidence/ignorance split is a `switch` a
+/// future refuter cannot slip past, and the documented under-refutation is closed
+/// in principle. What the corpus says is that the gap was never being exercised —
+/// not that closing it was unnecessary.
+///
+/// It also bounds the risk, which runs the other way for a rule that *suppresses*
+/// advice: a 3× wider settled set is 3× more opportunity to withdraw a true
+/// candidate. Zero moved, so that opportunity is currently unrealised. The
+/// one-pure-overload rule below is what keeps it bounded, and it is unchanged.
 ///
 /// ## Resolution is name-keyed, and a name must be settled
 ///
@@ -77,28 +111,56 @@ public struct PackagePurityJoin: Sendable {
     ///   hash-seed-dependent the way the idempotency family's hop counts once did.
     public init(sources: [SourceFileSyntax]) {
         let inferrer = PurityInferrer()
-        var byName: [String: [(verdict: PurityVerdict, throwsClause: Bool)]] = [:]
+        var byName: [String: [PurityRefutation?]] = [:]
         for source in sources {
             let collector = PackageFunctionCollector(viewMode: .sourceAccurate)
             collector.walk(source)
             for declaration in collector.declarations {
-                byName[declaration.name.text, default: []].append(
-                    (
-                        inferrer.verdict(for: declaration),
-                        declaration.signature.effectSpecifiers?.throwsClause != nil
-                    )
-                )
+                byName[declaration.name.text, default: []].append(inferrer.refutation(for: declaration))
             }
         }
 
         var settled: Set<String> = []
-        for (name, declarations) in byName where !declarations.isEmpty {
-            // Settled impure: every declaration refuted, and every one of them
-            // non-throwing so the refutation cannot be `propagatedTry` ignorance.
-            let allSettled = declarations.allSatisfy { $0.verdict == .refuted && !$0.throwsClause }
-            if allSettled { settled.insert(name) }
+        for (name, refutations) in byName where !refutations.isEmpty {
+            // Settled impure: every declaration refuted, and every refutation names
+            // a construct rather than reporting the oracle's own blindness.
+            if refutations.allSatisfy(Self.namesEvidence) { settled.insert(name) }
         }
         self.settledImpureNames = settled
+    }
+
+    /// Whether a refutation is **evidence** — it names a construct that makes the
+    /// function impure — rather than **ignorance**.
+    ///
+    /// Only two things are ignorance. `.propagatedTry` is the oracle saying *I
+    /// cannot see past this callee*, which is a fact about a leaf's view rather
+    /// than about the function; retracting a candidate on it would withdraw advice
+    /// on the grounds that something *might* be impure, which is the Daikon trap
+    /// through a new door. `.noBody` names nothing because there was nothing to
+    /// read — and it is also unreachable here, since `PackageFunctionCollector`
+    /// skips body-less declarations, so classifying it as ignorance costs nothing
+    /// and is the safe answer if that ever changes.
+    ///
+    /// `nil` — not refuted at all — is not evidence either: the function is `.pure`
+    /// or `.pureButPartial`, and neither says anything impure about it.
+    ///
+    /// **Exhaustive with no `default` on purpose.** A refuter added to SEI must be
+    /// classified here deliberately; the alternative is a new cause silently
+    /// landing on whichever side the `default` happened to take, which for this
+    /// rule means either withdrawing true advice or keeping false advice, with no
+    /// diff to notice it in.
+    private static func namesEvidence(_ refutation: PurityRefutation?) -> Bool {
+        guard let refutation else { return false }
+        switch refutation {
+        case .propagatedTry, .noBody:
+            return false
+
+        case .declaredAsync, .declaredThrows,
+             .sideEffectMarker, .nondeterministicMarker, .nondeterminismSource,
+             .fileRead, .partiality, .refutingDefaultArgument,
+             .mutatesCapturedState, .notAGetter:
+            return true
+        }
     }
 
     /// The name of the first settled-impure package function `function`'s body calls,

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/PurityInferrer.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/PurityInferrer.swift
@@ -72,4 +72,43 @@ public struct PurityInferrer: Sendable {
     public func isPure(_ accessor: AccessorBlockSyntax) -> Bool {
         underlying.isPure(accessor)
     }
+
+    /// **Why** purity was refuted, or `nil` when it was not.
+    ///
+    /// `nil` covers `.pure` **and** `.pureButPartial`: a function that raises only its own errors
+    /// has been narrowed, not refuted, so it has no witness — ask `verdict(for:)` for that
+    /// distinction.
+    ///
+    /// The forwarder carries this because a consumer that only gates on purity needs a `Bool` and a
+    /// consumer that *reports* on it needs the reason. `PackagePurityJoin` is the first: it used to
+    /// establish its witness by arithmetic over the signature, because the reason was private to
+    /// SEI, and now asks.
+    public func refutation(for function: FunctionDeclSyntax) -> PurityRefutation? {
+        underlying.refutation(for: function)
+    }
+
+    /// **Why** a closure literal is not referentially transparent, or `nil` when it is.
+    ///
+    /// The witness matters more for a closure than anywhere else, because a closure has no name: a
+    /// report saying *this predicate is impure* and not what makes it so leaves the reader to
+    /// re-derive the analysis from the one line the diagnostic points at.
+    public func refutation(for closure: ClosureExprSyntax) -> PurityRefutation? {
+        underlying.refutation(for: closure)
+    }
 }
+
+/// The witness type, re-exported under this package's own name.
+///
+/// Same reasoning as the forwarder above: `MemberImportVisibility` requires the *using* module to
+/// import the member's defining module, and a consumer naming `PurityRefutation` in a signature
+/// would otherwise need a direct `SwiftEffectInference` dependency it does not have.
+///
+/// **A typealias is enough to name the type and NOT enough to match on it**, which is worth knowing
+/// before the next consumer arrives. Measured while building this: a `switch` over the cases from a
+/// module that imports only this package fails with *"enum case 'noBody' is not available due to
+/// missing import of defining module 'SwiftEffectInference'"* — the same feature, reaching one level
+/// deeper than the forwarder pattern anticipated. `PackagePurityJoin` is unaffected because it lives
+/// in this module. A rule in `SwiftProjectLintRules` that wants to group findings by cause will need
+/// either its own SEI dependency or a rendering this package exposes; that decision belongs with the
+/// rule (SwiftProjectLint#186), not pre-empted here.
+public typealias PurityRefutation = SwiftEffectInference.PurityRefutation

--- a/Tests/CoreTests/Testability/PackagePurityJoinTests.swift
+++ b/Tests/CoreTests/Testability/PackagePurityJoinTests.swift
@@ -160,10 +160,12 @@ struct PackagePurityJoinTests {
     /// the oracle saying *I cannot see past this*, not *this is impure*. Retracting
     /// a candidate on that basis would withdraw advice on no evidence.
     ///
-    /// This is also the measured limit of the build: `PurityVerdict` carries no
-    /// witness, so the only witness establishable from public API is
-    /// *refuted AND does not throw*. A throwing callee is therefore never joined
-    /// on, which under-refutes rather than over-refutes.
+    /// **This now tests the real thing rather than a proxy for it.** While
+    /// `PurityVerdict` carried no witness, the only witness establishable from
+    /// public API was *refuted AND does not throw*, so every throwing callee was
+    /// treated as ignorance and the rule under-refuted. `loadContents` below is
+    /// `.propagatedTry` for real, and the twin test asserts the half the proxy got
+    /// wrong.
     @Test("a throwing callee does NOT sink the caller — that refutation may be ignorance")
     func doesNotPropagateIgnorance() {
         let found = gatedSymbols([
@@ -180,6 +182,37 @@ struct PackagePurityJoinTests {
         #expect(
             found.contains("lengthOf"),
             "a `propagatedTry` refutation is the oracle's ignorance and must not retract advice"
+        )
+    }
+
+    /// The other half of the split, and the row the old proxy could not see.
+    ///
+    /// `loadContents` **throws and carries a marker**, so its refutation is
+    /// `.sideEffectMarker("print")` — evidence, named by the oracle, reached before
+    /// the `throws` clause is even consulted. The arithmetic proxy classified every
+    /// throwing callee as possible ignorance and let the caller through; asking for
+    /// the reason settles it.
+    ///
+    /// Paired with `doesNotPropagateIgnorance` deliberately: the two fixtures differ
+    /// only in whether the throwing callee names an effect, which is the entire
+    /// content of the evidence/ignorance rule.
+    @Test("a throwing callee that names an effect DOES sink the caller")
+    func propagatesEvidenceFromAThrowingCallee() {
+        let found = gatedSymbols([
+            "Throwy.swift": """
+            func loadContents(_ path: String) throws -> String {
+                print(path)
+                throw LoadError.missing
+            }
+
+            func lengthOf(_ path: String) -> Int {
+                (try? loadContents(path))?.count ?? 0
+            }
+            """
+        ])
+        #expect(
+            found.contains("lengthOf") == false,
+            "the callee prints; `throws` does not make a named effect unknowable"
         )
     }
 


### PR DESCRIPTION
SEI#17 published `PurityRefutation`, the reason behind a `PurityVerdict`. This consumes it in the one place that was already documented as blocked on it.

## What changed

- All three SEI pins move to `1b62e76`. No behaviour rides on the bump — `verdict(for:)` and `isPure(_:)` are re-expressed upstream in terms of the witness and pinned equal to their old answers by SEI's own equivalence suite.
- The thin forwarder gains `refutation(for:)` over a function and over a closure, plus a typealias for the type.
- `PackagePurityJoin` asks for the witness instead of deriving it. Its evidence/ignorance split is now a `switch` with no `default`, so a refuter added upstream is a compile error here rather than landing silently on whichever side a default took.

## The measurement, which went against the prediction in the code

The old doc said *"if SEI ever publishes the refutation reason, this rule gets wider for free."* It got wider. Wider bought nothing.

| | settled names | census findings |
|---|---:|---:|
| join disabled | — | 4,592 |
| old proxy (`refuted && !throws`) | 2,175 | 4,566 |
| new witness | 6,586 | 4,566 |

**3.0× the settled names, the same 26 suppressions.** The disabled arm is the control that makes the zero a statement rather than an absence: the join is live and doing work, and the widening adds none of it.

The freed names say why — they are dominated by throwing test functions (`testLoadViolations`, `testAtomicWrite`, `anyCodableCodable`), which throw *and* carry a marker or a trap, so they are evidence, and which no production candidate calls free-shape. The two populations do not meet.

So this lands as a correctness and clarity change, not a yield change, and the doc now says that instead of promising a payoff it does not deliver. It is still worth having: the rule asks the question it means, the documented under-refutation is closed in principle, and the exhaustive switch makes the next refuter a decision rather than an accident. What the corpus says is that the gap was never being exercised — not that closing it was unnecessary.

It also bounds the risk, which runs the other way for a rule that *suppresses* advice: 3× more settled names is 3× more opportunity to withdraw a true candidate, and zero moved, so that opportunity is currently unrealised.

## What a reviewer should scrutinise

**The new test is verified by control, not by passing.** `propagatesEvidenceFromAThrowingCallee` differs from its existing twin only in whether the throwing callee prints. With the old predicate simulated in place, that one test fails and the other eleven pass — so it is testing the widening rather than restating the suite.

**`.noBody` is classified as ignorance.** It names nothing because there was nothing to read, and it is unreachable here since `PackageFunctionCollector` skips body-less declarations. Classifying it as ignorance costs nothing today and is the safe answer if that ever changes.

**A limit worth knowing before the next consumer.** A typealias is enough to *name* `PurityRefutation` and not enough to *match on it*: a `switch` over the cases from a module importing only `SwiftProjectLintVisitors` fails with `enum case 'noBody' is not available due to missing import of defining module`. `PackagePurityJoin` is unaffected, being in that module. A rule in `SwiftProjectLintRules` grouping findings by cause — #186 — will need either its own SEI dependency or a rendering exposed by the Visitors package. Recorded at the typealias; deliberately not pre-empted here.

3,612 tests in 433 suites; swiftlint unchanged (four pre-existing warnings, none in touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuwumNGy4BgJk7CNm8DV4R