### PR TITLE
Parallel List Drift: 11 → 0, and three of them were real defects

### DIFF
--- a/Docs/rules/parallel-list-drift.md
+++ b/Docs/rules/parallel-list-drift.md
@@ -116,6 +116,14 @@ is named: the same fix resolves all of them, and any remainder re-surfaces on th
   happens to cover most of a twelve-entry canonical one still fires. This is the rule's residual
   false positive and part of why it is `Info`. Suppress with
   `// swiftprojectlint:disable Parallel List Drift`.
+- **Two lists over one closed vocabulary read as drift however they were written.** The sharper
+  form of the above, and the one the corpus sweep actually produced: when two lists enumerate
+  the same fixed vocabulary — Swift's scalar type names, a log level's spellings, the verbs of
+  set algebra — for two *different* capabilities, they overlap heavily because there is only one
+  such vocabulary, not because either was copied. `randomReceiverTypeNames` (types you can call
+  `.random(in:)` on) against `trivialValueTypes` (types too common to be a distinctive
+  dictionary value) is the clearest instance. The rule matches on names and cannot see that the
+  predicates differ, so no threshold closes this. See issue #190.
 - **Test and fixture files are excluded entirely** — a test enumerating a deliberate subset is
   the most common instance of the above.
 - **Very common names are ignored when generating candidate pairs.** A name appearing in more
@@ -187,24 +195,70 @@ SourcePatternRegistry.registerFactory { registry, visitorRegistry in
 cannot drift again. When the counterpart is an enum, iterating `CaseIterable` replaces the
 hand-maintained copy outright and makes the next omission a compile error.
 
+Taking that advice also silences the finding, and by construction rather than by concession:
+a derived list is written `canonical.subtracting([…])` or `A.union(B)`, which is no longer an
+array literal of names for Phase 1 to catalog. Six of the thirteen findings in the corpus
+sweep closed this way. When the two lists genuinely differ on purpose there is nothing to
+derive, and then a directive with the reasoning beside it is the right answer — that is what
+the surviving three are.
+
 #### Real-world discovery
-Run against SwiftProjectLint itself (`--include-nested-packages`), the rule reports **14**
-findings, led by the case that motivated it:
+
+The rule's first run against SwiftProjectLint itself (`--include-nested-packages`) reported
+**14** findings, led by the case that motivated it:
 
 > `SourcePatternRegistry.registerFactory(…)` (registration run, 12 entries) agrees with
 > `PatternCategory` (enum, PatternCategory.swift:23) on 12 entries but is missing 2:
 > `idempotency`, `other`.
 
-Both omissions turn out to be intentional — `idempotency` factories are registered by a
-separate package, and `other` is a catch-all with no factory — which is the rule working as
-designed: it cannot know intent, so it surfaces the discrepancy for a human to confirm or fix.
-`Tests/CoreTests/CrossFileAnalysis/ParallelListDriftDogfoodTests.swift` pins this finding
+Both omissions are intentional — `idempotency` factories are registered by a separate
+package, and `other` is a catch-all with no factory. That is the rule working as designed:
+it cannot know intent, so it surfaces the discrepancy for a human to confirm or fix.
+`Tests/CoreTests/CrossFileAnalysis/ParallelListDriftDogfoodTests.swift` pins the finding
 against the checked-in sources, so if the two lists are ever reconciled the test records it.
+Inline suppression is applied by the **engine**, not the visitor, so the directive now
+sitting at `registerAll` silences the corpus report without touching that test.
 
-#### Measured precision on that run
+#### The corpus sweep: 13 → 0, and what each finding turned out to be
 
-All 14 findings were read individually. They are roughly **10 distinct pairs** (four are the same
-pair reported from both sides), of which **three are actionable**:
+A later sweep over 26 repositories reported **13** findings in three of them — 11 here, one
+in SwiftInferProperties, one in SwiftPropertyLaws. All 13 were read individually and every
+one is now dispositioned. **Three were real defects, four were real duplication, and the rest
+were decisions nobody had written down.**
+
+| # | Pair | Verdict |
+|---|---|---|
+| 1, 2 | `nonStableGeneratorTypes` ↔ `clockLikeTypeNames` | **Defect, both ways.** One knew `Clock` and not `DispatchTime`, the other the reverse. Hoisted to `FreshTimestampType`. |
+| 4, 5 | `activatableViews` ↔ `interactiveElements` | **Defect, both ways.** A `Slider` with a redundant `.isButton` was reported as unactionable; a `Picker` below 44pt was reported by nothing. Hoisted to `InteractiveView`. |
+| 10, 11 | `stdlibValueTypes` ↔ `equatableStdlibTypes` | **Defect one way.** Five Foundation `Equatable` types were missing from the assertability gate, so a pure function returning a `TimeZone` was refused as a candidate. Hoisted to `StdlibTypeNames`. |
+| 3 | `randomReceiverTypeNames` ↔ `trivialValueTypes` | Dissolved by fixing #6 — it paired against a literal that no longer exists. |
+| 6 | `trivialValueTypes` ⊂ `primitiveCarriers` | Duplication. The second list was the first minus four names, said in prose. Now `subtracting`. |
+| 8 | `osLogMethods` ⊂ `loggingMethodNames` | Duplication with a real difference, unnamed. Now `LoggingMethod.osLogger` / `.anyLogger`. |
+| 9 | `compoundTerms` ⊂ `secretKeywords` | Duplication. A lowercased copy declared inside a function body, three entries behind. Deleted. |
+| 7 | `registerAll` ↔ `PatternCategory` | Correct and intentional. Suppressed **with the reasoning at the declaration**. |
+| 12 | `SetOperation` ↔ `setCombinationVerbs` | Correct and intentional; its two neighbours already carried directives and it did not. Directive added, plus a test pinning the duplication that *is* exact. |
+| 13 | `RawType` ⊂ `MinimalCodableValue` | Correct and intentional. Two enumerations of Swift's scalar type names, serving unrelated purposes. Suppressed with reasoning. |
+
+**Following the rule's own suggestion removes the finding, and that is not a coincidence.**
+Six of the thirteen were closed by deriving one list from the other or by hoisting both to a
+shared constant — and in every case the report disappeared as a *side effect*, because a
+derived list is no longer an array literal of names for Phase 1 to catalog. The rule's advice
+and the rule's silence agree. A reader who suppresses instead gets to keep the finding as a
+decision on the record; a reader who derives gets neither, which is the right trade.
+
+**The residual false positive has a sharper name than "deliberate subset".** Five of the
+thirteen — 3, 6, 8, 12, 13 — are two lists quantifying over the **same closed vocabulary**
+for **different capabilities**: the names of Swift's scalar types, the spellings of a log
+level, the verbs of set algebra. `randomReceiverTypeNames` and `trivialValueTypes` both
+enumerate Swift's numeric types because there is only one such list to enumerate, not because
+one was copied from the other. The rule matches on name overlap and has no way to see that
+the *predicate* differs, so this class is not closable by tuning a threshold. It is filed as
+issue #190 rather than patched.
+
+#### Measured precision on the first run
+
+All 14 findings of the first run were read individually. They were roughly **10 distinct
+pairs** (four are the same pair reported from both sides), of which **three were actionable**:
 
 1. **`animationFactories`** — a real defect. `AnimationPerformanceVisitor` knew five SwiftUI
    animation factories and `HardcodedAnimationValuesVisitor` seven, so the duration check was
@@ -212,6 +266,7 @@ pair reported from both sides), of which **three are actionable**:
    rules one `AnimationFactory` list. This is the first real bug the rule found.
 2. **`nonStableGeneratorTypes` vs `clockLikeTypeNames`** — a genuine disagreement: each holds
    something the other lacks (`Clock` vs `DispatchTime`) while describing the same concept.
