### PR TITLE
Report each dependency cycle at one end, chosen by the code

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/CircularDependencyVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/CircularDependencyVisitor.swift
@@ -90,28 +90,46 @@ final class CircularDependencyVisitor: CrossFileVisitorBase, CrossFilePatternVis
 
     // MARK: - Phase 2: Detect cycles
 
+    /// Reports each cycle once, at its lexicographically smaller end.
+    ///
+    /// **A cycle has two ends and the rule has to pick one, so the pick must come from the code
+    /// rather than from the walk.** `typeReferences` is a `Dictionary`, and Swift seeds its hashing
+    /// per process, so iterating it directly reached `A ↔ B` from whichever side came up first —
+    /// which decided the reported file, the reported line, and the order of the two names in the
+    /// message. Measured: five runs of one binary over one unchanged repository gave three different
+    /// answers for the same two cycles, `MacCloudFile ↔ MacCloudShare` landing on its `MacCloudFile`
+    /// end in some runs and its `MacCloudShare` end in others.
+    ///
+    /// Nothing about that is a judgement the rule is entitled to make — the arrow is symmetric, and
+    /// neither end is more the cause than the other — so the tie is broken by name. That makes the
+    /// output a function of the source, which is what a baseline diff needs: before the fix, two
+    /// sweeps with no intervening code change produced phantom `REMOVED`/`ADDED` pairs, and a reader
+    /// comparing them had to rule out a real movement by hand.
+    ///
+    /// The outer walk is sorted for the same reason, so the *sequence* of issues is stable too.
     func finalizeAnalysis() {
         var reported: Set<String> = []
 
-        for (typeA, refs) in typeReferences {
-            for ref in refs {
+        for typeA in typeReferences.keys.sorted() {
+            for ref in typeReferences[typeA] ?? [] {
                 guard reportableCycleTarget(from: typeA, ref: ref) != nil else { continue }
                 let typeB = ref.target
 
                 // Avoid duplicate reports (A↔B and B↔A)
-                let cycleKey = [typeA, typeB].sorted().joined(separator: "↔")
+                let ends = [typeA, typeB].sorted()
+                let cycleKey = ends.joined(separator: "↔")
                 guard reported.contains(cycleKey) == false else { continue }
                 reported.insert(cycleKey)
 
-                let infoA = typeDeclarations[typeA]
-                let fileA = infoA?.file ?? currentFilePath
+                let (named, partner) = (ends[0], ends[1])
+                let info = typeDeclarations[named]
 
                 addIssue(
                     severity: .warning,
                     message: "Circular dependency detected: "
-                        + "'\(typeA)' \u{2194} '\(typeB)'",
-                    filePath: fileA,
-                    lineNumber: infoA.map { getLineNumber(for: $0.node) } ?? 0,
+                        + "'\(named)' \u{2194} '\(partner)'",
+                    filePath: info?.file ?? currentFilePath,
+                    lineNumber: info.map { getLineNumber(for: $0.node) } ?? 0,
                     suggestion: "Break the cycle by introducing a protocol for "
                         + "one side, using a mediator/coordinator pattern, "
                         + "or merging the types if they represent a single concern.",

--- a/Tests/CoreTests/CrossFileAnalysis/CircularDependencyDeterminismTests.swift
+++ b/Tests/CoreTests/CrossFileAnalysis/CircularDependencyDeterminismTests.swift
@@ -1,0 +1,141 @@
+@testable import Core
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+/// A cycle has two ends, and which one the rule reports must come from the code.
+///
+/// `typeReferences` is a `Dictionary`, so before the fix the walk reached `A ↔ B` from whichever
+/// side the per-process hash seed happened to offer first — and that decided the reported file, the
+/// reported line, and the order of the two names in the message. Five runs of one binary over one
+/// unchanged repository gave three different answers.
+///
+/// These tests drive the visit order explicitly rather than relying on a dictionary, because the
+/// claim is precisely that visit order does not reach the output.
+///
+/// **Two of the four only kill the defect about half the time, and that is the defect's own
+/// signature rather than a weakness to fix.** Run against the unfixed visitor ten times:
+/// `ordersSeveralCyclesStably` failed 10/10, `reportsTheSameEndWhicheverSideIsWalkedFirst` 6/10,
+/// `reportsTheLexicographicallySmallerEnd` 5/10, and the weak-reference control 0/10. A test whose
+/// subject is a per-process hash seed cannot be a decision on one run — the multi-cycle ordering is,
+/// because four cycles give the seed too many ways to be wrong at once, and it is the test to keep if
+/// only one survives. The other two are kept for what they say, not for their kill rate.
+@Suite
+struct CircularDependencyDeterminismTests {
+
+    private func analyze(order: [(name: String, source: String)]) -> [LintIssue] {
+        var cache: [String: SourceFileSyntax] = [:]
+        for file in order {
+            cache[file.name] = Parser.parse(source: file.source)
+        }
+        let visitor = CircularDependencyVisitor(fileCache: cache)
+        visitor.setPattern(CircularDependency().pattern)
+
+        for file in order {
+            guard let ast = cache[file.name] else { continue }
+            visitor.setFilePath(file.name)
+            visitor.setSourceLocationConverter(
+                SourceLocationConverter(fileName: file.name, tree: ast)
+            )
+            visitor.walk(ast)
+        }
+        visitor.finalizeAnalysis()
+        return visitor.detectedIssues.filter { $0.ruleName == .circularDependency }
+    }
+
+    /// `Zebra` declared first and `Apple` declared first must report identically.
+    private var pair: [(name: String, source: String)] {
+        [
+            ("Zebra.swift", """
+            class Zebra {
+                var apple: Apple
+            }
+            """),
+            ("Apple.swift", """
+            class Apple {
+                var zebra: Zebra
+            }
+            """)
+        ]
+    }
+
+    @Test func reportsTheSameEndWhicheverSideIsWalkedFirst() throws {
+        let forward = analyze(order: pair)
+        let reversed = analyze(order: pair.reversed())
+
+        #expect(forward.count == 1)
+        #expect(reversed.count == 1)
+
+        let first = try #require(forward.first)
+        let second = try #require(reversed.first)
+        #expect(first.filePath == second.filePath)
+        #expect(first.lineNumber == second.lineNumber)
+        #expect(first.message == second.message)
+    }
+
+    /// The end reported is the lexicographically smaller name, which is the only tie-break available
+    /// that is a fact about the code. Pinning *which* end keeps the previous test from passing on a
+    /// rule that is merely consistently wrong — two identical reports at the wrong end satisfy it.
+    @Test func reportsTheLexicographicallySmallerEnd() throws {
+        let issue = try #require(analyze(order: pair).first)
+        #expect(issue.filePath == "Apple.swift")
+        #expect(issue.message == "Circular dependency detected: 'Apple' ↔ 'Zebra'")
+    }
+
+    /// Several cycles come out in a stable sequence, not only each at a stable place. The outer walk
+    /// is over sorted keys for this reason; an unsorted one passes both tests above and still
+    /// reorders a multi-cycle report between runs.
+    @Test func ordersSeveralCyclesStably() {
+        let files: [(name: String, source: String)] = [
+            ("Delta.swift", """
+            class Delta {
+                var charlie: Charlie
+            }
+            """),
+            ("Charlie.swift", """
+            class Charlie {
+                var delta: Delta
+            }
+            """),
+            ("Bravo.swift", """
+            class Bravo {
+                var alpha: Alpha
+            }
+            """),
+            ("Alpha.swift", """
+            class Alpha {
+                var bravo: Bravo
+            }
+            """)
+        ]
+        let forward = analyze(order: files).map(\.message)
+        let reversed = analyze(order: files.reversed()).map(\.message)
+
+        #expect(forward.count == 2)
+        #expect(forward == reversed)
+        #expect(forward == [
+            "Circular dependency detected: 'Alpha' ↔ 'Bravo'",
+            "Circular dependency detected: 'Charlie' ↔ 'Delta'"
+        ])
+    }
+
+    /// A weak back-reference is still no cycle whichever side declares it, which is the one place
+    /// where naming the smaller end could have changed a decision rather than only a location.
+    @Test func aWeakBackReferenceIsStillNoCycleFromEitherSide() {
+        let files: [(name: String, source: String)] = [
+            ("Zebra.swift", """
+            class Zebra {
+                weak var apple: Apple?
+            }
+            """),
+            ("Apple.swift", """
+            class Apple {
+                var zebra: Zebra
+            }
+            """)
+        ]
+        #expect(analyze(order: files).isEmpty)
+        #expect(analyze(order: files.reversed()).isEmpty)
+    }
+}


### PR DESCRIPTION
## What changed

`CircularDependencyVisitor.finalizeAnalysis` iterated a `Dictionary`:

```swift
for (typeA, refs) in typeReferences {
```

Swift seeds `Dictionary` hashing per process, so `A ↔ B` was reached from whichever side came up first — and `typeA` decided the reported file, the reported line, and the order of the two names in the message. The tie is now broken by name (each cycle reported at its lexicographically smaller end), and the outer walk is over sorted keys so the *sequence* of issues is stable too.

## Measured

Five runs of one binary over one unchanged repository, before:

```
["MacCloudModels.swift:157 …'MacCloudVersion' ↔ …", "MacCloudModels.swift:184 …'MacCloudShare' ↔ …"]
["MacCloudModels.swift:157 …",                       "MacCloudModels.swift:66 …'MacCloudFile' ↔ …"]
["MacCloudModels.swift:66 …'MacCloudFile' ↔ …",      "MacCloudModels.swift:66 …"]
…
```

Three different answers. Six runs after: one answer.

**This was costing real measurement time.** Two corpus sweeps with no intervening change to this rule produced phantom `REMOVED`/`ADDED` pairs in the baseline diff, which a reader had to rule out by hand before trusting the rest.

## What a reviewer should scrutinise

- **Whether name order is the right tie-break.** It is the only tie-break available that is a fact about the code rather than about the run. Neither end of a symmetric arrow is more the cause, so the rule should not appear to claim one is — and a reader who wants the other end can read the message, which names both.
- **The kill rates, which are in the test file.** Against the unfixed visitor, ten runs: `ordersSeveralCyclesStably` 10/10, `reportsTheSameEndWhicheverSideIsWalkedFirst` 6/10, `reportsTheLexicographicallySmallerEnd` 5/10, weak-reference control 0/10. Two of the four are coin flips, which is the defect's own signature — a test whose subject is a per-process hash seed cannot be a decision on one run. The multi-cycle ordering test is the one that is, and is the one to keep if only one survives.
- **What did not catch this.** `DetectorRobustnessPropertyTests.detection_isDeterministic` exists and its doc comment names this exact failure mode — *"nondeterministic aggregation (set/dict iteration leaking into output)"*. It is single-file, so it never reaches `finalizeAnalysis`, and it compares two calls in one process, which holds the hash seed constant across both halves. Filed as a separate issue rather than widened here.

3,681 tests pass; `swiftlint` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrD7SdySCSbg15qC8qbpYy