### PR TITLE
A pure kernel may hold another pure kernel

### DIFF
--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/CleanInstanceMethodCatalog.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/CleanInstanceMethodCatalog.swift
@@ -144,21 +144,44 @@ public struct CleanInstanceMethodCatalog: Sendable, Equatable {
     }
 
     /// The types that hold nothing a test could not supply. See ``isPureKernel(_:)``.
+    ///
+    /// **A fixpoint, because a kernel may hold another kernel**, and the single-pass version could
+    /// not see it. `EffectAnnotationParser` is a `public struct` whose one stored property is an
+    /// `AttributeRecognition` — itself a struct of five `Set<String>` — and every method takes
+    /// syntax and returns an `Effect?`. Nothing there is substitutable: a test wanting different
+    /// behaviour passes a different `AttributeRecognition`, which is a *value*, not a different
+    /// conformance. It was refused because its storage was neither a stdlib value nor a project
+    /// enum, so three findings across two rules asked for a protocol seam in front of a pure
+    /// function — the exact shape SwiftProjectLint#163 exists to prevent, one level of nesting
+    /// down.
+    ///
+    /// One pass would only reach depth one, which is the same reason `SendableProtocols` resolves
+    /// its refinement set this way rather than with two passes.
+    ///
+    /// **Monotone and therefore safe in the direction that matters.** The set starts empty and
+    /// only ever grows, so a type is admitted only once everything it holds has been admitted on
+    /// its own evidence. A reference cycle simply never promotes — which is a refusal, not a wrong
+    /// answer — and a type holding `UserDefaults` never promotes, so nothing holding *it* does
+    /// either.
     private static func kernels(
         in types: [String: TypeMembers],
         given clean: [String: Set<String>],
         enumTypes: Set<String>
     ) -> Set<String> {
         var found: Set<String> = []
-        for (name, members) in types where !members.isActor {
-            guard members.declaredStorage.allSatisfy({ storage in
-                !storage.isMutable && storage.isValue(givenEnums: enumTypes)
-            }) else { continue }
-            let cleanHere = clean[name] ?? []
-            guard members.methods.keys.allSatisfy({ cleanHere.contains($0) }) else { continue }
-            found.insert(name)
+        while true {
+            var promotedThisPass = false
+            for (name, members) in types where !members.isActor && !found.contains(name) {
+                guard members.declaredStorage.allSatisfy({ storage in
+                    !storage.isMutable && storage.isValue(givenEnums: enumTypes, kernels: found)
+                }) else { continue }
+                let cleanHere = clean[name] ?? []
+                guard members.methods.keys.allSatisfy({ cleanHere.contains($0) }) else { continue }
+                found.insert(name)
+                promotedThisPass = true
+            }
+            guard promotedThisPass else { return found }
         }
-        return found
     }
 
     /// Promotes method names until a pass promotes nothing new.
@@ -232,10 +255,15 @@ public struct CleanInstanceMethodCatalog: Sendable, Equatable {
         /// contents is what constructing a different one means.
         let isSyntacticValue: Bool
 
-        func isValue(givenEnums enums: Set<String>) -> Bool {
+        /// `kernels` is the set admitted so far, which is what makes a kernel holding a kernel a
+        /// kernel. It grows between passes and is never read for a type not yet admitted on its
+        /// own evidence, so the recursion bottoms out at stdlib values and project enums.
+        func isValue(givenEnums enums: Set<String>, kernels: Set<String>) -> Bool {
             if isSyntacticValue { return true }
             guard let typeName else { return false }
-            return stdlibValueTypes.contains(typeName) || enums.contains(typeName)
+            return stdlibValueTypes.contains(typeName)
+                || enums.contains(typeName)
+                || kernels.contains(typeName)
         }
     }
 

--- a/Tests/CoreTests/Testability/KernelStorageFixpointTests.swift
+++ b/Tests/CoreTests/Testability/KernelStorageFixpointTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import SwiftParser
+@testable import SwiftProjectLintVisitors
+import SwiftSyntax
+import Testing
+
+/// A kernel may hold another kernel, and the single-pass version could not see it.
+///
+/// `isPureKernel` is the discriminator `DirectInstantiation` and `ConcreteTypeUsage` both consult
+/// before asking for a protocol seam (SwiftProjectLint#163). It admitted a type whose stored
+/// properties are stdlib values or project enums, and refused one whose storage is a *project
+/// struct* — however plainly that struct is itself a bag of values.
+@Suite("Pure kernels resolve their storage to a fixpoint")
+struct KernelStorageFixpointTests {
+
+    private func catalog(_ source: String, enums: Set<String> = []) -> CleanInstanceMethodCatalog {
+        CleanInstanceMethodCatalog.build(from: [Parser.parse(source: source)], enumTypes: enums)
+    }
+
+    /// The corpus shape, reduced: `EffectAnnotationParser` holds one `AttributeRecognition`, which
+    /// is five `Set<String>`. Before the fixpoint the inner type was admitted and the outer one was
+    /// not, so three findings across two rules asked for a protocol in front of a pure function.
+    @Test func aKernelHoldingAKernelIsAKernel() {
+        let source = """
+        struct Recognition {
+            let names: Set<String>
+            func matches(_ name: String) -> Bool { names.contains(name) }
+        }
+        struct Parser {
+            let recognition: Recognition
+            func parse(_ text: String) -> Bool { recognition.matches(text) }
+        }
+        """
+        let built = catalog(source)
+        #expect(built.isPureKernel("Recognition"))
+        #expect(built.isPureKernel("Parser"))
+    }
+
+    /// Three deep, because one extra pass would reach depth two and stop — the same reason
+    /// `SendableProtocols` resolves its refinement set to a fixpoint rather than with two passes.
+    @Test func transitivityIsNotDepthLimited() {
+        let source = """
+        struct Leaf { let values: Set<String> }
+        struct Middle { let leaf: Leaf }
+        struct Outer { let middle: Middle }
+        struct Top { let outer: Outer }
+        """
+        let built = catalog(source)
+        #expect(built.isPureKernel("Leaf"))
+        #expect(built.isPureKernel("Top"))
+    }
+
+    // MARK: - What it must still refuse
+
+    /// The direction that matters. `PluginPermissionGrantsStore` stores a `UserDefaults` and
+    /// `PersistenceController` a SwiftData `ModelContainer`; both are real dependencies, and both
+    /// were false exemptions when this test was written as a denylist. A type holding one of them
+    /// must not become a kernel because the holder is otherwise tidy.
+    @Test func holdingANonKernelIsNotAKernel() {
+        let source = """
+        struct GrantsStore { let defaults: UserDefaults }
+        struct Manager { let store: GrantsStore }
+        """
+        let built = catalog(source)
+        #expect(!built.isPureKernel("GrantsStore"))
+        #expect(!built.isPureKernel("Manager"))
+    }
+
+    /// A `var` is state whatever it holds, so a kernel cannot hold a mutable kernel either.
+    @Test func mutableStorageDisqualifiesHowevercleanItsTypeIs() {
+        let source = """
+        struct Leaf { let values: Set<String> }
+        struct Holder { var leaf: Leaf }
+        """
+        #expect(!catalog(source).isPureKernel("Holder"))
+    }
+
+    /// The set starts empty and only grows, so a reference cycle never promotes. That is a refusal
+    /// rather than a wrong answer, and it is the property that makes the loop safe to run to
+    /// stability.
+    @Test func aStorageCycleRefusesRatherThanLooping() {
+        let source = """
+        final class A { let b: B? = nil }
+        final class B { let a: A? = nil }
+        """
+        let built = catalog(source)
+        #expect(!built.isPureKernel("A"))
+        #expect(!built.isPureKernel("B"))
+    }
+
+    /// Condition (1) is unchanged and still does most of the work: a type whose methods reach the
+    /// file system is not a kernel however value-shaped its storage is.
+    @Test func aDirtyMethodStillDisqualifies() {
+        let source = """
+        struct CacheManager {
+            let root: URL
+            func purge() throws { try FileManager.default.removeItem(at: root) }
+        }
+        """
+        #expect(!catalog(source).isPureKernel("CacheManager"))
+    }
+}


### PR DESCRIPTION
## What this is

`isPureKernel` is the discriminator `DirectInstantiation` and `ConcreteTypeUsage` both consult
before asking for a protocol seam (#163). Its third condition — *every stored property is a
value* — accepted a stdlib value type or a project enum, and refused a project **struct** that is
itself a bag of values.

`EffectAnnotationParser` is the corpus instance, and it is the finding the run-30 notes left
explicitly unresolved: *"three name a parser the kernel exemption was expected to reach and did
not. Whether that refusal is right has not been checked."* It is a `public struct` whose one
stored property is an `AttributeRecognition` — itself a struct of five `Set<String>` — and every
method takes syntax and returns an `Effect?`. A test wanting different behaviour passes a
different `AttributeRecognition`, which is a *value*. There is nothing to substitute, and three
findings across two rules were asking for a protocol seam in front of a pure function.

**The refusal was not right.** Storage now resolves to a fixpoint.

## This moves the corpus by zero, and that is the finding

`EffectAnnotationParser` is **still reported**, because it also fails condition (1). Measured, not
assumed — I probed the catalog against the real file:

```
AttributeRecognition kernel?   true      ← the fixpoint works
EffectAnnotationParser kernel? false
refused methods: combinedDocTrivia, documentationTrivia, parseEffect, resolveDeclEffect
```

Those four are refused for one reason: **`combinedDocTrivia` calls its own overload, and
`parseEffect` and `resolveDeclEffect` call each other.** `resolve` is a least fixpoint that
requires every callee to be *already* known clean, so a recursive pure method never promotes. The
code says so and calls it correct — *"Cycles land here and stay out, correctly"* — and for purity
that is wrong: recursion is not an effect.

Filed as #195 with the diagnosis, because flipping to a greatest fixpoint changes a catalog four
rules consume and wants its own corpus measurement.

**Both changes are required and neither alone exempts the type.** With recursion fixed and this
one absent, the parser still holds an `AttributeRecognition` that is neither stdlib nor an enum.
That is why this ships measured at zero rather than being held until it pays.

## Safety

The set starts empty and only grows, so a type is admitted only once everything it holds has been
admitted on its own evidence. A reference cycle never promotes — a refusal, not a wrong answer.

Four of the six tests are negative, and they are the ones to read: a type holding a
`UserDefaults` holder (the shape that produced two false exemptions when this condition was first
written as a denylist), a mutable kernel, a storage cycle, and a struct whose method reaches the
file system. The two positive tests fail without the change — verified by removing it.

3,642 tests pass; `swiftlint` unchanged at 27 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrD7SdySCSbg15qC8qbpYy