+   Closed in the sweep above; it is `FreshTimestampType` now.
 3. **`osLogMethods` / `loggerLevelMethods`** — surfaced sideways. The real finding is that the
    two are byte-identical, which is [Parallel Enum Shape](parallel-enum-shape.md)'s job.
 
@@ -231,7 +286,7 @@ strict-subset floor** (see Phase 2 above). A three-repo sweep before and after t
 | SwiftProjectLint | 13 | **8** | dropped `systemViews`, `conflictingModifiers`, the `primitiveCarriers`/Equatable pair |
 | SwiftLintRuleStudio | 2 | **2** | one genuine *mutual-divergence* pair (`modeledReservedKeys` vs `defaultTopLevelKeyOrder`) — unaffected |
 
-The eight that survive on SwiftProjectLint are mutual divergences and near-complete subsets
+The eight that survived on SwiftProjectLint were mutual divergences and near-complete subsets
 (`registerAll` at 0.86, the logging lists at 0.82). The one real finding in RuleStudio is
 mutual and never depended on the subset path. So the floor removed a whole noise class without
 touching the signal — precision rose on all three codebases at once.

--- a/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Support/FreshTimestampType.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Support/FreshTimestampType.swift
@@ -1,0 +1,33 @@
+/// Type names whose `.now` yields a fresh reading of the clock, in one place.
+///
+/// Two idempotency rules ask the same question — "is `X.now` a value that changes between
+/// two evaluations?" — and each answered it from its own literal set. They had drifted in
+/// both directions: `MissingIdempotencyKeyVisitor` knew `Clock` and not `DispatchTime`,
+/// `TupleEqualityWithUnstableComponentsVisitor` knew `DispatchTime` and not `Clock`, so
+/// each rule was blind to one spelling the other already handled. Found by dogfooding
+/// `ParallelListDrift` on this project — the same finding that produced `AnimationFactory`.
+///
+/// One list means a type added for one rule is honoured by the other. The two rules still
+/// differ in the *shapes* they match — property `X.now` versus call `X.now()` — which is a
+/// difference in syntax, not in the roster.
+enum FreshTimestampType {
+
+    /// Types whose `now` is read from the clock rather than stored.
+    ///
+    /// `Clock` is the protocol rather than a concrete type, so `Clock.now` is not something
+    /// the compiler would accept; it is kept because the cost of a name that never matches is
+    /// nothing, and a project type of that name reads the same way. Every entry is unstable by
+    /// construction, so widening this set can only ever add a finding, never silence one.
+    static let all: Set<String> = [
+        "Date",
+        "Clock",
+        "ContinuousClock",
+        "SuspendingClock",
+        "DispatchTime"
+    ]
+
+    /// Whether `name` is one of the fresh-timestamp types.
+    static func matches(_ name: String) -> Bool {
+        all.contains(name)
+    }
+}

