### PR TITLE
A closure assignment proves the declared type is a function type

### DIFF
--- a/Docs/rules/concrete-type-usage.md
+++ b/Docs/rules/concrete-type-usage.md
@@ -170,11 +170,31 @@ class MyViewModel {
   ([String]) async throws -> Data` names a closure, and a property typed with it is already
   injected — a test substitutes another closure. Asking for a protocol around it would replace a
   working seam with a heavier one.
-- **…but only when the alias is declared in the analyzed sources.** The exemption comes from a
-  project-wide prescan, so a property typed with an alias published by *another* package is still
-  reported: the declaration that would exempt it is out of scope. Measured — `CLIToolCommandRunner`
-  is exempt inside LintStudioUI, which declares it, and still flagged in SwiftLintRuleStudio, which
-  imports it. Same boundary as `unused-protocol-abstraction`'s, for the same reason.
+- **~~…but only when the alias is declared in the analyzed sources.~~** This was recorded for two
+  sweeps as a package boundary — `CLIToolCommandRunner` exempt inside LintStudioUI, which declares
+  it, and flagged in SwiftLintRuleStudio and SwiftFormatRuleStudio, which import it.
+
+  It did not have to be a boundary, because **the evidence is local**:
+
+  ```swift
+  var bridgedRunner: CLIToolCommandRunner?
+  if let commandRunner {
+      bridgedRunner = { arguments, _ in … }        // ← only a function type accepts this
+  }
+  ```
+
+  Assigning a closure literal to a binding *proves* its declared type is a function type — the
+  compiler rejects it otherwise. That is a fact rather than a heuristic, and it holds whoever
+  declares the alias and wherever. The prescan now records both shapes: a declaration initialised
+  with a closure, and a declaration filled by a later assignment in the same body. Measured:
+  SwiftLintRuleStudio 2 → 1 and SwiftFormatRuleStudio 3 → 2, and nothing else moved.
+
+  Scoped to one function or initializer body, so an unrelated `runner` elsewhere in the file cannot
+  lend its name to a type it has nothing to do with. A nested shadow inside the same body could
+  still mislead; that residual is worth less than the boundary it removes. **The test that matters
+  is the negative one** — `client = OllamaHTTPClient(baseURL: url)` is an assignment too, and
+  keying on the assignment rather than on the assigned *value* would have exempted every service
+  built in an initializer.
 - **~~A value type used as a seam still reads as concrete.~~** Closed by the closure-wrapper
   exemption above. The limitation was recorded as *"advice worth refusing rather than a defect the
   rule can detect"* — which was wrong on the second half. It is detectable, by the same prescan

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FunctionTypeAliasCollector.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/FunctionTypeAliasCollector.swift
@@ -11,6 +11,32 @@ import SwiftSyntax
 ///
 /// Only the alias is recorded, not the signature. Whether the closure is `@Sendable`, `async`
 /// or throwing makes no difference to the question being asked.
+///
+/// ## A closure assignment is evidence too
+///
+/// The alias scan is project-wide, and "project" is the boundary it stops at. `CLIToolActor`'s
+/// `CLIToolCommandRunner` is declared in **LintStudioUI**, a separate repository pulled in as a
+/// package dependency, so two repositories that both bridge onto it each reported a finding the
+/// prescan could not answer — recorded for two sweeps as *"a cross-package typealias the prescan
+/// cannot see, a documented boundary rather than a defect"*.
+///
+/// It does not have to be a boundary, because the evidence is local:
+///
+/// ```swift
+/// var bridgedRunner: CLIToolCommandRunner?
+/// if let commandRunner {
+///     bridgedRunner = { arguments, _ in … }        // ← only a function type accepts this
+/// }
+/// ```
+///
+/// **Assigning a closure literal to a binding proves its declared type is a function type.** The
+/// compiler would reject it otherwise, so this is a fact rather than a heuristic, and it holds
+/// whoever declares the alias and wherever they declare it.
+///
+/// Scoped to one function or initializer body: the declaration and the assignment must share an
+/// enclosing body, so an unrelated `runner` elsewhere in the file cannot lend its name to a type
+/// it has nothing to do with. A nested shadow inside the same body could still mislead, which is
+/// the residual and is worth less than the boundary it removes.
 public final class FunctionTypeAliasCollector: SyntaxVisitor, TypeCollectorProtocol {
     public var collectedTypes: Set<String> { aliasNames }
 
@@ -25,6 +51,103 @@ public final class FunctionTypeAliasCollector: SyntaxVisitor, TypeCollectorProto
             aliasNames.insert(node.name.text)
         }
         return .visitChildren
+    }
+
+    override public func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+        if let body = node.body { recordClosureAssignedTypes(in: Syntax(body)) }
+        return .visitChildren
+    }
+
+    override public func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+        if let body = node.body { recordClosureAssignedTypes(in: Syntax(body)) }
+        return .visitChildren
+    }
+
+    /// Records every declared type that a closure literal is assigned to somewhere in `body`.
+    ///
+    /// Two shapes, because an optional binding is usually declared and filled in separate
+    /// statements: `let x: T = { … }` states it outright, and `var x: T?` followed by
+    /// `x = { … }` states it across two. The second is the one the corpus contains.
+    private func recordClosureAssignedTypes(in body: Syntax) {
+        var declaredType: [String: String] = [:]
+        collectAnnotatedBindings(in: body, into: &declaredType)
+        guard !declaredType.isEmpty else { return }
+        for name in closureAssignedNames(in: body) {
+            if let typeName = declaredType[name] { aliasNames.insert(typeName) }
+        }
+    }
+
+    /// Local bindings carrying a nominal type annotation, with the optional unwrapped — and the
+    /// ones already initialised with a closure recorded on the spot.
+    private func collectAnnotatedBindings(in node: Syntax, into found: inout [String: String]) {
+        for child in node.children(viewMode: .sourceAccurate) {
+            if let variable = child.as(VariableDeclSyntax.self) {
+                for binding in variable.bindings {
+                    guard let name = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
+                          let annotation = binding.typeAnnotation?.type,
+                          let typeName = Self.nominalName(of: annotation) else { continue }
+                    found[name] = typeName
+                    if let value = binding.initializer?.value, Self.isClosure(value) {
+                        aliasNames.insert(typeName)
+                    }
+                }
+            }
+            collectAnnotatedBindings(in: child, into: &found)
+        }
+    }
+
+    /// Names on the left of an `=` whose right-hand side is a closure literal.
+    ///
+    /// `SwiftParser` leaves an assignment unfolded as a `SequenceExprSyntax` of
+    /// `target`, `=`, `value`, so the three are read off the element list rather than from an
+    /// `InfixOperatorExprSyntax` — the same reason the `??` walk elsewhere handles both spellings.
+    private func closureAssignedNames(in node: Syntax) -> Set<String> {
+        var found: Set<String> = []
+        collectClosureAssignedNames(in: node, into: &found)
+        return found
+    }
+
+    private func collectClosureAssignedNames(in node: Syntax, into found: inout Set<String>) {
+        for child in node.children(viewMode: .sourceAccurate) {
+            if let sequence = child.as(SequenceExprSyntax.self) {
+                let elements = Array(sequence.elements)
+                for index in elements.indices.dropFirst().dropLast()
+                where elements[index].as(AssignmentExprSyntax.self) != nil {
+                    if let target = elements[index - 1].as(DeclReferenceExprSyntax.self),
+                       Self.isClosure(elements[index + 1]) {
+                        found.insert(target.baseName.text)
+                    }
+                }
+            }
+            if let infix = child.as(InfixOperatorExprSyntax.self),
+               infix.operator.is(AssignmentExprSyntax.self),
+               let target = infix.leftOperand.as(DeclReferenceExprSyntax.self),
+               Self.isClosure(infix.rightOperand) {
+                found.insert(target.baseName.text)
+            }
+            collectClosureAssignedNames(in: child, into: &found)
+        }
+    }
+
+    /// A closure literal, seeing through the wrappers an assignment may carry.
+    private static func isClosure(_ expression: ExprSyntax) -> Bool {
+        if expression.is(ClosureExprSyntax.self) { return true }
+        if let tuple = expression.as(TupleExprSyntax.self), tuple.elements.count == 1,
+           let only = tuple.elements.first {
+            return isClosure(only.expression)
+        }
+        return false
+    }
+
+    /// The base name of a nominal type annotation, with one level of optional unwrapped.
+    /// `CLIToolCommandRunner?` is the spelling a bridged seam uses, and an annotation that is
+    /// *already* a function type needs no evidence — the existing alias path or the declaration
+    /// itself covers it.
+    private static func nominalName(of type: TypeSyntax) -> String? {
+        if let optional = type.as(OptionalTypeSyntax.self) {
+            return nominalName(of: optional.wrappedType)
+        }
+        return type.as(IdentifierTypeSyntax.self)?.name.text
     }
 
     /// Whether `type` is a function type, seeing through the wrappers an alias commonly uses.

