### PR TITLE
Reach through a member that only re-presents the value

### DIFF
--- a/Docs/rules/non-injected-nondeterminism.md
+++ b/Docs/rules/non-injected-nondeterminism.md
@@ -171,6 +171,34 @@ reads the clock into a receiver or an operand, never into a bare argument:
 | `Date.now.timeIntervalSince1970` | a number bound into SQL |
 | `"probe_\(UUID().uuidString).swift"` | a filename this scope composed |
 
+**A member that only re-presents the value is reached through.** A receiver is normally the scope
+*using* the value, and that is where every defect this rule has produced lives — but four of the nine
+sites this arm could not reach were receivers that merely change the value's type and then hand it on:
+`Date.now.formatted(date: .abbreviated, time: .shortened)` bound and passed as a `timestamp:`,
+`bind(Date.now.timeIntervalSince1970, at: 1)`, `R(identifier: UUID().uuidString, …)`. None of those is
+a decision.
+
+The distinction is whether the member's arguments **reach into the scope**:
+
+| expression | arguments | what it is |
+| --- | --- | --- |
+| `.uuidString` | none | the same identity as text |
+| `.timeIntervalSince1970` | none | the same instant as a number |
+| `.httpHeader` | none | the same instant as an RFC1123 header |
+| `.formatted(date: .abbreviated, time: .shortened)` | leading-dot style options | the same instant, formatted |
+| `.addingTimeInterval(timeout)` | **`timeout`** | a deadline |
+| `.timeIntervalSince(start)` | **`start`** | an elapsed time — a benchmark's whole output |
+
+An argument may contain literals and leading-dot members and nothing else; one bare identifier and the
+member counts as combining, because resolving whether that identifier is a local, a parameter or a
+static constant is a scope walk, and guessing it wrong turns a deadline into an end state. A trailing
+closure is never inert.
+
+**Re-presentation alone is not enough** — the result still has to be handed on. A formatted instant
+that is *returned* rather than passed keeps the ordinary message, as does one interpolated into a
+string. Measured: 3 of our 34 findings reclassified and 2 of 37 in third-party checkouts, with none
+added or removed in either set.
+
 The bound spelling counts too — `let now = Date()` then only `f(asOf: now)` — and it demands that
 **every** reference to the binding is itself an argument. One comparison, one piece of arithmetic,
 one `return`, and the binding keeps the ordinary message. That is the safe direction: a shadowed

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor+Placement.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor+Placement.swift
@@ -156,8 +156,24 @@ extension NonInjectedNondeterminismVisitor {
     /// one that does not. It is scoped to a local `let`; a stored property's initial value is not a
     /// composition root, because the read happens once per instance and the uses are elsewhere.
     func isHandedStraightOn(_ node: Syntax) -> Bool {
-        if isArgumentPosition(node) { return true }
-        return isBoundAndOnlyPassedOn(node)
+        // Reach through any member chain that only restates the value, so both spellings below ask
+        // about the same expression: `bind(Date.now.timeIntervalSince1970, …)` is the argument form
+        // and `let stamp = Date.now.formatted(…)` is the bound one.
+        let effective = outermostRepresentation(of: node)
+        if isArgumentPosition(effective) { return true }
+        return isBoundAndOnlyPassedOn(effective)
+    }
+
+    /// `node` with every re-presenting member applied — the outermost expression that is still only
+    /// the same fact in another type. Returns `node` itself when the first member does something.
+    private func outermostRepresentation(of node: Syntax) -> Syntax {
+        var outer = node
+        while let member = outer.parent?.as(MemberAccessExprSyntax.self),
+              member.base.map({ Syntax($0).id == outer.id }) == true,
+              let next = representation(of: member) {
+            outer = next
+        }
+        return outer
     }
 
     /// The `let name = <read>` case: a local binding whose every use is an argument.
@@ -209,6 +225,8 @@ extension NonInjectedNondeterminismVisitor {
         var current = node.parent
         while let syntax = current {
             // A receiver, not an argument: this scope is about to do something with the value.
+            // Re-presenting members were already stepped past by `outermostRepresentation(of:)`, so
+            // anything still in receiver position here is combining.
             if let member = syntax.as(MemberAccessExprSyntax.self) {
                 return member.base.map { Syntax($0).id == child.id } == false
             }
@@ -224,6 +242,67 @@ extension NonInjectedNondeterminismVisitor {
             current = syntax.parent
         }
         return false
+    }
+
+    /// The outermost expression of a **re-presenting** member access, or `nil` when the member is
+    /// doing something with the value rather than restating it.
+    ///
+    /// A receiver is normally where this rule's precision comes from: every defect it has produced
+    /// across the corpus reads the clock into one. But four of the nine sites the composition-root
+    /// arm could not reach were receivers that merely change the value's *type* and then hand it on:
+    ///
+    /// ```swift
+    /// let stamp = Date.now.formatted(date: .abbreviated, time: .shortened)  // …timestamp: stamp
+    /// statement.bind(Date.now.timeIntervalSince1970, at: 1)
+    /// UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
+    /// ```
+    ///
+    /// None of those is a decision. The instant or the identity is the same fact in a `String` or a
+    /// `Double`, handed to something that takes it as a parameter — which is the shape this arm
+    /// exists to name.
+    ///
+    /// **The distinction is whether the member's arguments reach into the scope.** Combining the
+    /// value with a local or a parameter produces a *new* fact, and that is where every defect lives:
+    ///
+    /// | expression | arguments | what it is |
+    /// | --- | --- | --- |
+    /// | `.uuidString` | none | the same identity as text |
+    /// | `.timeIntervalSince1970` | none | the same instant as a number |
+    /// | `.formatted(date: .abbreviated, time: .shortened)` | leading-dot style options | the same instant, formatted |
+    /// | `.addingTimeInterval(timeout)` | **`timeout`** | a deadline |
+    /// | `.timeIntervalSince(start)` | **`start`** | an elapsed time — a benchmark's whole output |
+    ///
+    /// Deliberately strict about what counts as inert: an argument may contain literals and
+    /// leading-dot members and **nothing else**. One bare identifier and the member is treated as
+    /// combining, because resolving whether that identifier is a local, a parameter or a static
+    /// constant is a scope walk, and guessing it wrong turns a deadline into an end state.
+    private func representation(of member: MemberAccessExprSyntax) -> Syntax? {
+        guard let call = member.parent?.as(FunctionCallExprSyntax.self),
+              Syntax(call.calledExpression).id == Syntax(member).id else {
+            // A bare member with no call: `.uuidString`, `.timeIntervalSince1970`. Nothing was
+            // supplied, so nothing was combined.
+            return Syntax(member)
+        }
+        guard call.arguments.allSatisfy({ Self.isInert($0.expression) }),
+              call.trailingClosure == nil,
+              call.additionalTrailingClosures.isEmpty else { return nil }
+        return Syntax(call)
+    }
+
+    /// An argument that supplies no value from the surrounding scope.
+    ///
+    /// The leading-dot test is written out rather than as
+    /// `expression.as(MemberAccessExprSyntax.self)?.base == nil`, which reads correctly and is
+    /// wrong: optional-chaining a non-member expression yields `nil`, and `nil == nil` is `true`, so
+    /// that spelling calls **every** argument inert. It shipped for one build and the negative test
+    /// for `Date().addingTimeInterval(timeout)` caught it — a deadline reported as an end state,
+    /// which is the one direction this arm must never fail in.
+    private static func isInert(_ expression: ExprSyntax) -> Bool {
+        if let member = expression.as(MemberAccessExprSyntax.self), member.base == nil { return true }
+        return !expression.tokens(viewMode: .sourceAccurate).contains { token in
+            if case .identifier = token.tokenKind { return true }
+            return false
+        }
     }
 
     /// Wrappers that do not change what is being done with the value.

--- a/Tests/CoreTests/Testability/NonInjectedNondeterminismCompositionRootTests.swift
+++ b/Tests/CoreTests/Testability/NonInjectedNondeterminismCompositionRootTests.swift
@@ -110,18 +110,67 @@ struct NonInjectedNondeterminismCompositionRootTests {
     // MARK: - Receivers are uses, not hand-offs
 
     /// Every real defect this rule has produced across the corpus reads the clock into a receiver
-    /// or an operand: a deadline, an elapsed time, a rate-limit window. None of them is an
-    /// argument, and that is the whole precision of the arm.
-    @Test("a receiver is the scope using the value, not passing it", arguments: [
+    /// **and combines it with something from the scope** — a deadline, an elapsed time, a rate-limit
+    /// window. That combination is the precision of the arm, not the receiver itself.
+    @Test("combining the value with a local or parameter is not a hand-off", arguments: [
         "func f(_ t: TimeInterval) { let deadline = Date().addingTimeInterval(t); wait(until: deadline) }",
-        "func f(_ start: Date) -> Double { Date().timeIntervalSince(start) }",
-        "func f() { bind(Date.now.timeIntervalSince1970, at: 1) }",
+        "func f(_ start: Date) -> Double { Date().timeIntervalSince(start) }"
+    ])
+    func combiningReceiverIsNotACompositionRoot(source: String) {
+        #expect(analyze(source).count == 1)
+        #expect(!isCompositionRoot(source))
+    }
+
+    /// Re-presenting the value and then *not* handing it on is still not a composition root: these
+    /// return or interpolate the result rather than passing it to anything.
+    @Test("re-presentation alone is not enough — it still has to be handed on", arguments: [
         "func f() -> String { Date.now.formatted(date: .abbreviated, time: .shortened) }",
         "func f() -> String { \"probe_\\(UUID().uuidString).swift\" }"
     ])
-    func receiverIsNotACompositionRoot(source: String) {
+    func representationWithoutAHandOffIsNotACompositionRoot(source: String) {
         #expect(analyze(source).count == 1)
         #expect(!isCompositionRoot(source))
+    }
+
+    // MARK: - Re-presentation is reached through
+
+    /// **This test asserted the opposite when the arm shipped**, on the reasoning that a receiver is
+    /// always the scope using the value. `.timeIntervalSince1970` takes no argument: it is the same
+    /// instant as a number, handed to `bind` as an argument. Four of the nine sites the arm could not
+    /// reach were this shape (SwiftProjectLint#193), and the distinction is not the receiver but
+    /// whether its arguments reach into the scope.
+    @Test("a zero-argument member re-presents the value and is reached through", arguments: [
+        "func f() { bind(Date.now.timeIntervalSince1970, at: 1) }",
+        "func f(_ content: C) { schedule(R(identifier: UUID().uuidString, content: content)) }"
+    ])
+    func zeroArgumentMemberIsReachedThrough(source: String) {
+        #expect(analyze(source).count == 1)
+        #expect(isCompositionRoot(source))
+    }
+
+    /// Arguments that are leading-dot style options supply nothing from the scope, so the instant is
+    /// still only being restated — here into a `String` that is then handed on.
+    @Test func formattedThenPassedOnIsACompositionRoot() {
+        let source = """
+        func export(report: R, as format: F) {
+            let stamp = Date.now.formatted(date: .abbreviated, time: .shortened)
+            write(Exporter.export(report, as: format, timestamp: stamp))
+        }
+        """
+        #expect(analyze(source).count == 1)
+        #expect(isCompositionRoot(source))
+    }
+
+    /// One bare identifier in the arguments and the member is treated as combining, because
+    /// resolving whether it is a local, a parameter or a static constant is a scope walk — and
+    /// guessing it wrong turns a deadline into an end state.
+    @Test func anIdentifierArgumentIsNotInert() {
+        #expect(!isCompositionRoot("func f(_ s: S) { send(Date().addingTimeInterval(s.window)) }"))
+    }
+
+    /// A trailing closure can run anything, so a member carrying one is never re-presentation.
+    @Test func aTrailingClosureIsNotInert() {
+        #expect(!isCompositionRoot("func f() { send(Date.now.transformed { $0 }) }"))
     }
 
     // MARK: - Arm order


### PR DESCRIPTION
Closes the class-B half of #193.

## What the arm was refusing

It rejected a receiver outright — *a receiver is the scope using the value, not passing it* — which is
true of every defect this rule has produced. But four of the nine sites the arm could not reach were
receivers that merely change the value's **type** and hand it on:

```swift
let stamp = Date.now.formatted(date: .abbreviated, time: .shortened)   // …timestamp: stamp
statement.bind(Date.now.timeIntervalSince1970, at: 1)
UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
```

None is a decision. The instant or the identity is the same fact in a `String` or a `Double`, handed to
something that takes it as a parameter — the shape this arm exists to name.

## The distinction: do the member's arguments reach into the scope?

| expression | arguments | what it is |
| --- | --- | --- |
| `.uuidString` | none | the same identity as text |
| `.timeIntervalSince1970` | none | the same instant as a number |
| `.formatted(date: .abbreviated, time: .shortened)` | leading-dot style options | the same instant, formatted |
| `.addingTimeInterval(timeout)` | **`timeout`** | a deadline |
| `.timeIntervalSince(start)` | **`start`** | an elapsed time — a benchmark's whole output |

An argument may contain literals and leading-dot members and **nothing else**. One bare identifier and
the member counts as combining: resolving whether it is a local, a parameter or a static constant is a
scope walk, and guessing wrong turns a deadline into an end state. A trailing closure is never inert.

**Re-presentation alone is not enough** — the result still has to be handed on. A formatted instant that
is *returned*, or interpolated into a string, keeps the ordinary message.

## A bug that shipped for one build, and the test that caught it

The leading-dot check was first written as:

```swift
if expression.as(MemberAccessExprSyntax.self)?.base == nil { return true }
```

That reads correctly and is wrong. Optional-chaining a non-member expression yields `nil`, and
`nil == nil` is `true` — so it called **every** argument inert and reported
`Date().addingTimeInterval(timeout)` as a composition root. The negative test for that exact shape
failed immediately, which is the one direction this arm must never fail in. The corrected spelling
carries that history in a comment.

## Measured on two sets, one of which this arm has never been tuned on

| | findings | reclassified | added | removed |
|---|---|---|---|---|
| our corpus | 34 → **34** | 3 | 0 | 0 |
| SwiftLint, SwiftPlantUML, swift-argument-parser, Hummingbird, swift-aws-lambda-runtime | 37 → **37** | 2 | 0 | 0 |

The three in ours are the three the issue identified; the fourth is a string interpolation rather than a
member chain and correctly stays.

**The two in third-party code were read, not counted.** Both are `Date.now.httpHeader` in Hummingbird's
`DateCache` — a zero-argument member formatting the instant as an RFC1123 header, handed straight to
`DateContainer.init(date:)`. Correct. Nothing else among 37 moved, including Hummingbird's
`Router+validation.swift` ×7, SwiftLint's `Linter.swift` ×2 and aws-lambda-runtime's `Utils.swift` ×2.

## What stays refused

**Class A — assignment to storage — deliberately.** `lastSyncTime = Date()`,
`user.lastLogin = Date()`, `let signedInAt = Date()` assigned on two branches. That is where
`MacCloudFile.init`'s invented-stamp defect lived, and correct code and the defect wear the same shape
from outside. Six of the nine sites remain, and #193 keeps the account.

3,670 tests pass; `swiftlint` output diffed against `main` and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrD7SdySCSbg15qC8qbpYy