### PR TITLE
Stop telling composition roots they block a property test

### DIFF
--- a/Docs/rules/non-injected-nondeterminism.md
+++ b/Docs/rules/non-injected-nondeterminism.md
@@ -19,10 +19,10 @@ A property-based test re-runs logic against many randomized inputs and, when it 
 Uses in a parameter *default value* position are exempt — a defaulted `clock: () -> Date = { Date() }`
 is itself the injection seam — as are test files.
 
-### Three faults, one trigger
+### Four faults, one trigger
 
-The same marker witnesses three different problems, and only one of them is about testability. The
-rule reports all three, with different messages.
+The same marker witnesses four different situations, and only one of them is a testability problem
+you can fix by injecting anything. The rule reports all four, with different messages.
 
 **Cannot control the value.** A clock or an RNG read inline, feeding a bound, a branch or a retry
 window. The value is real; a test cannot pin it. The discriminator this fault wants — does the
@@ -136,6 +136,81 @@ site, `now` reads as a value, and only the second one misleads.
 
 Like the lazy-creation gate, this **changes what the rule says and not what it counts**: the same
 sites are reported, with a message that names the fault they actually have.
+
+#### Handed straight on — a composition-root read
+
+The read's value becomes a call argument and this scope never looks at it again:
+
+```swift
+store.approve(proposalID: id, by: reviewer, on: Date())
+
+let now = Date()
+summary(asOf: now)
+content(asOf: now)
+```
+
+**This is what following the rest of this rule's advice produces**, which is why it needed its own
+sentence rather than a gate. The ordinary message says a property-based test cannot pin the value.
+At a composition root that is false about everything that decides: the callee takes the instant as
+a parameter and a test pins it there. The only unpinnable thing is the expression itself, which
+contains no logic. A reader who moved every clock read to the edge — exactly what this rule asked
+for — was still being told their code was untestable.
+
+So the message changes and the count does not. These sites were already reported and still are;
+see [A composition-root read stays reported](#a-composition-root-read-stays-reported-and-that-is-deliberate)
+for why suppressing them would be worse than reporting them.
+
+**Argument position only, and that restriction is the whole precision.** A receiver is not handing
+the value on, it is *using* it — and every real defect this rule has produced across the corpus
+reads the clock into a receiver or an operand, never into a bare argument:
+
+| Shape | What the scope did with it |
+| --- | --- |
+| `Date().addingTimeInterval(timeout)` | a subprocess deadline |
+| `Date().timeIntervalSince(start)` | the entire output of a benchmark |
+| `Date.now.timeIntervalSince1970` | a number bound into SQL |
+| `"probe_\(UUID().uuidString).swift"` | a filename this scope composed |
+
+The bound spelling counts too — `let now = Date()` then only `f(asOf: now)` — and it demands that
+**every** reference to the binding is itself an argument. One comparison, one piece of arithmetic,
+one `return`, and the binding keeps the ordinary message. That is the safe direction: a shadowed
+name can only add a reference that must also pass, never excuse one that does not. A stored
+property's initial value is *not* a composition root, because the read happens once per instance
+and the uses are in members this walk cannot see — `WaiverRequestSheet`'s
+`@State private var openedAt = Date()` is the corpus instance, and it feeds arithmetic two lines
+below.
+
+**The message does not say "no action", and that distinction is load-bearing.** The corpus's one
+live defect of this shape was
+
+```swift
+for entry in filtered { … }                       // the whole eval run
+let report = EvalReport(gitSHA: sha, startedAt: Date(), results: results)
+```
+
+— `startedAt` read *after* the loop, so the `started_at` column of `swift-assist-eval history` and
+every report filename carried the instant each run **finished**. Nothing there is untestable and
+nothing is fabricated; the read is simply taken at the wrong moment. A message that closed the
+finding would have hidden it, so the suggestion asks the one question this shape can still get
+wrong: *is the value read at the moment its label claims?*
+
+**Measured before shipping, and the estimate was wrong in the usual direction.** Reading all 37
+corpus findings by hand suggested the arm would reach about 34. The inline form alone reached
+**20 of 37**; adding the bound form took it to **25**. That is the fifth time a prediction about a
+rule on this project has come in high, and the second on this rule.
+
+**The arm reclassifies and never removes**, which is asserted by a test rather than assumed: the
+corpus reported 37 before and 37 after, with 20 of them carrying the new sentence. The rule now
+reports 34 across the corpus, and the missing three are declines merged separately — an edge-case
+generator whose filler is arbitrary by design, and a deliberately broken `Hashable` conformance in
+a book chapter that exists to be falsified. Both are the shape
+[the decline section](#when-a-suppression-is-right) names.
+
+The nine that keep the ordinary message are worth listing, because they are what the arm is
+*not* claiming: two stamps assigned to storage, a lazy-created session id, a `@State` initial
+value that feeds arithmetic, and four receivers — `Date.now.formatted(…)`,
+`Date.now.timeIntervalSince1970`, `UUID().uuidString`, and a `UUID()` interpolated into a probe
+filename.
 
 ### Two shapes where the finding is right and "inject the source" is wrong
 

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor+Messages.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor+Messages.swift
@@ -84,6 +84,45 @@ extension NonInjectedNondeterminismVisitor {
     ///
     /// This changes what the rule *says* and not what it counts — these sites
     /// were already reported, and still are.
+    /// Reports the fourth shape: the read is handed straight to something that takes it as a
+    /// parameter, and this scope never examines it.
+    ///
+    /// **This is what following the rest of this rule's advice looks like**, which is why it needed
+    /// its own sentence. The ordinary message says a property-based test cannot pin the value — and
+    /// at a composition root that is false in the way that matters: the decision is in the callee,
+    /// the callee takes the instant as a parameter, and a test pins it there. `WaiversView` went
+    /// 20 findings to 20 by moving every clock read to the top of `body`, and every one of the
+    /// survivors was still being told it blocked a test.
+    ///
+    /// **It does not say the line is fine, and that distinction is load-bearing.** The corpus's one
+    /// live defect of this shape is `EvalReport(gitSHA:, startedAt: Date(), results: results)`,
+    /// written *after* the fixture loop — so the eval history table's `started_at` column and every
+    /// report filename carried the instant the run **finished**. Nothing there is untestable and
+    /// nothing is fabricated; the read is simply taken at the wrong moment. A message that said
+    /// "composition root, no action" would have closed that finding. So the sentence asks the one
+    /// question this shape can still get wrong.
+    ///
+    /// Same severity and still counted. The list is the answer to *where does this program touch
+    /// the clock?*, and suppressing the entries that answer it correctly would leave a census that
+    /// only contains mistakes.
+    func flagCompositionRoot(_ source: String, at node: Syntax) {
+        addIssue(
+            severity: .warning,
+            message: "Clock/RNG read at a composition root: `\(source)` is handed straight on as an "
+                + "argument and never examined here, so the only thing a test cannot pin is this "
+                + "expression",
+            filePath: getFilePath(for: node),
+            lineNumber: getLineNumber(for: node),
+            suggestion: "Nothing to inject — whatever decides takes this value as a parameter and "
+                + "is testable there. This is the end state the rest of this rule asks for, and it "
+                + "stays listed so the set of places the program reads ambient state is visible. "
+                + "The one thing still worth checking: is the value read at the moment its label "
+                + "claims? A `startedAt:` filled in after the work is done is not a testability "
+                + "problem and is still wrong.",
+            ruleName: .nonInjectedNondeterminism
+        )
+    }
+
     func flagFreshReadPerAccess(_ source: String, property: String, at node: Syntax) {
         addIssue(
             severity: .warning,

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor+Placement.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor+Placement.swift
@@ -124,6 +124,117 @@ extension NonInjectedNondeterminismVisitor {
     /// clause rather than merely to have a parameter ancestor, and a function
     /// or accessor body between the two ends it — a nested declaration's body
     /// is code that runs, not a value being handed over.
+    /// Whether the read is **handed straight on** — its value becomes a call argument and this
+    /// scope never looks at it.
+    ///
+    /// This is the shape the rest of this rule's own advice produces. "Move the clock read to the
+    /// edge and pass the instant down" is what the ordinary message asks for, and a reader who does
+    /// it lands here: `resolve(asOf: Date())`, `store.approve(on: Date())`,
+    /// `EvalReport(startedAt: Date(), …)`. The finding is still true — nothing can pin *this line* —
+    /// but the sentence attached to it was not: everything that decides takes the instant as a
+    /// parameter, so a test pins the decision at the callee's boundary. Telling a reader their code
+    /// is untestable when the untestable part is a single unexamined expression is how a rule talks
+    /// someone out of a repair it asked for.
+    ///
+    /// **Argument position only, and that restriction is the whole precision.** A receiver is not
+    /// handing the value on, it is *using* it: `Date().addingTimeInterval(timeout)` is a deadline,
+    /// `Date().timeIntervalSince(start)` is an elapsed time, `Date.now.timeIntervalSince1970` is a
+    /// number this scope computed. Every real defect this rule has produced across the corpus —
+    /// the subprocess timeout, the benchmark timings, the rate limiters, the snapshot collision
+    /// loop — reads the clock into a receiver or an operand, never into a bare argument.
+    ///
+    /// **The bound spelling counts too, and it had to.** `let now = Date()` at the top of a `body`,
+    /// then `header(asOf: now)` and `content(asOf: now)`, is the archetype — it is the shape the
+    /// repositories worked on earlier runs were left in, and an arm that could not label it would
+    /// miss the case it exists for. Measured before shipping: the inline form alone reached 20 of
+    /// 37 findings and the bound form takes it to 25, and every one of the five it adds carries a
+    /// hand-written comment above it recording the defect that moving the read there fixed.
+    ///
+    /// The bound form demands that **every** reference to the binding is itself handed straight on.
+    /// One comparison, one piece of arithmetic, one `return`, and the binding fails — which is the
+    /// safe direction: a shadowed name can only add a reference that must also pass, never excuse
+    /// one that does not. It is scoped to a local `let`; a stored property's initial value is not a
+    /// composition root, because the read happens once per instance and the uses are elsewhere.
+    func isHandedStraightOn(_ node: Syntax) -> Bool {
+        if isArgumentPosition(node) { return true }
+        return isBoundAndOnlyPassedOn(node)
+    }
+
+    /// The `let name = <read>` case: a local binding whose every use is an argument.
+    private func isBoundAndOnlyPassedOn(_ node: Syntax) -> Bool {
+        guard let clause = node.parent?.as(InitializerClauseSyntax.self),
+              Syntax(clause.value).id == node.id,
+              let binding = clause.parent?.as(PatternBindingSyntax.self),
+              let declaration = binding.parent?.parent?.as(VariableDeclSyntax.self),
+              declaration.bindingSpecifier.text == "let",
+              // A stored property is not a composition root: the read happens per instance and
+              // the uses are in other members, where this walk cannot see them.
+              declaration.parent?.parent?.is(CodeBlockItemListSyntax.self) == true,
+              let name = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
+              let scope = enclosingScope(of: Syntax(declaration)) else { return false }
+
+        var references = 0
+        var allPassedOn = true
+        walkReferences(named: name, in: scope) { reference in
+            references += 1
+            if !self.isArgumentPosition(reference) { allPassedOn = false }
+        }
+        return references > 0 && allPassedOn
+    }
+
+    /// The nearest enclosing block, which is as far as a local binding can be seen.
+    private func enclosingScope(of node: Syntax) -> Syntax? {
+        var current = node.parent
+        while let syntax = current {
+            if syntax.is(CodeBlockSyntax.self) || syntax.is(AccessorBlockSyntax.self) {
+                return syntax
+            }
+            current = syntax.parent
+        }
+        return nil
+    }
+
+    private func walkReferences(named name: String, in scope: Syntax, _ visit: (Syntax) -> Void) {
+        for child in scope.children(viewMode: .sourceAccurate) {
+            if let reference = child.as(DeclReferenceExprSyntax.self),
+               reference.baseName.text == name {
+                visit(Syntax(reference))
+            }
+            walkReferences(named: name, in: child, visit)
+        }
+    }
+
+    private func isArgumentPosition(_ node: Syntax) -> Bool {
+        var child = node
+        var current = node.parent
+        while let syntax = current {
+            // A receiver, not an argument: this scope is about to do something with the value.
+            if let member = syntax.as(MemberAccessExprSyntax.self) {
+                return member.base.map { Syntax($0).id == child.id } == false
+            }
+            if let element = syntax.as(LabeledExprSyntax.self),
+               let list = element.parent?.as(LabeledExprListSyntax.self),
+               let call = list.parent?.as(FunctionCallExprSyntax.self) {
+                // The callee itself is not an argument.
+                return Syntax(call.calledExpression).id != child.id
+            }
+            if syntax.is(CodeBlockSyntax.self) || syntax.is(AccessorBlockSyntax.self) { return false }
+            guard isTransparentPassthrough(syntax) else { return false }
+            child = syntax
+            current = syntax.parent
+        }
+        return false
+    }
+
+    /// Wrappers that do not change what is being done with the value.
+    ///
+    /// Narrower than the `??`-chain walk's `isTransparentWrapper`, which also steps through tuple
+    /// elements: a tuple *is* a value this scope built, so stepping through one would read
+    /// `f((Date(), x))` as handing the instant on when what was handed on is the pair.
+    private func isTransparentPassthrough(_ syntax: Syntax) -> Bool {
+        syntax.is(TryExprSyntax.self) || syntax.is(AwaitExprSyntax.self)
+    }
+
     func isParameterDefaultValue(_ node: Syntax) -> Bool {
         var child = node
         var current = node.parent

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor.swift
@@ -172,6 +172,13 @@ final class NonInjectedNondeterminismVisitor: BasePatternVisitor {
             flagFreshReadPerAccess(source.marker, property: property, at: node)
             return
         }
+        // Checked last: the fresh-read arm is about *where the read is declared* and this one is
+        // about what the surrounding expression does with it, so a computed property whose body
+        // hands a fresh read on is the first fault and not this one.
+        if isHandedStraightOn(node) {
+            flagCompositionRoot(source.marker, at: node)
+            return
+        }
         flag(source.marker, at: node)
     }
 

--- a/Tests/CoreTests/Testability/NonInjectedNondeterminismCompositionRootTests.swift
+++ b/Tests/CoreTests/Testability/NonInjectedNondeterminismCompositionRootTests.swift
@@ -1,0 +1,161 @@
+@testable import Core
+import Foundation
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+/// The fourth arm: a read handed straight on as an argument, never examined by the scope that
+/// takes it.
+///
+/// **This is what following the rest of the rule's advice produces.** "Move the clock read to the
+/// edge and pass the instant down" is what the ordinary message asks for, and the reader who does
+/// it was still told a property-based test could not pin the value — which at a composition root
+/// is false about everything that decides. The arm changes the sentence and not the count.
+@Suite("Non-Injected Nondeterminism — the composition-root arm")
+struct NonInjectedNondeterminismCompositionRootTests {
+
+    private func analyze(_ source: String, filePath: String = "Logic.swift") -> [LintIssue] {
+        let visitor = NonInjectedNondeterminismVisitor(patternCategory: .testability)
+        let syntax = Parser.parse(source: source)
+        let converter = SourceLocationConverter(fileName: filePath, tree: syntax)
+        visitor.setSourceLocationConverter(converter)
+        visitor.setFilePath(filePath)
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == .nonInjectedNondeterminism }
+    }
+
+    private func message(_ source: String) -> String {
+        analyze(source).first?.message ?? "(no finding)"
+    }
+
+    private func isCompositionRoot(_ source: String) -> Bool {
+        message(source).hasPrefix("Clock/RNG read at a composition root")
+    }
+
+    // MARK: - Reclassified, not removed
+
+    /// The whole contract of this arm. If any of these ever stops reporting, the census that
+    /// answers *where does this program touch the clock?* has quietly lost an entry.
+    @Test("every composition root is still reported, exactly once", arguments: [
+        "func f() { store.approve(on: Date()) }",
+        "func f() -> R { R(capturedAt: Date(), items: items) }",
+        "func f() { let now = Date(); header(asOf: now); footer(asOf: now) }"
+    ])
+    func stillReported(source: String) {
+        #expect(analyze(source).count == 1)
+        #expect(isCompositionRoot(source))
+    }
+
+    // MARK: - The inline form
+
+    @Test func inlineArgumentIsACompositionRoot() {
+        #expect(isCompositionRoot("func f() { gate.recordAttempt(at: Date()) }"))
+    }
+
+    @Test func inlineArgumentToAnInitializerIsACompositionRoot() {
+        #expect(isCompositionRoot("func f() -> H { H(status: \"ok\", timestamp: Date()) }"))
+    }
+
+    // MARK: - The bound form
+
+    @Test func boundThenOnlyPassedIsACompositionRoot() {
+        let source = """
+        func body() -> V {
+            let now = Date()
+            return V(header: header(asOf: now), rows: rows(asOf: now))
+        }
+        """
+        #expect(isCompositionRoot(source))
+    }
+
+    /// One use that is not an argument disqualifies the whole binding. This is the direction that
+    /// matters: a binding compared once is a decision this scope makes, and calling it a
+    /// composition root would tell a reader to stop looking exactly where the defect is.
+    @Test func boundThenComparedIsNotACompositionRoot() {
+        let source = """
+        func f(_ xs: [Item]) -> [Item] {
+            let now = Date()
+            report(asOf: now)
+            return xs.filter { $0.expiry < now }
+        }
+        """
+        #expect(analyze(source).count == 1)
+        #expect(!isCompositionRoot(source))
+    }
+
+    @Test func boundThenReturnedIsNotACompositionRoot() {
+        #expect(!isCompositionRoot("func f() -> Date { let now = Date(); log(at: now); return now }"))
+    }
+
+    /// A `var` can be reassigned, so "every reference is an argument" says nothing about what the
+    /// value was when it got there.
+    @Test func varBindingIsNotACompositionRoot() {
+        #expect(!isCompositionRoot("func f() { var now = Date(); log(at: now) }"))
+    }
+
+    /// A stored property's initial value is read once per instance and used in other members this
+    /// walk cannot see. `WaiverRequestSheet`'s `@State private var openedAt = Date()` is the corpus
+    /// instance, and it feeds arithmetic in a computed property two lines below.
+    @Test func storedPropertyInitialValueIsNotACompositionRoot() {
+        let source = """
+        struct S {
+            @State private var openedAt = Date()
+            var expiry: Date { openedAt.addingTimeInterval(86_400) }
+        }
+        """
+        #expect(!isCompositionRoot(source))
+    }
+
+    // MARK: - Receivers are uses, not hand-offs
+
+    /// Every real defect this rule has produced across the corpus reads the clock into a receiver
+    /// or an operand: a deadline, an elapsed time, a rate-limit window. None of them is an
+    /// argument, and that is the whole precision of the arm.
+    @Test("a receiver is the scope using the value, not passing it", arguments: [
+        "func f(_ t: TimeInterval) { let deadline = Date().addingTimeInterval(t); wait(until: deadline) }",
+        "func f(_ start: Date) -> Double { Date().timeIntervalSince(start) }",
+        "func f() { bind(Date.now.timeIntervalSince1970, at: 1) }",
+        "func f() -> String { Date.now.formatted(date: .abbreviated, time: .shortened) }",
+        "func f() -> String { \"probe_\\(UUID().uuidString).swift\" }"
+    ])
+    func receiverIsNotACompositionRoot(source: String) {
+        #expect(analyze(source).count == 1)
+        #expect(!isCompositionRoot(source))
+    }
+
+    // MARK: - Arm order
+
+    /// The fresh-read arm is about where the read is *declared*; this one is about what the
+    /// surrounding expression does with it. A computed property whose body hands a fresh read on is
+    /// the first fault — every access is a separate read however tidily it is passed along.
+    @Test func freshReadPerAccessWinsOverCompositionRoot() {
+        let source = """
+        struct S {
+            var stamped: String { format(at: Date()) }
+        }
+        """
+        #expect(message(source).hasPrefix("Fresh read per access"))
+    }
+
+    /// A fabricated fallback is an argument in the shapes the corpus contains
+    /// (`R(id: model.id ?? UUID())`), so the fabrication arm must be reached first or the defect
+    /// it names would be relabelled as an end state.
+    @Test func fabricationWinsOverCompositionRoot() {
+        let source = "func f(_ model: M) -> R { R(id: model.id ?? UUID()) }"
+        #expect(message(source).hasPrefix("Fabricated fallback"))
+    }
+
+    // MARK: - The message does not say "no action"
+
+    /// The corpus's one live defect of this shape is `EvalReport(startedAt: Date(), results:)`
+    /// written *after* the loop that produced `results`, so the eval history's `started_at` column
+    /// held the instant each run finished. Nothing is untestable and nothing is fabricated — the
+    /// read is taken at the wrong moment. A message that closed the finding would have hidden it.
+    @Test func theSuggestionAsksWhetherTheInstantMatchesItsLabel() {
+        let issue = analyze("func f() { save(R(startedAt: Date(), results: results)) }").first
+        let suggestion = issue?.suggestion ?? ""
+        #expect(suggestion.contains("read at the moment its label"))
+        #expect(issue?.severity == .warning)
+    }
+}


### PR DESCRIPTION
## What this is

The corpus sweep produced **37** `non-injected-nondeterminism` findings across 13 repositories,
all carrying one message. Reading all 37 by hand: **one is a defect, three are declared-purpose
declines, and 33 are the rule describing a correct site wrongly.**

The ordinary message says *"a property-based test can't pin the value or reproduce a failure."*
Where the read is handed straight on as an argument, that is false about everything that decides:

```swift
store.approve(proposalID: id, by: reviewer, on: Date())

let now = Date()
summary(asOf: now)
content(asOf: now)
```

The callee takes the instant as a parameter and a test pins it there. The only unpinnable thing
is the expression, which contains no logic.

**This is the shape the rule's own advice produces.** "Move the clock read to the edge and pass
the instant down" is what the ordinary message asks for. `WaiversView` went 20 findings to 20
doing exactly that, and all twenty survivors kept the sentence that had sent them there. Six of
the eight findings in SwiftLintRuleStudioTeam carry a hand-written comment above them recording
the defect that moving the read there fixed — and were still being told they blocked a test.

## The part to scrutinise: it does not say "no action"

The corpus's one live defect of this shape is a composition root:

```swift
for entry in filtered { … }                       // the whole eval run
let report = EvalReport(gitSHA: sha, startedAt: Date(), results: results)
```

`startedAt` read *after* the loop, so `swift-assist-eval history`'s `started_at` column and every
report filename carried the instant each run **finished**. Nothing untestable, nothing fabricated
— the read is at the wrong moment. **A message that closed the finding would have hidden it**, so
the suggestion asks the one question this shape can still get wrong: *is the value read at the
moment its label claims?* (Fixed separately in SwiftAssist#24.)

## Precision

**Argument position only.** A receiver is the scope *using* the value, and every real defect this
rule has produced across the corpus reads the clock into one:

| Shape | What the scope did with it |
| --- | --- |
| `Date().addingTimeInterval(timeout)` | a subprocess deadline |
| `Date().timeIntervalSince(start)` | the entire output of a benchmark |
| `Date.now.timeIntervalSince1970` | a number bound into SQL |
| `"probe_\(UUID().uuidString).swift"` | a filename this scope composed |

**The bound form demands that every reference is an argument.** One comparison, one `return`, one
reassignment and the binding keeps the ordinary message — the safe direction, since a shadowed
name can only add a reference that must also pass. A stored property's initial value is not a
composition root: `WaiverRequestSheet`'s `@State private var openedAt = Date()` feeds arithmetic
two lines below, and stays ordinary.

**Arm order is tested.** A fabricated fallback (`R(id: model.id ?? UUID())`) and a
fresh-read-per-access are both *arguments* in the shapes the corpus contains, so both must be
reached first or the defects they name would be relabelled as end states.

## Measured before shipping, and wrong in the usual direction

Reading all 37 by hand suggested the arm would reach about 34. The inline form alone reached
**20 of 37**; adding the bound form took it to **25**. Fifth high prediction on this project, second
on this rule.

**37 before, 37 after** — the arm reclassifies and never removes, asserted by a test rather than
assumed. The corpus now reports 34 because three sites were declined separately
(SwiftPropertyLaws#38, pbt-book#180), which are the shape the rule's own doc names as a correct
suppression.

## Tests and docs

12 new tests, most of them negative. 3,636 pass; `swiftlint` output is unchanged from `main`
except one pre-existing warning's line number.

The doc gains the fourth arm, the receiver table, the measurement including the wrong prediction,
and the list of the nine sites that keep the ordinary message — because what the arm is *not*
claiming is the part worth being able to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrD7SdySCSbg15qC8qbpYy