### PR TITLE
Lift the root-relative path derivation into a kernel with laws

### DIFF
--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/LintConfiguration.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/LintConfiguration.swift
@@ -193,18 +193,19 @@ public struct LintConfiguration: Sendable {
         // Build a lookup from basename → full relative path for path matching.
         // Issue file paths are basenames; excluded_paths patterns match relative paths.
         var basenameToRelativePath: [String: String] = [:]
-        if let root = projectRoot {
-            let allFiles = FileAnalysisUtils.findSwiftFiles(in: root)
-            // Resolve symlinks so the prefix matches the canonical paths returned by findSwiftFiles.
-            // FileManager.enumerator resolves symlinks in item paths (e.g. /var → /private/var on
-            // macOS), so an unresolved root prefix would fail the hasPrefix check.
-            let resolvedRoot = FileAnalysisUtils.realPath(root)
-            let prefix = resolvedRoot.hasSuffix("/") ? resolvedRoot : resolvedRoot + "/"
+        if let givenRoot = projectRoot {
+            let allFiles = FileAnalysisUtils.findSwiftFiles(in: givenRoot)
+            // Canonicalised so the prefix matches the paths `findSwiftFiles` returns: the enumerator
+            // spells item paths with the resolved root even when handed an unresolved one
+            // (`/var` → `/private/var` on macOS). See `ProjectRoot`.
+            let root = ProjectRoot(givenRoot)
             for fullPath in allFiles {
                 let basename = (fullPath as NSString).lastPathComponent
-                let relative = fullPath.hasPrefix(prefix)
-                    ? String(fullPath.dropFirst(prefix.count))
-                    : fullPath
+                // Not under the root: match against the absolute path, which is the widest thing a
+                // pattern can be tried on. A third fallback, and now a stated one -- the other two
+                // callers of this derivation answer differently, because an exclusion that matches
+                // too little is safer here than one that matches the wrong relative path.
+                let relative = root.relativePath(of: fullPath)?.value ?? fullPath
                 basenameToRelativePath[basename] = relative
             }
         }

--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/FileAnalysis/DirectoryScanner.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/FileAnalysis/DirectoryScanner.swift
@@ -30,32 +30,31 @@ public struct DirectoryScanner {
         rootPath: String, maxDepth: Int = 4
     ) -> DirectoryNode {
         let fileManager = FileManager.default
-        let rootURL = URL(fileURLWithPath: rootPath, isDirectory: true)
-        let resolvedRoot = FileAnalysisUtils.realPath(rootURL.path)
+        let root = ProjectRoot(rootPath)
         let rootName = (rootPath as NSString).lastPathComponent
 
-        let root = DirectoryNode(
+        let rootNode = DirectoryNode(
             identifier: "",
             name: rootName,
             depth: 0
         )
 
-        var lookup: [String: DirectoryNode] = ["": root]
+        var lookup: [String: DirectoryNode] = ["": rootNode]
 
         guard let enumerator = fileManager.enumerator(
-            at: rootURL,
+            at: root.url,
             includingPropertiesForKeys: [.isDirectoryKey],
             options: .skipsHiddenFiles
         ) else {
-            return root
+            return rootNode
         }
 
-        let prefix = resolvedRoot.hasSuffix("/")
-            ? resolvedRoot
-            : resolvedRoot + "/"
-
         while let itemURL = enumerator.nextObject() as? URL {
-            let resolvedPath = FileAnalysisUtils.realPath(itemURL.path)
+            // The item path is canonicalised as well as the root, which is a decision rather than
+            // symmetry: a symlinked *subdirectory* resolves to somewhere outside the root, so it
+            // lands on the fallback below instead of being placed in the tree at a path that does
+            // not contain it. `ProjectRoot` deliberately leaves this to the caller.
+            let resolvedPath = ProjectRoot.canonical(itemURL.path)
 
             guard let resourceValues = try? itemURL.resourceValues(
                 forKeys: [.isDirectoryKey]
@@ -63,11 +62,14 @@ public struct DirectoryScanner {
                 continue
             }
 
-            let relativePath = resolvedPath.hasPrefix(prefix)
-                ? String(resolvedPath.dropFirst(prefix.count))
-                : (resolvedPath as NSString).lastPathComponent
-
-            let dirName = (relativePath as NSString).lastPathComponent
+            // Not under the root: keep the directory's own name, so a resolved symlink still appears
+            // as a child of the root rather than disappearing. This tree is a display of the project
+            // layout, so a shallow placement is better than an omission -- the opposite call from
+            // `FileAnalysisUtils`, which drives exclusion matching and must skip instead.
+            let relative = root.relativePath(of: resolvedPath)
+                ?? RelativePath((resolvedPath as NSString).lastPathComponent)
+            let relativePath = relative.value
+            let dirName = relative.lastComponent
 
             // Skip build artifacts, VCS directories, and Xcode project bundles
             if FileAnalysisUtils.skippedDirectories.contains(dirName)
@@ -87,7 +89,7 @@ public struct DirectoryScanner {
                 continue
             }
 
-            let depth = relativePath.components(separatedBy: "/").count
+            let depth = relative.depth
             if depth > maxDepth {
                 enumerator.skipDescendants()
                 continue
@@ -99,9 +101,10 @@ public struct DirectoryScanner {
                 depth: depth
             )
 
-            // Find parent
-            let parentPath = (relativePath as NSString).deletingLastPathComponent
-            let parentKey = parentPath == "." ? "" : parentPath
+            // Find parent. `components` has no empty entries, so dropping the last one gives the
+            // parent key directly -- and the "." that `deletingLastPathComponent` can return, which
+            // this line used to map to "", cannot arise from a normalised relative path.
+            let parentKey = relative.components.dropLast().joined(separator: "/")
             if let parentNode = lookup[parentKey] {
                 node.parent = parentNode
                 parentNode.children.append(node)
@@ -111,9 +114,9 @@ public struct DirectoryScanner {
         }
 
         // Sort children alphabetically at every level
-        sortChildren(of: root)
+        sortChildren(of: rootNode)
 
-        return root
+        return rootNode
     }
 
     private static func sortChildren(of node: DirectoryNode) {

--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/FileAnalysis/FileAnalysisUtils.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/FileAnalysis/FileAnalysisUtils.swift
@@ -177,13 +177,13 @@ public struct FileAnalysisUtils {
     ) -> [String] {
         let fileManager = FileManager.default
         var swiftFiles: [String] = []
-        let rootURL = URL(fileURLWithPath: path, isDirectory: true)
-        // FileManager.enumerator resolves symlinks in item paths (e.g. /var → /private/var on
-        // macOS). Use realpath() to canonicalise the root so dropFirst offsets are correct.
-        let resolvedRootPath = Self.realPath(rootURL.path)
+        // Canonicalised once, and enumerated at the canonical URL rather than the given one: a root
+        // that is itself a symlink to a directory makes `enumerator(at:)` yield zero items, so a
+        // project linted through a symlinked path reported no files and exit 0. See `ProjectRoot`.
+        let root = ProjectRoot(path)
 
         guard let enumerator = fileManager.enumerator(
-            at: rootURL,
+            at: root.url,
             includingPropertiesForKeys: [.isDirectoryKey],
             options: .skipsHiddenFiles
         ) else {
@@ -192,33 +192,25 @@ public struct FileAnalysisUtils {
 
         for case let itemURL as URL in enumerator {
             let isDirectory = (try? itemURL.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
-            // Compute the path relative to the project root for matching.
-            let relativePath = String(itemURL.path.dropFirst(resolvedRootPath.count + 1))
-            let components = relativePath.components(separatedBy: "/")
-
-            // If any path component is a directory we should skip, prune the
-            // entire subtree with skipDescendants() rather than filtering each
-            // file individually — this avoids walking thousands of build artefacts.
-            if components.contains(where: { skippedDirectories.contains($0) }) {
+            // An item the enumerator produced is under the root, so `nil` means something changed
+            // underfoot. Skipping it is the only safe answer: the previous unguarded `dropFirst`
+            // carried on with a tail of the wrong length, and that tail drove both the skip check
+            // below and the user's `excluded_paths` — an exclusion that silently stops excluding.
+            guard let relative = root.relativePath(of: itemURL.path) else {
                 if isDirectory { enumerator.skipDescendants() }
                 continue
             }
 
-            // Skip directories that contain their own Package.swift — they are
-            // separate Swift packages and are normally linted only when the tool
-            // is invoked with that directory as root. Opting in with
-            // `includeNestedPackages` keeps them in scope so cross-file rules can
-            // span the boundary; build artefacts and resolved dependencies (under
-            // .build / Pods / Carthage) are already pruned above, so this reaches
-            // first-party local packages without pulling in third-party code.
-            if !includeNestedPackages, isDirectory,
-               fileManager.fileExists(atPath: itemURL.appendingPathComponent("Package.swift").path) {
-                enumerator.skipDescendants()
-                continue
-            }
-
-            // Check user-configured excluded paths
-            if !excludedPaths.isEmpty, excludedPaths.contains(where: { relativePath.contains($0) }) {
+            if isPruned(
+                relative: relative,
+                itemURL: itemURL,
+                isDirectory: isDirectory,
+                excludedPaths: excludedPaths,
+                includeNestedPackages: includeNestedPackages
+            ) {
+                // Prune the entire subtree rather than filtering each file individually — this
+                // avoids walking thousands of build artefacts. A pruned *file* has no descendants,
+                // which is why the call is gated.
                 if isDirectory { enumerator.skipDescendants() }
                 continue
             }
@@ -229,6 +221,38 @@ public struct FileAnalysisUtils {
         }
 
         return swiftFiles
+    }
+
+    /// Whether the item at `relative` should be skipped along with anything below it.
+    ///
+    /// The three reasons a subtree is dropped, in one place: a skipped directory anywhere in the
+    /// path, a nested Swift package, and a user-configured exclusion. They were three branches in
+    /// the walk, each repeating the `skipDescendants()` gate; collapsing them leaves the walk with
+    /// one decision and puts the policy where it can be read on its own.
+    private static func isPruned(
+        relative: RelativePath,
+        itemURL: URL,
+        isDirectory: Bool,
+        excludedPaths: [String],
+        includeNestedPackages: Bool
+    ) -> Bool {
+        if relative.components.contains(where: { skippedDirectories.contains($0) }) { return true }
+
+        // A directory with its own Package.swift is a separate Swift package, normally linted only
+        // when the tool is invoked with that directory as root. Opting in with
+        // `includeNestedPackages` keeps them in scope so cross-file rules can span the boundary;
+        // build artefacts and resolved dependencies (under .build / Pods / Carthage) are already
+        // pruned above, so this reaches first-party local packages without pulling in third-party
+        // code.
+        if !includeNestedPackages, isDirectory,
+           FileManager.default.fileExists(
+               atPath: itemURL.appendingPathComponent("Package.swift").path
+           ) {
+            return true
+        }
+
+        return !excludedPaths.isEmpty
+            && excludedPaths.contains { relative.value.contains($0) }
     }
 
     /// Whether `url` is a Swift file the caller asked to keep.

--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/FileAnalysis/ProjectRoot.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/FileAnalysis/ProjectRoot.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// A canonicalised project root, and the derivation of paths relative to it.
+///
+/// ## Why this is a type
+///
+/// The derivation existed three times in this module, with three different answers to the one
+/// question that matters — *what if the item is not under the root?*
+///
+/// | site | guard | fallback |
+/// |---|---|---|
+/// | `DirectoryScanner` | `hasPrefix` | `lastPathComponent` |
+/// | `FileAnalysisUtils` | **none** | a garbled prefix-drop |
+/// | `LintConfiguration` | `hasPrefix` | the whole absolute path |
+///
+/// `FileAnalysisUtils` is the one that mattered: `String(itemURL.path.dropFirst(root.count + 1))`
+/// cannot fail and cannot report failure, so a path not under the root silently became a string that
+/// is not a relative path at all — and that string then drove `skippedDirectories` matching and the
+/// user's `excluded_paths`. An exclusion that stops working is invisible; it does not throw, it
+/// reports more findings.
+///
+/// So the kernel answers with `nil` and each caller names its own fallback at the call site. The
+/// three fallbacks are still three, but they are now three decisions rather than three accidents.
+///
+/// ## What it canonicalises, and what it deliberately does not
+///
+/// `init` resolves symlinks with `realpath(3)` and, failing that (a root that does not exist yet),
+/// keeps what it was given. So canonicalisation is **total and idempotent** but not complete: a
+/// non-existent `"/a/../b"` stays `"/a/../b"`, because nothing can resolve `..` across a symlink
+/// without the directory being there. Idempotent either way, which is what the law states.
+///
+/// **It does not canonicalise the item path.** That is a policy about symlinked *subdirectories* —
+/// resolving one can move it outside the root, which turns it into a `nil` and sends the caller to
+/// its fallback — and the two walkers disagree about it today. Folding it in here would hide the
+/// disagreement; leaving it out keeps it visible at the call site.
+public struct ProjectRoot: Sendable, Hashable {
+
+    /// The canonical root, with no trailing separator unless it is `"/"`.
+    public let path: String
+
+    /// The URL to enumerate.
+    ///
+    /// **Enumerate here, not at the path the user gave.** `FileManager.enumerator(at:)` on a root
+    /// that *is itself* a symlink to a directory yields **zero items** — measured, reproducibly, on
+    /// macOS 15 — so a project linted through a symlinked path reported no files, no findings, and
+    /// exit 0. Enumerating the resolved root yields the tree.
+    ///
+    /// Resolving also makes the derivation's precondition hold by construction: the enumerator
+    /// spells item paths with the *resolved* root even when handed an unresolved one (`/tmp/x`
+    /// yields `/private/tmp/x/...`), which is why the offsets lined up before this type existed.
+    public var url: URL { URL(fileURLWithPath: path, isDirectory: true) }
+
+    public init(_ given: String) {
+        path = Self.canonical(given)
+    }
+
+    /// The path of `relative` under this root — the round-trip partner of `relativePath(of:)`.
+    public func absolutePath(of relative: RelativePath) -> String {
+        guard !relative.isRoot else { return path }
+        return path.hasSuffix("/") ? path + relative.value : path + "/" + relative.value
+    }
+
+    /// Where `itemPath` sits under this root, or `nil` when it does not sit under it at all.
+    ///
+    /// `nil` is the answer the three hand-written copies were missing. A caller that has a sensible
+    /// fallback should write it; a caller that does not should skip the item rather than carry on
+    /// with a string that is not a relative path.
+    public func relativePath(of itemPath: String) -> RelativePath? {
+        if itemPath == path { return .root }
+        let prefix = path.hasSuffix("/") ? path : path + "/"
+        guard itemPath.hasPrefix(prefix) else { return nil }
+        return RelativePath(String(itemPath.dropFirst(prefix.count)))
+    }
+
+    /// `realpath(3)`, falling back to the input when the path does not resolve.
+    ///
+    /// Total by construction: a root that does not exist yet is a legitimate thing to name, and
+    /// every caller needs an answer rather than an error.
+    static func canonical(_ given: String) -> String {
+        let absolute = URL(fileURLWithPath: given, isDirectory: true).path
+        var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
+        guard realpath(absolute, &buffer) != nil else { return absolute }
+        return String(cString: &buffer)
+    }
+}

--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/FileAnalysis/RelativePath.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/FileAnalysis/RelativePath.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// A path relative to a project root, held as its components.
+///
+/// Components rather than a string because every caller wants them: one asks for the last one as a
+/// directory name, one counts them as a depth, one searches them for a skipped directory. Holding
+/// the string and splitting it at each use is how the three copies of this derivation came to
+/// disagree about what an empty component means.
+///
+/// **Empty components are dropped**, so `"a//b"` and `"a/b/"` are the same relative path. That makes
+/// `init` idempotent through `value`, which is the normalisation half of the round-trip law.
+public struct RelativePath: Sendable, Hashable {
+
+    /// The components, in order, none of them empty.
+    public let components: [String]
+
+    /// The path itself, `"Sources/Deep"`.
+    public var value: String { components.joined(separator: "/") }
+
+    /// The final component, or `""` for the root.
+    public var lastComponent: String { components.last ?? "" }
+
+    /// How far below the root this sits. The root is 0.
+    public var depth: Int { components.count }
+
+    /// Whether this names the root rather than something under it.
+    public var isRoot: Bool { components.isEmpty }
+
+    public init(_ raw: String) {
+        components = raw.components(separatedBy: "/").filter { !$0.isEmpty }
+    }
+
+    /// The root itself.
+    public static let root = Self("")
+}

--- a/Tests/CoreTests/FileAnalysis/ProjectRelativePathLawTests.swift
+++ b/Tests/CoreTests/FileAnalysis/ProjectRelativePathLawTests.swift
@@ -1,0 +1,198 @@
+import Foundation
+import PropertyBased
+@testable import SwiftProjectLintConfig
+import Testing
+
+/// The laws the Extractable Total Kernel finding predicted for this derivation: the round trip and
+/// the idempotence of normalising. Both are stated over generated roots and paths, which is the point
+/// of lifting the computation out of two directory walkers and a configuration pass — inside them it
+/// could only be reached by building a real tree on disk.
+@Suite
+struct ProjectRelativePathLawTests {
+
+    // MARK: - Generators
+
+    /// Components that are awkward on purpose: spaces, dots, a leading dot, and a `..` that nothing
+    /// here resolves. A generator of tidy identifiers would make every law pass for the wrong reason.
+    private static let componentGen = Gen<String?>.element(of: [
+        "Sources", "Tests", ".build", "a b", "..", ".", "x.swift", "Pods", "node_modules", "é"
+    ]).compactMap(\.self)
+
+    private static let relativeGen = componentGen
+        .array(of: 1 ... 5)
+        .map { RelativePath($0.joined(separator: "/")) }
+
+    /// Roots spelled several ways, including with a trailing slash and as `/`, because the prefix
+    /// arithmetic is where the hand-written copies differed.
+    private static let rootGen = Gen<String?>.element(of: [
+        "/projects/app", "/projects/app/", "/", "/a", "/a/b/c",
+        "/Users/someone/My Project", "/nonexistent-root-\(UInt8.max)"
+    ]).compactMap(\.self)
+
+    // MARK: - Round trip
+
+    /// **The round-trip law.** Rebuild the whole from the root and the derived part, and the
+    /// derivation gives back what it started with.
+    ///
+    /// This is the law the unguarded `dropFirst(root.count + 1)` broke: it returns a string for every
+    /// input, and for an input not under the root that string does not rebuild into anything.
+    @Test func derivingThenRebuildingIsTheIdentity() async {
+        await propertyCheck(
+            input: Self.rootGen, Self.relativeGen
+        ) { given, relative in
+            let root = ProjectRoot(given)
+            let absolute = root.absolutePath(of: relative)
+            #expect(
+                root.relativePath(of: absolute) == relative,
+                "root=\(root.path) relative=\(relative.value)"
+            )
+        }
+    }
+
+    /// The other direction: rebuilding a derived part gives back the path it was derived from, for
+    /// any path actually under the root.
+    @Test func rebuildingADerivedPartGivesBackTheSamePath() async {
+        await propertyCheck(
+            input: Self.rootGen, Self.relativeGen
+        ) { given, relative in
+            let root = ProjectRoot(given)
+            let absolute = root.absolutePath(of: relative)
+            guard let derived = root.relativePath(of: absolute) else {
+                Issue.record("a path built under the root must derive: \(absolute)")
+                return
+            }
+            #expect(root.absolutePath(of: derived) == absolute)
+        }
+    }
+
+    // MARK: - Idempotence
+
+    /// **The idempotence law.** Canonicalising twice equals canonicalising once — including for a
+    /// root that does not exist, where `realpath` fails and the input is kept.
+    @Test func canonicalisingIsIdempotent() async {
+        await propertyCheck(input: Self.rootGen) { given in
+            let once = ProjectRoot(given)
+            let twice = ProjectRoot(once.path)
+            #expect(twice.path == once.path, "given=\(given)")
+        }
+    }
+
+    /// Normalising a relative path is idempotent through its own spelling, which is what lets the
+    /// round-trip law compare values rather than strings.
+    @Test func normalisingARelativePathIsIdempotent() async {
+        await propertyCheck(
+            input: Self.componentGen.array(of: 0 ... 5).map { $0.joined(separator: "//") }
+        ) { raw in
+            let once = RelativePath(raw)
+            #expect(RelativePath(once.value) == once, "raw=\(raw)")
+        }
+    }
+
+    // MARK: - Totality
+
+    /// **The refusal law, and the one the old code could not satisfy.** For *any* two strings the
+    /// answer is either `nil` or a relative path that rebuilds — never a string that merely looks
+    /// like one. `dropFirst` is total on a `String`, which is exactly why the defect was silent.
+    ///
+    /// **This law was first written as the identity on the item path, and the first run refuted it**:
+    /// root `/` with item `/projects/app/` derives `projects/app`, which rebuilds as `/projects/app`.
+    /// That is not a bug in the derivation — dropping a trailing separator is the normalisation the
+    /// type exists to do, and the idempotence law above says so. Asserting the identity on the string
+    /// asks the derivation to preserve a spelling it is supposed to discard.
+    ///
+    /// So the law is the weaker and true one: rebuilding is a **retraction**, and deriving a rebuilt
+    /// path gives back the same relative path. Everything the strong form was meant to catch is still
+    /// caught — an unguarded `dropFirst` produces a tail that rebuilds to a *different* path, which
+    /// then derives to a *different* relative path — and the law no longer fails on a correct
+    /// implementation.
+    @Test func anItemIsEitherRefusedOrNormalisesStably() async {
+        let anyPath = Gen<String?>.element(of: [
+            "/projects/app/Sources/File.swift", "/projects/appendix/Other.swift",
+            "/elsewhere/File.swift", "/", "", "/projects/app", "/projects/app/",
+            "relative/not/absolute", "/a", "/projects/app/../app/Sources"
+        ]).compactMap(\.self)
+
+        await propertyCheck(input: Self.rootGen, anyPath) { given, itemPath in
+            let root = ProjectRoot(given)
+            guard let derived = root.relativePath(of: itemPath) else { return }
+            let rebuilt = root.absolutePath(of: derived)
+            #expect(
+                root.relativePath(of: rebuilt) == derived,
+                "root=\(root.path) item=\(itemPath) derived=\(derived.value) rebuilt=\(rebuilt)"
+            )
+        }
+    }
+
+    /// `/projects/appendix` is not under `/projects/app`, and the separator is the only thing that
+    /// says so. This is the off-by-one the round-trip law exists to catch, pinned as an example
+    /// because a reader should see the case the arithmetic turns on.
+    @Test func aSiblingWithASharedNamePrefixIsNotUnderTheRoot() {
+        let root = ProjectRoot("/projects/app")
+        #expect(root.relativePath(of: "/projects/appendix/Other.swift") == nil)
+        #expect(root.relativePath(of: "/projects/app/Other.swift")?.value == "Other.swift")
+    }
+
+    /// The root names itself, and both spellings of it agree.
+    @Test func theRootDerivesToTheRootPath() {
+        let root = ProjectRoot("/projects/app")
+        #expect(root.relativePath(of: "/projects/app")?.isRoot == true)
+        #expect(root.relativePath(of: "/projects/app/")?.isRoot == true)
+        #expect(root.absolutePath(of: .root) == "/projects/app")
+    }
+
+    /// Components carry the three uses the call sites have, so none of them re-splits the string.
+    @Test func componentsCarryTheNameTheDepthAndTheSearch() {
+        let relative = RelativePath("Sources/.build/Deep")
+        #expect(relative.lastComponent == "Deep")
+        #expect(relative.depth == 3)
+        #expect(relative.components.contains(".build"))
+        #expect(RelativePath("").depth == 0)
+        #expect(RelativePath("").lastComponent.isEmpty)
+    }
+
+    // MARK: - The planted violator
+
+    /// The implementation that was at `FileAnalysisUtils.swift:196`, kept here so the laws above are
+    /// shown to be worth having rather than asserted to be.
+    ///
+    /// ```swift
+    /// let relativePath = String(itemURL.path.dropFirst(resolvedRootPath.count + 1))
+    /// ```
+    ///
+    /// No guard, no way to report failure, and `dropFirst` is total on a `String` — so an item not
+    /// under the root yields a tail of the wrong length instead of nothing.
+    private static func unguardedDerivation(root: String, itemPath: String) -> RelativePath {
+        RelativePath(String(itemPath.dropFirst(ProjectRoot(root).path.count + 1)))
+    }
+
+    /// **The retraction law refutes it, and that is the point of writing the law down.**
+    ///
+    /// `/projects/appendix/Other.swift` under root `/projects/app` is the case: 13 characters of root
+    /// plus one separator drops `"/projects/app"` and the `e`, leaving `"ndix/Other.swift"`. That is
+    /// not a relative path, it rebuilds to `/projects/app/ndix/Other.swift`, and it was then handed
+    /// to `skippedDirectories` matching and the user's `excluded_paths` — where being wrong means an
+    /// exclusion silently stops excluding.
+    @Test func theUnguardedDerivationFailsTheRetractionLaw() {
+        let root = ProjectRoot("/projects/app")
+        let sibling = "/projects/appendix/Other.swift"
+
+        let wrong = Self.unguardedDerivation(root: "/projects/app", itemPath: sibling)
+        #expect(wrong.value == "ndix/Other.swift")
+        #expect(root.absolutePath(of: wrong) == "/projects/app/ndix/Other.swift")
+
+        // The kernel refuses instead, which is the whole difference.
+        #expect(root.relativePath(of: sibling) == nil)
+    }
+
+    /// And it agrees with the kernel wherever the item really is under the root — which is why the
+    /// defect survived: every path the walker actually produced was fine, so no example test that
+    /// built a real tree would ever have reached it.
+    @Test func theUnguardedDerivationAgreesOnItemsActuallyUnderTheRoot() async {
+        await propertyCheck(input: Self.rootGen, Self.relativeGen) { given, relative in
+            let root = ProjectRoot(given)
+            let absolute = root.absolutePath(of: relative)
+            guard !relative.isRoot, root.path != "/" else { return }
+            #expect(Self.unguardedDerivation(root: given, itemPath: absolute) == relative)
+        }
+    }
+}


### PR DESCRIPTION
## What changed

`ProjectRoot` + `RelativePath` replace three hand-written copies of one derivation in `SwiftProjectLintConfig`. The copies disagreed on the only question that matters — *what if the item is not under the root?*

| site | guard | fallback |
|---|---|---|
| `DirectoryScanner` | `hasPrefix` | `lastPathComponent` |
| `FileAnalysisUtils` | **none** | a garbled prefix-drop |
| `LintConfiguration` | `hasPrefix` | the whole absolute path |

The kernel answers `nil`; each caller names its own fallback at the call site. Three fallbacks are still three, but now three decisions rather than three accidents.

## Two bugs

**1. A silent exclusion failure.** `String(itemURL.path.dropFirst(resolvedRootPath.count + 1))` cannot fail and cannot report failure — `dropFirst` is total on a `String`. An item not under the root became a tail of the wrong length, and that tail drove `skippedDirectories` matching *and* the user's `excluded_paths`. An exclusion that stops working doesn't throw; it reports more findings.

**2. A symlinked root enumerated nothing.** Found while measuring the first. Both walkers enumerated at the URL the user gave rather than the resolved one, and `FileManager.enumerator(at:)` on a root that is *itself* a symlink to a directory yields **zero items**:

```
BEFORE, linting this repo through a symlinked path: 0 issues
AFTER:                                            325 issues
```

No files, no findings, exit 0, no warning.

## Ten laws, two of which earned their keep immediately

- **The round-trip law refuted its own first spelling.** Asserting the identity on the item path fails for root `/`, item `/projects/app/` — which derives `projects/app` and rebuilds without the trailing separator. That's the normalisation the type exists to do, so the law is the true weaker one: rebuilding is a **retraction**. The correction is recorded in the test rather than the law quietly weakened.
- **The planted violator is the old implementation.** `/projects/appendix` under root `/projects/app` drops 13 characters and a separator, leaving `"ndix/Other.swift"`. A second law shows the old code agrees with the kernel on *every* path actually under the root — which is why no example test that built a real tree would ever have reached it.

## Measured

| | before | after |
|---|---|---|
| Extractable Total Kernel (ours) | 24 | **22** |
| non-census prompts (ours) | 204 | **202** |
| third-party findings | 1163 | 1163 |

Both ETK removals are these sites. 3,691 tests pass; `swiftlint` clean on the touched files.

## What a reviewer should scrutinise

- **`DirectoryScanner` still canonicalises the item path and `FileAnalysisUtils` does not.** That asymmetry is deliberate and documented at both call sites: resolving a symlinked *subdirectory* can move it outside the root, which sends the caller to its fallback. The tree view prefers a shallow placement to an omission; the file walk must skip, because its relative path drives exclusion matching. `ProjectRoot` deliberately leaves the choice out rather than hiding it.
- **`RelativePath` drops empty components**, so `"a//b"` and `"a/b/"` are one path. That makes `init` idempotent, which is what the round-trip law rests on — and it changes `depth` for malformed input (old `"a//b"` counted 3, new counts 2). Real enumerator paths have neither shape; the corpus sweep confirms no movement.
- **`isPruned`** collapses three prune branches into one. The `skipDescendants()` gate was `if isDirectory` in two of them and implied by the condition in the third, so unifying it is equivalent — worth checking that reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrD7SdySCSbg15qC8qbpYy