--- a/Tests/CoreTests/Architecture/ClosureAssignmentEvidenceTests.swift
+++ b/Tests/CoreTests/Architecture/ClosureAssignmentEvidenceTests.swift
@@ -1,0 +1,103 @@
+@testable import Core
+import Foundation
+import SwiftParser
+@testable import SwiftProjectLintVisitors
+import SwiftSyntax
+import Testing
+
+/// Assigning a closure literal to a binding proves its declared type is a function type — the
+/// compiler would reject it otherwise. That is what lets `ConcreteTypeUsage` recognise a seam whose
+/// `typealias` is declared in a package this project does not own.
+@Suite("A closure assignment proves the declared type is a function type")
+struct ClosureAssignmentEvidenceTests {
+
+    private func names(_ source: String) -> Set<String> {
+        let collector = FunctionTypeAliasCollector()
+        collector.walk(Parser.parse(source: source))
+        return collector.collectedTypes
+    }
+
+    /// The corpus shape, from `SwiftLintCLIActor.init` and `SwiftFormatCLIActor.init`.
+    /// `CLIToolCommandRunner` is declared in LintStudioUI — a different repository — so the alias
+    /// scan cannot reach it, and both repositories reported a finding nobody could act on.
+    @Test func aDeferredAssignmentProvesTheType() {
+        let source = """
+        actor Tool {
+            init(commandRunner: Runner?) {
+                var bridgedRunner: CLIToolCommandRunner?
+                if let commandRunner {
+                    bridgedRunner = { arguments, _ in try await commandRunner(arguments) }
+                }
+                self.tool = CLIToolActor(runner: bridgedRunner)
+            }
+        }
+        """
+        #expect(names(source).contains("CLIToolCommandRunner"))
+    }
+
+    @Test func anInitialisedDeclarationProvesTheType() {
+        let source = """
+        func make() {
+            let runner: ForeignRunner = { _ in Data() }
+            use(runner)
+        }
+        """
+        #expect(names(source).contains("ForeignRunner"))
+    }
+
+    /// The alias path still works on its own, and an alias in scope needs no assignment.
+    @Test func theAliasPathIsUnaffected() {
+        let source = "typealias Runner = @Sendable ([String]) async throws -> Data"
+        #expect(names(source) == ["Runner"])
+    }
+
+    // MARK: - What it must not claim
+
+    /// A service assigned from a call is not a function type, and this is the shape the gate would
+    /// wrongly exempt if it keyed on assignment alone rather than on the assigned *value*.
+    @Test func assigningACallResultProvesNothing() {
+        let source = """
+        func make() {
+            var client: OllamaHTTPClient?
+            client = OllamaHTTPClient(baseURL: url)
+            use(client)
+        }
+        """
+        #expect(names(source).isEmpty)
+    }
+
+    /// A closure assigned to a *property* of something else says nothing about the local's type.
+    @Test func assigningThroughAMemberProvesNothing() {
+        let source = """
+        func make() {
+            var holder: SomeService?
+            holder?.handler = { _ in }
+            use(holder)
+        }
+        """
+        #expect(names(source).isEmpty)
+    }
+
+    /// The declaration and the assignment must share a body. Without that, any name reused across
+    /// two functions could lend its type to a closure it has nothing to do with.
+    @Test func aDeclarationInAnotherBodyIsNotEvidence() {
+        let source = """
+        func declare() {
+            var runner: RealService?
+            use(runner)
+        }
+        func assign() {
+            var runner: Callback?
+            runner = { _ in }
+            use(runner)
+        }
+        """
+        #expect(!names(source).contains("RealService"))
+        #expect(names(source).contains("Callback"))
+    }
+
+    /// No annotation, nothing to record — the type is inferred and the collector reads spellings.
+    @Test func anInferredBindingIsNotEvidence() {
+        #expect(names("func make() { var handler = { _ in }; use(handler) }").isEmpty)
+    }
+}