--- a/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Visitors/MissingIdempotencyKeyVisitor.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Visitors/MissingIdempotencyKeyVisitor.swift
@@ -189,7 +189,7 @@ final class MissingIdempotencyKeyVisitor: CrossFileVisitorBase, CrossFilePattern
             // `Date.now` — the classic "timestamp as idempotency key" mistake.
             if let base = member.base,
                let baseRef = base.as(DeclReferenceExprSyntax.self),
-               Self.nonStableGeneratorTypes.contains(baseRef.baseName.text),
+               FreshTimestampType.matches(baseRef.baseName.text),
                member.declName.baseName.text == "now" {
                 return "`\(baseRef.baseName.text).now` (a fresh timestamp)"
             }
@@ -206,14 +206,6 @@ final class MissingIdempotencyKeyVisitor: CrossFileVisitorBase, CrossFilePattern
         "arc4random",
         "arc4random_uniform",
         "CFUUIDCreate"
-    ]
-
-    /// Types whose `.now` property is a fresh-per-call timestamp.
-    private static let nonStableGeneratorTypes: Set<String> = [
-        "Date",
-        "Clock",
-        "ContinuousClock",
-        "SuspendingClock"
     ]
 
     private func calleeBaseName(of expr: ExprSyntax) -> String? {

--- a/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Visitors/TupleEqualityWithUnstableComponentsVisitor.swift
+++ b/Packages/SwiftProjectLintIdempotencyRules/Sources/SwiftProjectLintIdempotencyRules/Visitors/TupleEqualityWithUnstableComponentsVisitor.swift
@@ -146,7 +146,7 @@ final class TupleEqualityWithUnstableComponentsVisitor: BasePatternVisitor {
         let methodName = member.declName.baseName.text
         let baseName = base.baseName.text
         if methodName == "now",
-           Self.clockLikeTypeNames.contains(baseName),
+           FreshTimestampType.matches(baseName),
            call.arguments.isEmpty {
             return "\(baseName).now()"
         }
@@ -163,7 +163,7 @@ final class TupleEqualityWithUnstableComponentsVisitor: BasePatternVisitor {
     private func unstableReason(forMemberAccess member: MemberAccessExprSyntax) -> String? {
         guard member.declName.baseName.text == "now",
               let base = member.base?.as(DeclReferenceExprSyntax.self),
-              Self.clockLikeTypeNames.contains(base.baseName.text) else {
+              FreshTimestampType.matches(base.baseName.text) else {
             return nil
         }
         return "\(base.baseName.text).now"
@@ -186,13 +186,6 @@ final class TupleEqualityWithUnstableComponentsVisitor: BasePatternVisitor {
     private static let unstableZeroArgFunctions: Set<String> = [
         "CFAbsoluteTimeGetCurrent",
         "mach_absolute_time"
-    ]
-
-    private static let clockLikeTypeNames: Set<String> = [
-        "Date",
-        "DispatchTime",
-        "ContinuousClock",
-        "SuspendingClock"
     ]
 
     private static let randomReceiverTypeNames: Set<String> = [

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/InteractiveView.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/InteractiveView.swift
@@ -1,0 +1,24 @@
+/// The SwiftUI views that carry their own action, in one place.
+///
+/// Two accessibility rules ask the same question — "does this view already respond to the
+/// user?" — and each answered it from its own literal set. They had drifted in both
+/// directions: `IsButtonTraitWithoutActionVisitor` knew `Picker` and not `Slider`,
+/// `TapTargetTooSmallVisitor` knew `Slider` and not `Picker`. Each omission is a real miss:
+/// a `Slider` carrying a redundant `.isButton` trait was reported as unactionable, and a
+/// `Picker` squeezed below 44pt was not reported at all.
+///
+/// One list means a view added for one rule is honoured by the other. Found by dogfooding
+/// `ParallelListDrift` on this project, the same way `AnimationFactory` was.
+enum InteractiveView {
+
+    /// Views that respond to the activate gesture without any modifier being added.
+    static let all: Set<String> = [
+        "Button", "NavigationLink", "Link", "Menu",
+        "Toggle", "Stepper", "Picker", "Slider"
+    ]
+
+    /// Whether `name` is one of the interactive views.
+    static func matches(_ name: String) -> Bool {
+        all.contains(name)
+    }
+}

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/IsButtonTraitWithoutActionVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/IsButtonTraitWithoutActionVisitor.swift
@@ -41,11 +41,6 @@ final class IsButtonTraitWithoutActionVisitor: BasePatternVisitor {
         "simultaneousGesture"
     ]
 
-    /// Views that already carry an action, where `.isButton` is merely redundant.
-    private static let activatableViews: Set<String> = [
-        "Button", "NavigationLink", "Link", "Menu", "Toggle", "Stepper", "Picker"
-    ]
-
     required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
         super.init(pattern: pattern, viewMode: viewMode)
     }
@@ -62,7 +57,7 @@ final class IsButtonTraitWithoutActionVisitor: BasePatternVisitor {
         if node.calledExpression.is(MemberAccessExprSyntax.self) { return }
 
         if let callee = node.calledExpression.as(DeclReferenceExprSyntax.self),
-           Self.activatableViews.contains(callee.baseName.text) {
+           InteractiveView.matches(callee.baseName.text) {
             return
         }
 

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/TapTargetTooSmallVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Accessibility/Visitors/TapTargetTooSmallVisitor.swift
@@ -8,11 +8,6 @@ final class TapTargetTooSmallVisitor: BasePatternVisitor {
 
     private static let minimumTapTarget: Double = 44.0
 
-    private static let interactiveElements: Set<String> = [
-        "Button", "Toggle", "Stepper", "Slider",
-        "Link", "NavigationLink", "Menu"
-    ]
-
     required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
         super.init(pattern: pattern, viewMode: viewMode)
     }
@@ -95,7 +90,7 @@ final class TapTargetTooSmallVisitor: BasePatternVisitor {
             // Check if current is an interactive element call
             if let call = current.as(FunctionCallExprSyntax.self),
                let declRef = call.calledExpression.as(DeclReferenceExprSyntax.self),
-               Self.interactiveElements.contains(declRef.baseName.text) {
+               InteractiveView.matches(declRef.baseName.text) {
                 return true
             }
             break

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/PrimitiveBypassingDomainTypeVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/PrimitiveBypassingDomainTypeVisitor.swift
@@ -35,17 +35,20 @@ final class PrimitiveBypassingDomainTypeVisitor: CrossFileVisitorBase, CrossFile
         "UUID", "URL", "Data", "Decimal"
     ]
 
+    /// The carriers distinctive enough that a `[…: T]` map matching a `[W: T]` one is worth
+    /// trusting. A `[…: Data]` or `[…: UUID]` map says something; a `[…: String]` one does not.
+    private static let richCarriers: Set<String> = ["UUID", "URL", "Data", "Decimal"]
+
     /// Value types too ubiquitous for the value-type guard to mean anything: a `[…: String]` or
-    /// `[…: Int]` map is everywhere, so matching one against `[W: String]` is coincidence. The
-    /// richer primitives (`UUID`, `URL`, `Data`, `Decimal`) are *not* here — a `[…: Data]` map is
-    /// distinctive enough to trust. Measured: 58 `String` + 13 `Int` false hits vs 1 real
-    /// (`[…: MediaType]`) across 32 projects.
-    private static let trivialValueTypes: Set<String> = [
-        "String", "Substring", "Character",
-        "Int", "Int8", "Int16", "Int32", "Int64",
-        "UInt", "UInt8", "UInt16", "UInt32", "UInt64",
-        "Double", "Float", "Bool"
-    ]
+    /// `[…: Int]` map is everywhere, so matching one against `[W: String]` is coincidence.
+    /// Measured: 58 `String` + 13 `Int` false hits vs 1 real (`[…: MediaType]`) across 32
+    /// projects.
+    ///
+    /// Derived rather than restated. This is `primitiveCarriers` minus the four rich ones, and
+    /// it used to be a second literal saying so — which meant a carrier added above and not
+    /// below would silently become a trusted value type. Written this way the relationship is
+    /// the code, and a new carrier joins both sides at once.
+    private static let trivialValueTypes: Set<String> = primitiveCarriers.subtracting(richCarriers)
 
     private struct DictUsage {
         let key: String

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/BuiltInRules.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/BuiltInRules.swift
@@ -31,6 +31,19 @@ public enum BuiltInRules {
     /// The category factories themselves. Split out so the locked region stays
     /// readable; it must only ever be called with `lock` held.
     private static func registerCategoryFactories() {
+        // `ParallelListDrift` reports this run against `PatternCategory` — twelve of the
+        // fourteen cases have a factory here, `idempotency` and `other` do not — and it is
+        // right to: two lists that agree on twelve entries and disagree on two is exactly the
+        // shape that is usually a forgotten registration. This pair is the exception, and the
+        // reason is not readable from either file. `idempotency`'s factories are registered by
+        // `SwiftProjectLintIdempotencyRules`, a separate package with its own entry point, and
+        // `other` is the catch-all a rule falls into when it has no category — there is no
+        // factory for it to have. Neither omission can be fixed by adding a line here.
+        //
+        // `ParallelListDriftDogfoodTests` still pins the raw finding, because suppression is
+        // applied by the engine and not by the visitor. So the rule's behaviour stays under
+        // test while the corpus stops re-asking a question that has an answer.
+        // swiftprojectlint:disable:next parallel-list-drift
         SourcePatternRegistry.registerFactory { registry, visitorRegistry in
             StateManagement(registry: registry, visitorRegistry: visitorRegistry)
         }

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/CatchWithoutHandlingVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/CatchWithoutHandlingVisitor.swift
@@ -97,11 +97,6 @@ final class CatchWithoutHandlingVisitor: BasePatternVisitor {
 
     // MARK: - Logging Call Detection
 
-    private static let loggingMethodNames: Set<String> = [
-        "log", "error", "warning", "warn", "debug", "info",
-        "critical", "fault", "verbose", "trace", "notice"
-    ]
-
     private static let loggingFunctionNames: Set<String> = [
         "print", "debugPrint", "NSLog", "os_log", "os_signpost"
     ]
@@ -115,7 +110,7 @@ final class CatchWithoutHandlingVisitor: BasePatternVisitor {
             }
             // Method calls: logger.error(...), os.log.debug(...), etc.
             if let member = call.calledExpression.as(MemberAccessExprSyntax.self),
-               Self.loggingMethodNames.contains(member.declName.baseName.text) {
+               LoggingMethod.anyLogger.contains(member.declName.baseName.text) {
                 return true
             }
         }

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/LoggingMethod.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/LoggingMethod.swift
@@ -1,0 +1,29 @@
+/// The method names a logging call is spelled with, in one place.
+///
+/// Two rules ask a question about the same vocabulary from opposite ends.
+/// `LoggingSensitiveDataVisitor` asks *"is this call writing to the log?"* and must stay on
+/// Apple's `Logger` surface, because it reports a secret being logged and a false positive
+/// there is an accusation. `CatchWithoutHandlingVisitor` asks *"did this catch block do
+/// anything at all?"* and is better off recognising every logger anyone ships, because a
+/// name it does not know turns a handled error into a reported one.
+///
+/// So the two sets genuinely differ, and the difference is now written down rather than
+/// implied by two literals that happened not to match. `osLogger` is the closed roster of
+/// `os.Logger`'s own methods; `anyLogger` adds the spellings third-party loggers use.
+/// Before this, `CatchWithoutHandlingVisitor` carried the union as its own literal and the
+/// relationship between the two was invisible — the shape `ParallelListDrift` reports.
+enum LoggingMethod {
+
+    /// `os.Logger`'s logging methods. Closed: this is an API surface, not a convention.
+    static let osLogger: Set<String> = [
+        "log", "trace", "debug", "info",
+        "notice", "warning", "error", "critical", "fault"
+    ]
+
+    /// Spellings that are *not* on `os.Logger` but are what other logging libraries call
+    /// the same levels — SwiftyBeaver's `verbose`, CocoaLumberjack's `warn`.
+    static let thirdPartyOnly: Set<String> = ["verbose", "warn"]
+
+    /// Any method name that reads as a logging call, whichever library it came from.
+    static let anyLogger: Set<String> = osLogger.union(thirdPartyOnly)
+}

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Security/Visitors/LoggingSensitiveDataVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Security/Visitors/LoggingSensitiveDataVisitor.swift
@@ -28,10 +28,6 @@ final class LoggingSensitiveDataVisitor: BasePatternVisitor {
         "NSLog"
     ]
 
-    private static let osLogMethods: Set<String> = [
-        "log", "debug", "info", "notice", "error", "fault", "warning", "critical", "trace"
-    ]
-
     private var insideIfDebug = false
 
     required init(pattern: SyntaxPattern, viewMode: SyntaxTreeViewMode = .sourceAccurate) {
@@ -64,7 +60,7 @@ final class LoggingSensitiveDataVisitor: BasePatternVisitor {
             isLoggingCall = Self.loggingFunctions.contains(declRef.baseName.text)
                 || Self.nsLogFunctions.contains(declRef.baseName.text)
         } else if let memberAccess = node.calledExpression.as(MemberAccessExprSyntax.self) {
-            isLoggingCall = Self.osLogMethods.contains(memberAccess.declName.baseName.text)
+            isLoggingCall = LoggingMethod.osLogger.contains(memberAccess.declName.baseName.text)
         } else {
             isLoggingCall = false
         }

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Security/Visitors/SecurityVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Security/Visitors/SecurityVisitor.swift
@@ -198,16 +198,19 @@ class SecurityVisitor: BasePatternVisitor {
     }
 
     /// Sensitive name check for entropy-based detection.
-    /// Uses compound keywords to avoid false positives on "cacheKey", "sortKey", etc.
+    ///
+    /// Reads `secretKeywords` — the same list the literal-assignment check uses, matched the
+    /// same case-insensitive-substring way. It used to be a second, lowercased copy declared
+    /// inside this function, and the copy had fallen three entries behind: it lacked
+    /// `apiSecret`, `clientSecret` and `secretAccessKey`. Those three cost nothing, because
+    /// `secret` is a substring of all of them — which is the point. The duplicate was
+    /// invisible to review precisely because it *could* drift without changing an answer, so
+    /// nothing would have caught the entry that did.
+    ///
+    /// Every keyword is compound (`apiKey`, not `key`), which is what keeps `cacheKey` and
+    /// `sortKey` from matching.
     private func isSensitiveVariableName(_ name: String) -> Bool {
-        let lower = name.lowercased()
-        let compoundTerms = [
-            "apikey", "secretkey", "authkey", "privatekey",
-            "encryptionkey", "signingkey", "accesskey",
-            "secret", "token", "password", "passwd",
-            "credential", "bearer", "passphrase"
-        ]
-        return compoundTerms.contains { lower.contains($0) }
+        Self.secretKeywords.contains { name.localizedCaseInsensitiveContains($0) }
     }
 
     /// Computes Shannon entropy in bits per character.

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/CleanInstanceMethodCatalog.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/CleanInstanceMethodCatalog.swift
@@ -108,15 +108,9 @@ public struct CleanInstanceMethodCatalog: Sendable, Equatable {
     /// data the caller already supplies, not a collaborator it would want to replace.
     ///
     /// Collections, optionals and tuples are recognised by syntax rather than by name, so the list
-    /// carries only the nominal leaves.
-    static let stdlibValueTypes: Set<String> = [
-        "String", "Substring", "Character", "Bool",
-        "Int", "Int8", "Int16", "Int32", "Int64",
-        "UInt", "UInt8", "UInt16", "UInt32", "UInt64",
-        "Double", "Float", "CGFloat", "Decimal",
-        "URL", "Data", "UUID", "Date", "TimeInterval", "Range", "ClosedRange",
-        "IndexSet", "IndexPath", "Locale", "TimeZone", "Calendar"
-    ]
+    /// carries only the nominal leaves — which is why it reads `valueLeaves` and not the whole of
+    /// `StdlibTypeNames.equatable`.
+    static let stdlibValueTypes: Set<String> = StdlibTypeNames.valueLeaves
 
     /// The clean method names declared on `typeName`, or none for a free function.
     public func cleanMethods(on typeName: String?) -> Set<String> {

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/PropertyTestCandidacy.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/PropertyTestCandidacy.swift
@@ -53,14 +53,7 @@ public enum PropertyTestCandidacy {
     /// Standard-library types whose values are `Equatable` out of the box. Container names are
     /// `Equatable` when their elements are; `baseTypeName` unwraps `[T]` to `T` so a custom element
     /// is still checked against the project's conformance index.
-    private static let equatableStdlibTypes: Set<String> = [
-        "Int", "Int8", "Int16", "Int32", "Int64",
-        "UInt", "UInt8", "UInt16", "UInt32", "UInt64",
-        "Double", "Float", "Float16", "CGFloat", "Decimal",
-        "Bool", "String", "Character", "Substring", "StaticString",
-        "Date", "UUID", "URL", "Data", "TimeInterval",
-        "Array", "Set", "Dictionary", "Range", "ClosedRange"
-    ]
+    private static let equatableStdlibTypes: Set<String> = StdlibTypeNames.equatable
 
     /// What `function` is a function of, or `nil` when it is not a property-test candidate.
     ///

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/StdlibTypeNames.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/StdlibTypeNames.swift
@@ -1,0 +1,38 @@
+/// The stdlib and Foundation type names two rules both enumerate, in one place.
+///
+/// `CleanInstanceMethodCatalog.stdlibValueTypes` asks *"is a stored property of this type
+/// data the test already supplies?"* and `PropertyTestCandidacy.equatableStdlibTypes` asks
+/// *"can a test assert on a value of this type?"* Those are different questions with almost
+/// the same answer, and each was answered from its own literal. The two had drifted five
+/// entries in each direction.
+///
+/// One of those directions was a real gap: `Calendar`, `Locale`, `TimeZone`, `IndexSet` and
+/// `IndexPath` are all `Equatable`, and a function returning one was refused as a
+/// property-test candidate because the assertability list had never been told. The other
+/// direction is a deliberate difference, and it is what `valueLeaves` and
+/// `equatableContainers` are named for: a container is `Equatable` when its elements are, so
+/// `Array` belongs to the assertability question and not to the "nominal leaves" one, which
+/// recognises containers by syntax instead.
+///
+/// Found by dogfooding `ParallelListDrift` on this project.
+enum StdlibTypeNames {
+
+    /// Nominal leaves: a value a test constructs directly, and `Equatable` out of the box.
+    static let valueLeaves: Set<String> = [
+        "String", "Substring", "Character", "StaticString", "Bool",
+        "Int", "Int8", "Int16", "Int32", "Int64",
+        "UInt", "UInt8", "UInt16", "UInt32", "UInt64",
+        "Double", "Float", "Float16", "CGFloat", "Decimal",
+        "URL", "Data", "UUID", "Date", "TimeInterval",
+        "Range", "ClosedRange",
+        "IndexSet", "IndexPath", "Locale", "TimeZone", "Calendar"
+    ]
+
+    /// Generic containers, `Equatable` exactly when their elements are. Present for the
+    /// assertability question and deliberately absent from `valueLeaves`, where containers,
+    /// optionals and tuples are recognised by syntax rather than by name.
+    static let equatableContainers: Set<String> = ["Array", "Set", "Dictionary"]
+
+    /// Every stdlib name whose values a test can compare.
+    static let equatable: Set<String> = valueLeaves.union(equatableContainers)
+}

--- a/Tests/CoreTests/Accessibility/IsButtonTraitWithoutActionVisitorTests.swift
+++ b/Tests/CoreTests/Accessibility/IsButtonTraitWithoutActionVisitorTests.swift
@@ -94,6 +94,29 @@ struct IsButtonTraitWithoutActionVisitorTests {
         #expect(visitor.detectedIssues.count == 1)
     }
 
+    /// `Slider` was absent from this rule's own list while its twin,
+    /// `TapTargetTooSmallVisitor`, already had it — so a slider carrying a redundant
+    /// `.isButton` was reported as having nothing to activate. Both rules now read
+    /// `InteractiveView`.
+    @Test
+    func noIssueForSliderWhichCarriesItsOwnAction() {
+        let source = """
+        import SwiftUI
+
+        struct MyView: View {
+            var body: some View {
+                Slider(value: $amount, in: 0 ... 1)
+                    .accessibilityAddTraits(.isButton)
+            }
+        }
+        """
+
+        let visitor = makeVisitor()
+        runVisitor(visitor, source: source)
+
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
     // MARK: - Negative Cases
 
     @Test("No issue when the element is activatable", arguments: [

--- a/Tests/CoreTests/Accessibility/TapTargetTooSmallVisitorTests.swift
+++ b/Tests/CoreTests/Accessibility/TapTargetTooSmallVisitorTests.swift
@@ -73,6 +73,18 @@ struct TapTargetTooSmallVisitorTests {
         #expect(issues.count == 1)
     }
 
+    /// `Picker` was absent from this rule's own list while its twin,
+    /// `IsButtonTraitWithoutActionVisitor`, already had it — so a picker squeezed below the
+    /// 44pt minimum was reported by nothing. Both rules now read `InteractiveView`.
+    @Test func testFlagsPicker() {
+        let source = """
+        Picker("Mode", selection: $mode) { Text("A").tag(0) }
+            .frame(width: 30, height: 30)
+        """
+        let issues = filteredIssues(source)
+        #expect(issues.count == 1)
+    }
+
     // MARK: - Negative: should NOT flag
 
     @Test func testNoIssueForMeetsMinimum() {

--- a/Tests/CoreTests/Testability/PureFunctionCandidateVisitorTests.swift
+++ b/Tests/CoreTests/Testability/PureFunctionCandidateVisitorTests.swift
@@ -463,6 +463,15 @@ struct PureFunctionCandidateGateTests {
         #expect(analyze("func half(_ x: Int) -> Double { Double(x) / 2 }").count == 1)
     }
 
+    /// The five Foundation value types this gate had never been told about. All are
+    /// `Equatable`, all were already on `CleanInstanceMethodCatalog`'s twin list, and a
+    /// function returning one was refused as a candidate for no reason anyone had chosen.
+    /// Both lists now read `StdlibTypeNames`.
+    @Test(arguments: ["Calendar", "Locale", "TimeZone", "IndexSet", "IndexPath"])
+    func keepsFoundationEquatableReturns(typeName: String) {
+        #expect(analyze("func pick(_ x: Int) -> \(typeName) { .current }").count == 1)
+    }
+
     @Test func keepsOptionalAndArrayOfEquatable() {
         #expect(analyze("func maybe(_ x: Int) -> Int? { x > 0 ? x : nil }").count == 1)
         #expect(analyze("func dupe(_ x: Int) -> [Int] { [x, x] }").count == 1)


### PR DESCRIPTION
## What this is

The 26-repository sweep reported **13** `parallel-list-drift` findings, 11 of them here. All
11 are dispositioned in this branch. Parallel List Drift now reports **zero** on this
repository.

The disposition is not uniform, and that is the point of reading all of them:

| # | Pair | What it was |
|---|---|---|
| 1, 2 | `nonStableGeneratorTypes` ↔ `clockLikeTypeNames` | **Defect, both directions.** One rule knew `Clock` and not `DispatchTime`; the other knew `DispatchTime` and not `Clock`. Each was blind to a spelling its twin already handled. → `FreshTimestampType` |
| 4, 5 | `activatableViews` ↔ `interactiveElements` | **Defect, both directions.** A `Slider` carrying a redundant `.isButton` was reported as having nothing to activate; a `Picker` squeezed below 44pt was reported by nothing at all. → `InteractiveView` |
| 10, 11 | `stdlibValueTypes` ↔ `equatableStdlibTypes` | **Defect one direction.** `Calendar`, `Locale`, `TimeZone`, `IndexSet`, `IndexPath` are all `Equatable` and were already on one list; the assertability gate had never been told, so a pure function returning a `TimeZone` was refused as a property-test candidate. → `StdlibTypeNames` |
| 6 | `trivialValueTypes` ⊂ `primitiveCarriers` | Duplication. The second list was the first minus four names, stated in prose above it. Now `primitiveCarriers.subtracting(richCarriers)`. |
| 3 | `randomReceiverTypeNames` ↔ `trivialValueTypes` | Dissolved by #6 — it paired against a literal that no longer exists. |
| 8 | `osLogMethods` ⊂ `loggingMethodNames` | Duplication hiding a real difference nobody had named: one rule must stay on `os.Logger`'s surface because it accuses code of logging a secret, the other should recognise every logger anyone ships. → `LoggingMethod.osLogger` / `.thirdPartyOnly` / `.anyLogger` |
| 9 | `compoundTerms` ⊂ `secretKeywords` | Duplication. A lowercased copy of the roster declared *inside a function body*, already three entries behind. Deleted; the function reads the static. |
| 7 | `registerAll` ↔ `PatternCategory` | Correct and intentional, and the answer was written in the rule's docs and a test comment but in neither file a reader would open. Directive with the reasoning at the declaration. |

**Three defects, four duplications, one recorded decline.** None of the three defects would
have been found by a test, because in every case both rules pass their own suites — the
missing entry is a name neither suite mentions.

## Two things worth scrutinising

**The widenings are one-directional and I claim that makes them safe.** `FreshTimestampType`
gains `DispatchTime` for one rule and `Clock` for the other; every entry in that set is
unstable by construction, so widening can add a finding and never silence one. Same for
`InteractiveView`: adding a name can only exempt a view from the `.isButton` rule and only
subject it to the tap-target rule, both of which are the correct direction for a genuinely
interactive view. `StdlibTypeNames` is the one to check hardest — it widens the *assertability*
gate, which decides whether something becomes a property-test seed, so a wrong entry there
produces a seed for a type a test cannot compare. All five additions are `Equatable` in
Foundation.

**Finding 9's fix looks like a behaviour change and is not.** The deleted copy lacked
`apiSecret`, `clientSecret` and `secretAccessKey` — and `secret` is a substring of all three,
matched case-insensitively, so the three were already covered. That is exactly why the
duplicate survived review: it could drift without changing an answer, so nothing would have
caught the entry that did.

## Tests

Three regression tests, one per defect, each pinning the entry the list was missing. All
three fail if the name is removed — verified by removing it.

`ParallelListDriftDogfoodTests` is untouched and still pins finding 7's raw output, because
inline suppression is applied by the engine and not by the visitor.

3,624 tests pass; `swiftlint` exits 0.

## Documentation, and one issue left open

The rule's doc is brought up to date: the 13-finding sweep with a verdict per row; the
observation that **following the rule's own advice silences it by construction** (a derived
list is `canonical.subtracting([…])`, not an array literal, so Phase 1 never catalogs it —
six of thirteen closed that way); and a sharper name for the residual false positive.

Five of the thirteen were **two lists over one closed vocabulary answering different
questions** — Swift's scalar type names, log-level spellings, set-algebra verbs. They overlap
because there is only one such vocabulary, not because either was copied. No threshold
reaches that, because the difference is in the predicate the list is consulted with. Filed as
#190 rather than patched, with the three gates I could describe and why each is worse than
the finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrD7SdySCSbg15qC8qbpYy