### PR TITLE
Measure the ternary blindness and close it as a non-gap

### DIFF
--- a/Docs/rules/boolean-control-coupling.md
+++ b/Docs/rules/boolean-control-coupling.md
@@ -137,13 +137,39 @@ in a plain `=` to it. Arms that merely happen to end by assigning the same varia
   dominant behavior — five of eight findings — which is a limitation large enough to be the
   rule not working. Gate 4 now handles it, and this entry is kept as the record of a
   known limitation that was bigger than it looked.
-- **Spelling sensitivity: ternaries are invisible.** The rule sees `if`/`else` blocks only.
-  In `LiftedTestEmitter+Determinism.swift:53` an `isAsync` flag selects between two paths via
-  `isAsync ? … : …` on the line above the reported `isThrows` branch — the same coupling, in
-  the same function, unreported. So the count is a census of *spelling* as much as of
-  coupling. Extending to ternaries is tracked separately; most of what it would add looks like
-  gate-5 value selection, which is the thing worth measuring before widening the rule.
-  Tracked as issue #208.
+- **Ternaries are invisible, and measurement says leave it that way.** The rule sees
+  `if`/`else` blocks only, so `flag ? a : b` never reaches it. A census over the same
+  26-repository corpus (2,940 non-test files) found **57 ternaries whose condition
+  references a `Bool` parameter of the enclosing function**, and every one of them
+  produces a value:
+
+  | position | count | | operand | count |
+  |---|---|---|---|---|
+  | assigned to a `let` | 38 | | literal | 40 |
+  | passed as an argument | 6 | | reference | 9 |
+  | bare statement | 5 | | call | 8 |
+  | `return` | 4 | | | |
+  | implicit return | 3 | | | |
+  | collection element | 1 | | | |
+
+  **The decisive bucket — call operands evaluated for effect in statement position — is
+  empty.** All eight call operands build a value: seven initialize a `let`, one is a
+  single-expression function body. So every one of the 57 is the boolean→value selection
+  gates 3 and 5 already decline, and visiting ternaries would add **zero** findings after
+  the existing gates. The count being a census of spelling is true and costs nothing.
+
+  The motivating example was `LiftedTestEmitter+Determinism.swift`, where an `isAsync`
+  ternary sits inside a reported `isThrows` branch. That shape — one flag of a function
+  `if`-branched while another is ternary-branched — occurs **twice** corpus-wide, both at
+  that one site, and both are `let` initializations.
+
+  **If this is ever revisited, note that `TernaryExprSyntax` is not what the parser
+  produces.** `a ? b : c` arrives as a `SequenceExprSyntax` of
+  `[condition…, UnresolvedTernaryExprSyntax, else…]`; folding needs an operator table a
+  lint visitor does not have. A `visit(_: TernaryExprSyntax)` override compiles, runs, and
+  never fires — the census tool did exactly that and reported 0 across all 2,940 files
+  before the shape was checked. It is the same trap that `assignsAsFinalStatement` has to
+  work around for `=`. Measured in #208, which this closes.
 - **Platform-convention flags** (`animated:`, `reversed:`, `ascending:`) rarely trip the
   two-substantial-arms gate, so they seldom fire — but if one genuinely branches two
   algorithms, it will, and that's usually correct.


### PR DESCRIPTION
Documentation only. Replaces the speculative "Known limitations" entry added in #206 with the measurement issue #208 asked for.

## The question

#208 argued that the rule sees `if`/`else` blocks only, so `flag ? a : b` never reaches it — and that its count therefore measures **spelling** as much as coupling. The motivating example: in `LiftedTestEmitter+Determinism.swift`, an `isAsync` ternary sits inside a reported `isThrows` branch, the same coupling in the same function, unreported.

The issue asked for a census before widening the rule: ternaries whose condition references a `Bool` parameter of the enclosing function, bucketed by operand kind, position, and whether the same function also branches with an `if`.

## The answer

Over the same 26 repositories, 2,940 non-test files (the rule's own test/fixture gate drops 5,696 → 2,940): **57 ternaries on a `Bool` parameter.**

| position | count | | operand | count |
|---|---|---|---|---|
| assigned to a `let` | 38 | | literal | 40 |
| passed as an argument | 6 | | reference | 9 |
| bare statement | 5 | | call | 8 |
| `return` | 4 | | | |
| implicit return | 3 | | | |
| collection element | 1 | | | |

**The decisive bucket — call operands evaluated for effect in statement position — is empty.** All eight call operands build a value: seven initialize a `let`, one is a single-expression function body. Every one of the 57 is the boolean→value selection gates 3 and 5 already decline, so visiting ternaries would add **zero** findings after the existing gates.

The motivating shape — one flag of a function `if`-branched while another is ternary-branched — occurs **twice** corpus-wide, both at that one site, both `let` initializations.

So the blindness is real and costs nothing measurable. Recommendation: document it, don't fix it.

## The part worth keeping

**The parser does not produce `TernaryExprSyntax`.** `a ? b : c` arrives as a `SequenceExprSyntax` holding an `UnresolvedTernaryExprSyntax`; folding needs an operator table a lint visitor doesn't have. A `visit(_: TernaryExprSyntax)` override compiles, runs, and never fires.

The census tool did exactly that and **reported 0 across all 2,940 files** before the shape was checked. That zero and the real zero are indistinguishable from outside — the only reason it got caught is that #208 cites a concrete example the tool should have found. It is the same unfolded-operator trap `assignsAsFinalStatement` works around for `=` in #206; twice in one session, one root cause.

## What a reviewer should scrutinise

- **The "implicit return" bucket is load-bearing.** Before it existed, `arrowStrokeStyle(isAsync:)` — a single-expression body returning one of two `StrokeStyle`s — counted as a bare statement and was the sole entry in the decisive bucket. Swift spells single-expression bodies as a lone `CodeBlockItem`, so without separating them the decisive bucket fills with value selections.
- **Scope matches the rule's, including its gaps.** The census tracks `FunctionDecl` and `InitializerDecl` parameters only, so closure and subscript parameters are out — same as the rule. A ternary on a stored `Bool` property is also out, correctly: this rule is about parameters.

Closes #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeZ6uZMfPc3bgznF69r98K