### PR DESCRIPTION
## The boundary this removes

`CLIToolCommandRunner` is a closure `typealias` declared in **LintStudioUI**, a separate repository
pulled in as a package dependency. The alias exemption comes from a project-wide prescan, so two
repositories that bridge onto it each reported a finding the prescan could not answer — written up
for two sweeps as *"a cross-package typealias the prescan cannot see, a documented boundary rather
than a defect."*

**The evidence was local all along:**

```swift
var bridgedRunner: CLIToolCommandRunner?
if let commandRunner {
    bridgedRunner = { arguments, _ in … }        // ← only a function type accepts this
}
```

Assigning a closure literal to a binding **proves** its declared type is a function type — the
compiler rejects it otherwise. That is a fact, not a heuristic, and it holds whoever declares the
alias and wherever they declare it.

## What changed

`FunctionTypeAliasCollector` now records two more shapes: a declaration initialised with a closure
(`let runner: ForeignRunner = { … }`), and a declaration filled by a later assignment in the same
body (the corpus shape).

**Widened the existing collector rather than adding a prescan**, for two reasons: the set it
produces already means *"names known to denote a function type"*, and wiring a new prescan through
the engine takes eight hops — three of which were once done, leaving a gate that compiled, passed
its tests, and never fired.

## Precision

Scoped to one function or initializer body, so an unrelated `runner` elsewhere in the file cannot
lend its name to a type it has nothing to do with. A nested shadow inside the same body could
still mislead; that is the residual, and it is worth less than the boundary it removes.

**The test that matters is negative:**

```swift
var client: OllamaHTTPClient?
client = OllamaHTTPClient(baseURL: url)
```

That is an assignment too. Keying on the assignment rather than on the assigned **value** would
have exempted every service constructed in an initializer — including four of the findings this
rule currently reports correctly. Also covered: a closure assigned through a member
(`holder?.handler = { }`), a declaration in a different body, and an inferred binding with no
annotation.

## Measured

| | before | after |
|---|---|---|
| SwiftLintRuleStudio | 2 | **1** |
| SwiftFormatRuleStudio | 3 | **2** |
| Concrete Type Usage, corpus | 15 | **13** |

Nothing else moved. 3,652 tests pass; `swiftlint` unchanged at 27 lines.

The doc's "only when the alias is declared in the analyzed sources" limitation is struck through
with the measurement and the reason, rather than deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrD7SdySCSbg15qC8qbpYy