### PR TITLE
Recursion is not an effect: let a recursive pure method promote

### DIFF
--- a/Docs/rules/concrete-type-usage.md
+++ b/Docs/rules/concrete-type-usage.md
@@ -199,9 +199,43 @@ class MyViewModel {
   oracle cannot see it. The storage test is positive for that reason: a kernel may hold only
   values, and an unrecognised stored type disqualifies.
 
-- **`EffectAnnotationParser` is still reported, and the exemption was expected to reach it.** It
-  stores one `AttributeRecognition` value struct and its methods parse syntax, so it looked like a
-  kernel; the oracle refutes at least one of its methods. Whether that refusal is right has not
-  been checked, and the three findings stand until it is.
+- **~~`EffectAnnotationParser` is still reported, and the exemption was expected to reach it.~~**
+  Checked, and the refusal was wrong **twice over**. The two causes are independent, and neither
+  fix alone exempts the type — which is why the first shipped measured at zero.
+
+  **It held a kernel.** Condition (3) accepted a stdlib value type or a project enum as storage
+  and refused a project *struct* that is itself a bag of values. `AttributeRecognition` is five
+  `Set<String>`; it was admitted, and the parser holding it was not. Storage now resolves to a
+  fixpoint, for the reason `SendableProtocols` already gives about refinement chains: one extra
+  pass reaches depth two and stops.
+
+  **And four of its methods were recursive.** `resolve` promoted a method only once every method
+  it calls was *already* known clean, so a cycle could never start: `combinedDocTrivia`'s
+  two-argument overloads call its four-argument one — overloads share a name key, so the name
+  calls itself — and `parseEffect` and `resolveDeclEffect` call each other. The loop's comment
+  said those *"stay out, correctly"*. **Recursion is not an effect**, and the four refused methods
+  are the purest in the file: the deepest one appends `TriviaPiece`s to a local array and returns
+  a `Trivia`.
+
+  So the loop runs the other way now — assume every method clean, demote on evidence that owes
+  nothing to the assumption — and the old test that pinned the limitation as a requirement is
+  replaced by four that pin what actually matters, including that a cycle with an impure member
+  still fails.
+
+  **The scope of that fix is much wider than three findings, and the corpus says how much wider.**
+  The same catalog decides the property-test census, so every recursive helper had been
+  suppressing its callers too. Measured across all 26 repositories, with the two changes swept
+  separately so the attribution is not a guess:
+
+  | | Concrete Type Usage | census |
+  |---|---|---|
+  | run 31 | 18 | 4,572 |
+  | + storage fixpoint | 18 | 4,572 |
+  | + recursion fix | **15** | **4,661** |
+
+  **89 pure functions this project had never been able to see**, and the storage half contributes
+  exactly zero to that column — which is what makes the split measured rather than asserted.
+  `Extractable Total Kernel` and `Direct Instantiation` share the machinery and were checked
+  rather than assumed: both unmoved.
 
 ---

--- a/Docs/rules/direct-instantiation.md
+++ b/Docs/rules/direct-instantiation.md
@@ -98,7 +98,17 @@ second instance to hold differently and no effect for a double to intercept.
 asks the same question from the declared type rather than the construction site. Three conditions:
 every method is a function of its inputs under the purity fixpoint this project already resolved,
 no stored property is mutable, and every stored property is a value — a stdlib value type, a
-project enum, or a collection or optional of one.
+project enum, a collection or optional of one, **or another kernel**.
+
+**That last clause and the fixpoint under condition (1) were both added after
+`EffectAnnotationParser` refused to qualify**, and neither alone would have admitted it. It holds
+one `AttributeRecognition` — five `Set<String>` — which was itself admitted while the type holding
+it was not, so storage now resolves to a fixpoint rather than one pass. And four of its methods
+are recursive: two `combinedDocTrivia` overloads share a name key and so call themselves, and
+`parseEffect` and `resolveDeclEffect` call each other. The purity fixpoint used to promote a
+method only once its callees were *already* clean, so a cycle never started — and **recursion is
+not an effect**. It now assumes and demotes instead. See `ConcreteTypeUsage`'s notes for the full
+account.
 
 **Both cheap approximations were measured and refused.** *Value type* fails on `CacheManager`, a
 `public struct` doing file I/O. *No-argument initializer* fails on `AntiPatternStore()` and

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/CleanInstanceMethodCatalog.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/CleanInstanceMethodCatalog.swift
@@ -184,36 +184,65 @@ public struct CleanInstanceMethodCatalog: Sendable, Equatable {
         }
     }
 
-    /// Promotes method names until a pass promotes nothing new.
+    /// Demotes method names until a pass demotes nothing, starting from every method assumed
+    /// clean.
     ///
-    /// The loop is what lets `serialize` qualify on the pass after `orderedTopLevelPairs` did, so
-    /// declaration order — and file order — does not decide the answer.
+    /// **This runs the other way round from the obvious direction, and it has to, because
+    /// recursion is not an effect.** The first version promoted: a method qualified once every
+    /// method it calls was *already* known clean. That is sound and it cannot resolve a cycle —
+    /// `combinedDocTrivia`'s two-argument overloads call its four-argument one, so the name calls
+    /// itself and could never go first; `parseEffect` and `resolveDeclEffect` call each other and
+    /// neither could. The loop's comment claimed those *"stay out, correctly"*. They are the
+    /// purest functions in the file they live in: the deepest one appends `TriviaPiece`s to a
+    /// local array and returns a `Trivia`.
+    ///
+    /// So the assumption is optimistic and the evidence is a **refutation**. A declaration is
+    /// demoted for a reason that has nothing to do with the assumption — it is `mutating`, the
+    /// purity oracle refutes it outright, or it touches `self` in a way that is not a read of
+    /// immutable storage or a call to a sibling still believed clean — and a demotion can only
+    /// cause further demotions. Nothing is ever promoted, so the set shrinks monotonically from a
+    /// finite start and the loop terminates.
+    ///
+    /// A mutually recursive pair whose only unresolved references are to each other therefore
+    /// survives, which is the right answer: two pure bodies calling each other are pure, and the
+    /// worst a cycle with no other content can do is fail to terminate — which is not an effect
+    /// this catalog models. A pair where one member reads a clock or the file system does not
+    /// survive: that member is refuted on its own, and its partner follows on the next pass.
+    ///
+    /// The old direction's one virtue is preserved: declaration order and file order still do not
+    /// decide the answer, because the loop runs to stability either way.
     private static func resolve(_ types: [String: TypeMembers]) -> [String: Set<String>] {
         let inferrer = PurityInferrer()
         var clean: [String: Set<String>] = [:]
+        for (typeName, members) in types where !members.isActor {
+            clean[typeName] = Set(members.methods.keys)
+        }
 
         while true {
-            var promotedThisPass = false
+            var demotedThisPass = false
 
             for (typeName, members) in types where !members.isActor {
                 var known = clean[typeName] ?? []
 
-                for (methodName, declarations) in members.methods where !known.contains(methodName) {
+                for (methodName, declarations) in members.methods where known.contains(methodName) {
+                    // Read against the set as it stands, so a demotion earlier in this pass is
+                    // seen immediately. That only reaches the fixpoint sooner; it cannot change
+                    // which one, because demotions never reverse.
                     guard declarations.allSatisfy({
                         isClean($0, in: members, given: known, inferrer: inferrer)
                     }) else {
+                        known.remove(methodName)
+                        demotedThisPass = true
                         continue
                     }
-                    known.insert(methodName)
-                    promotedThisPass = true
                 }
 
                 clean[typeName] = known
             }
 
-            // A pass that promotes nothing will promote nothing next time either: only a newly
-            // promoted name can change a verdict. Cycles land here and stay out, correctly.
-            guard promotedThisPass else { return clean }
+            // A pass that demotes nothing will demote nothing next time either: only a newly
+            // demoted name can change a verdict.
+            guard demotedThisPass else { return clean }
         }
     }
 

--- a/Tests/CoreTests/Testability/CleanInstanceMethodCatalogTests.swift
+++ b/Tests/CoreTests/Testability/CleanInstanceMethodCatalogTests.swift
@@ -95,13 +95,59 @@ struct CleanInstanceMethodCatalogTests {
         """).isEmpty)
     }
 
-    @Test func neverPromotesACycle() {
-        // Mutual recursion has no base case to promote from; the fixpoint must terminate with both
-        // out rather than spinning.
+    /// **This test used to assert the opposite, and the comment above it said why: "mutual
+    /// recursion has no base case to promote from; the fixpoint must terminate with both out."**
+    /// The second half of that sentence was a fact about the loop's direction written up as a
+    /// requirement. Both of these are functions of their argument — the only thing either does is
+    /// hand `text` to the other — and refusing them cost their whole enclosing type its kernel
+    /// status, which is how three `Concrete Type Usage` findings came to ask for a protocol seam
+    /// in front of a parser (SwiftProjectLint#195).
+    ///
+    /// What the old test was right about is termination, and that is still pinned: this returns.
+    @Test func aPureCycleIsClean() {
         #expect(clean("""
         struct Engine {
             func ping(_ text: String) -> String { pong(text) }
             func pong(_ text: String) -> String { ping(text) }
+        }
+        """) == ["ping", "pong"])
+    }
+
+    /// The direction that makes the optimistic start safe. One member is refuted on evidence that
+    /// owes nothing to the assumption — the purity oracle sees the clock — and the other follows
+    /// on the next pass because its only unresolved reference is to a name no longer believed
+    /// clean. Assume-then-refute reaches the same answer as the old loop wherever the old loop had
+    /// an answer.
+    @Test func aCycleWithAnImpureMemberIsNotClean() {
+        #expect(clean("""
+        struct Engine {
+            func ping(_ text: String) -> String { pong(text) }
+            func pong(_ text: String) -> String { ping(text + Date().description) }
+        }
+        """).isEmpty)
+    }
+
+    /// A self-call under one name, which is what overload groups produce: the catalog keys methods
+    /// by name, so a two-argument form delegating to a four-argument one is a name that calls
+    /// itself. This is the exact shape of `EffectAnnotationParser.combinedDocTrivia`.
+    @Test func anOverloadDelegatingToItsSiblingIsClean() {
+        #expect(clean("""
+        struct Engine {
+            func render(_ text: String) -> String { render(text, width: 80) }
+            func render(_ text: String, width: Int) -> String { String(text.prefix(width)) }
+        }
+        """) == ["render"])
+    }
+
+    /// A cycle where one member reads mutable storage. Storage access is judged without reference
+    /// to the assumed set, so this demotes on the first pass whatever the loop believes about
+    /// sibling calls.
+    @Test func aCycleReadingMutableStateIsNotClean() {
+        #expect(clean("""
+        struct Engine {
+            var count: Int = 0
+            func ping(_ text: String) -> String { pong(text) }
+            func pong(_ text: String) -> String { text + String(count) }
         }
         """).isEmpty)
     }


### PR DESCRIPTION
Closes #195.

## The defect

`CleanInstanceMethodCatalog.resolve` was a **least** fixpoint: a method promoted to "clean" only
once every method it calls was *already* known clean. Its own comment stated the consequence and
called it correct:

> Cycles land here and stay out, **correctly**.

For purity that last word is wrong. A function that calls itself is pure exactly when its body is
pure; the self-call adds nothing to refute.

Four methods on `EffectAnnotationParser` are refused for a cycle and nothing else:

| Method | Why it could not promote |
|---|---|
| `combinedDocTrivia` | Two 2-arg overloads call the private 4-arg one. Overloads share a name key, so **the name calls itself**. |
| `documentationTrivia` | Calls `combinedDocTrivia`. |
| `parseEffect` ↔ `resolveDeclEffect` | Mutually recursive. |

They are the purest functions in the file — the deepest one appends `TriviaPiece`s to a local
array and returns a `Trivia` — and they were the only ones refused.

## The change

Assume every method clean, then demote on evidence that owes nothing to the assumption:
`mutating`, a purity-oracle refutation, or a `self` access that is not a read of immutable
storage or a call to a sibling still believed clean. A demotion can only cause further demotions,
so the set shrinks monotonically from a finite start and the loop terminates — which is the half
of the old comment that was right, and is still pinned.

A mutually recursive pair whose only unresolved references are to each other survives, which is
the right answer. A pair where one member reads a clock does not: that member is refuted on its
own, and its partner follows on the next pass.

**`known` is used in exactly one place** — `SelfAccessAnalyzer(cleanMethods:)`, to resolve sibling
calls — so the flip is contained to how self-calls resolve. Cross-type calls and storage access
are judged without it and are unaffected.

## Measured across all 26 repositories, with the two changes swept separately

| | Concrete Type Usage | census |
|---|---|---|
| run 31 | 18 | 4,572 |
| + storage fixpoint (#194) | 18 | 4,572 |
| + this | **15** | **4,661** |

The 18 → 15 is exactly the three `EffectAnnotationParser` findings, as #195 predicted.

**+89 on the census is the number worth reading**: pure functions this project had never been
able to see, because a recursive helper was suppressing every caller that used it. The storage
fixpoint contributes **zero** to that column — checked by sweeping it alone rather than inferred —
so the attribution is measured.

`Extractable Total Kernel` and `Direct Instantiation` share the machinery and were checked rather
than assumed: both unmoved. `swiftlint` output byte-identical to `main`.

## The test that had to change

`neverPromotesACycle` asserted `.isEmpty` on a pure `ping`/`pong` pair, with the comment *"mutual
recursion has no base case to promote from; the fixpoint must terminate with both out."* That
bundles a real requirement (termination) with the loop's direction (both out) and pins the second
as a principle — the shape this corpus keeps recording.

Replaced by four: a pure cycle is clean, a cycle with a clock read is not, an overload delegating
to its sibling is clean, and a cycle reading mutable storage is not. 3,645 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrD7SdySCSbg15qC8qbpYy