### PR TITLE
An unrecognised suppression name no longer disables every rule

### DIFF
--- a/Docs/user/reference.md
+++ b/Docs/user/reference.md
@@ -319,20 +319,44 @@ Omit the rule name to target every rule:
 // swiftprojectlint:enable
 ```
 
-### An unrecognised rule name disables everything
+### An unrecognised rule name suppresses nothing, and says so
 
-A directive whose names are all unrecognised is indistinguishable from one that
-names none, so it suppresses **every** rule for its scope:
+A directive whose names all fail to resolve targets **no** rule:
 
 ```swift
-// swiftprojectlint:disable:next Boolean Control Coupling   // ← three unknown tokens
-// swiftprojectlint:disable:next totally-fictional-rule     // ← one unknown token
+// swiftprojectlint:disable:next totally-fictional-rule
+try! riskyCall()          // still reported
 ```
 
-Both silence the following line entirely. Get the kebab-case spelling right — it is
-the doc file name under `Docs/rules/`, and the display name with spaces is **not** it.
-Twelve rule docs used to show the display-name spelling in their own suppression advice;
-they were corrected, and no suppression in the corpus that taught this had ever used it.
+and the run writes a notice to stderr naming the file, the line, the token, and the
+key it thinks you meant:
+
+```
+Warning: 1 suppression comment names a rule that does not exist.
+  Sources/App/Model.swift:28: unknown rule 'legacy-observable-object' — did you mean
+  'legacy-observableobject'? This directive now suppresses nothing.
+```
+
+A name that resolves alongside one that doesn't still works: the resolved rules are
+suppressed, the unknown one is reported. That keeps a file naming a rule from a newer
+build working on an older one, which is why unknown names are ignored rather than fatal.
+
+**This used to be the opposite.** An empty rule set meant "all rules", and a directive
+whose every name failed to resolve produced an empty set — so it silenced *everything*
+on its target line, silently. Five such comments existed in this repository, and one of
+them was hiding [SwiftProjectLint Suppression](../rules/swiftprojectlint-suppression.md),
+the rule whose whole job is to report suppression comments.
+
+### Getting the spelling right
+
+The key is the lowercased display name with spaces replaced by hyphens — which is the
+doc file name under `Docs/rules/`. It is **not** always what you would guess: the display
+name decides where the hyphens fall, so `Legacy ObservableObject` gives
+`legacy-observableobject`, not `legacy-observable-object`. 26 of the 208 keys differ from
+the kebab-case of the rule's own identifier this way.
+
+Both real mistakes found in this codebase were hyphen placement alone, which is why the
+notice above can suggest an exact key rather than a near miss.
 
 ### Scope
 

--- a/Docs/user/user-guide.md
+++ b/Docs/user/user-guide.md
@@ -146,6 +146,12 @@ let b = result!
 | `// swiftprojectlint:disable:next rule-name` | Suppress the next line only |
 | `// swiftprojectlint:disable:this rule-name` | Suppress this line only |
 
+Rule keys are the doc file name under `Docs/rules/` — the lowercased display name with
+spaces replaced by hyphens, which is not always the spelling you would guess
+(`legacy-observableobject`, not `legacy-observable-object`). A name that matches no rule
+suppresses nothing and is reported on stderr with the key it probably meant. See
+[reference.md](reference.md#getting-the-spelling-right).
+
 Omit the rule name to target all rules. Multiple rule names can appear space-separated on one line. Rule names use kebab-case (e.g. `force-try`, `magic-number`, `fat-view-detection`).
 
 ---

--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Suppression/InlineSuppressionFilter.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Suppression/InlineSuppressionFilter.swift
@@ -46,8 +46,11 @@ public struct InlineSuppressionFilter {
         var openDisables: [RuleIdentifier?: Int] = [:]
 
         for directive in directives.sorted(by: { $0.line < $1.line }) {
-            // An empty rules set targets all rules, represented by a nil dictionary key.
-            let keys: [RuleIdentifier?] = directive.rules.isEmpty
+            // A directive that named nothing targets all rules, represented by a nil
+            // dictionary key. One whose every name failed to resolve targets nothing
+            // and yields no keys, so it suppresses nothing — `SuppressionAudit` is
+            // what tells the user their comment is inert.
+            let keys: [RuleIdentifier?] = directive.targetsAllRules
                 ? [nil]
                 : directive.rules.map { Optional($0) }
             applyDirective(

--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Suppression/InlineSuppressionParser.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Suppression/InlineSuppressionParser.swift
@@ -16,10 +16,28 @@ public struct SuppressionDirective: Sendable {
 
     /// The kind of directive.
     public let kind: Kind
-    /// Rules targeted by this directive. An empty set means "all rules".
+    /// Rules this directive resolved. **Empty does not mean "all rules"** — see
+    /// `targetsAllRules`, which is the question callers actually want answered.
     public let rules: Set<RuleIdentifier>
+    /// Tokens that matched no rule, in source order.
+    ///
+    /// Kept rather than dropped so a directive that named *nothing* can be told
+    /// from one that named only things this build does not recognise. Collapsing
+    /// the two made the second silently take the first's meaning: every rule
+    /// disabled, by a comment that reads as naming one.
+    public let unrecognizedNames: [String]
     /// 1-based line number of the comment in the source file.
     public let line: Int
+
+    /// Whether this directive targets every rule — true only when it named no
+    /// rules at all, which is the documented spelling of "suppress everything".
+    ///
+    /// A directive whose every name failed to resolve targets **nothing**. That
+    /// is the conservative reading: the author meant a specific rule, and a
+    /// build that cannot tell which one should not answer "then all of them".
+    public var targetsAllRules: Bool {
+        rules.isEmpty && unrecognizedNames.isEmpty
+    }
 }
 
 /// Parses inline suppression comments from Swift source.
@@ -60,8 +78,13 @@ public struct InlineSuppressionParser {
             let rest = String(trimmed.dropFirst(commentPrefix.count))
             guard let (kind, rulesPart) = parseKindAndRules(from: rest) else { continue }
 
-            let rules = parseRules(from: rulesPart)
-            directives.append(SuppressionDirective(kind: kind, rules: rules, line: lineNumber))
+            let parsed = parseRules(from: rulesPart)
+            directives.append(SuppressionDirective(
+                kind: kind,
+                rules: parsed.rules,
+                unrecognizedNames: parsed.unrecognized,
+                line: lineNumber
+            ))
         }
 
         return directives
@@ -88,15 +111,28 @@ public struct InlineSuppressionParser {
         return nil
     }
 
-    private static func parseRules(from rulesPart: String) -> Set<RuleIdentifier> {
+    /// Splits the names on a directive into the rules they resolve to and the
+    /// tokens that resolve to nothing.
+    ///
+    /// An unknown token is still ignored *as a rule* — a file naming a rule a
+    /// newer build has must not fail on an older one, which is why they were
+    /// dropped in the first place. What changes is that they are no longer
+    /// forgotten: a directive left with no rules and some unrecognised names is
+    /// a different thing from one that named nothing, and `targetsAllRules`
+    /// keeps them apart.
+    private static func parseRules(
+        from rulesPart: String
+    ) -> (rules: Set<RuleIdentifier>, unrecognized: [String]) {
         let tokens = rulesPart.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
         var rules: Set<RuleIdentifier> = []
+        var unrecognized: [String] = []
         for token in tokens {
             if let rule = keyToRule[token.lowercased()] {
                 rules.insert(rule)
+            } else {
+                unrecognized.append(token)
             }
-            // Unknown tokens are silently ignored — future rules won't break old files
         }
-        return rules
+        return (rules, unrecognized)
     }
 }

--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Suppression/SuppressionAudit.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Suppression/SuppressionAudit.swift
@@ -1,0 +1,101 @@
+import Foundation
+import SwiftProjectLintModels
+
+/// A suppression name that matched no rule, with the key the author probably meant.
+public struct UnrecognizedSuppressionName: Sendable, Equatable {
+    /// Path as the caller supplied it — this type does no path arithmetic of its own.
+    public let filePath: String
+    /// 1-based line of the directive comment.
+    public let line: Int
+    /// The token, exactly as written.
+    public let name: String
+    /// The rule key this most likely meant, when one can be identified.
+    public let suggestion: String?
+    /// Whether the directive is left naming no rules at all, and so suppresses nothing.
+    public let directiveIsInert: Bool
+
+    public init(filePath: String, line: Int, name: String, suggestion: String?, directiveIsInert: Bool) {
+        self.filePath = filePath
+        self.line = line
+        self.name = name
+        self.suggestion = suggestion
+        self.directiveIsInert = directiveIsInert
+    }
+}
+
+/// Finds suppression directives naming rules that do not exist.
+///
+/// Split from `InlineSuppressionFilter` on purpose. The filter returns early when a
+/// file has no issues, so a diagnostic riding along with it would report a file's bad
+/// directives only while that file happened to be failing something else — the
+/// files where a suppression is *working* would be exactly the ones that stayed
+/// quiet. This runs over source text alone and does not care what was found.
+public enum SuppressionAudit {
+
+    /// Every unrecognised rule name in `fileContent`.
+    ///
+    /// **Two linters disagree about this body and SwiftLint wins**, because it is
+    /// the pre-commit gate. SwiftProjectLint's own `Map Used For Side Effects`
+    /// reports the implicitly-returned `flatMap` here as a discarded result;
+    /// SwiftLint's `implicit_return` rejects the explicit `return` that silences
+    /// it. The SwiftProjectLint rule is wrong — it cannot see that a lone
+    /// expression in a body *is* the return value — and the two findings this
+    /// leaves are tracked rather than worked around.
+    public static func unrecognizedNames(in fileContent: String, filePath: String) -> [UnrecognizedSuppressionName] {
+        InlineSuppressionParser.parse(fileContent: fileContent).flatMap { directive in
+            directive.unrecognizedNames.map { name in
+                UnrecognizedSuppressionName(
+                    filePath: filePath,
+                    line: directive.line,
+                    name: name,
+                    suggestion: suggestion(for: name),
+                    directiveIsInert: directive.rules.isEmpty
+                )
+            }
+        }
+    }
+
+    /// The key `name` probably meant, or `nil`.
+    ///
+    /// Compares with hyphens removed, which is an exact match rather than a fuzzy
+    /// one — and it is enough, because **the keys are derived from display names
+    /// and the hyphens fall where the display name happens to put spaces**.
+    /// `Legacy ObservableObject` gives `legacy-observableobject`, so the natural
+    /// spelling `legacy-observable-object` is wrong in hyphens alone. 26 of the
+    /// 208 rules have a key that is not the kebab-case of their own identifier,
+    /// and both real-world mistakes found in the corpus were hyphen placement.
+    ///
+    /// Unambiguous by construction: no two rule keys collide once hyphens are
+    /// dropped, which `suggestionsAreUnambiguous` pins so a future rule name
+    /// cannot quietly make this a guess.
+    public static func suggestion(for name: String) -> String? {
+        let needle = normalized(name)
+        guard needle.isEmpty == false else { return nil }
+        return RuleIdentifier.allCases
+            .first { normalized($0.suppressionKey) == needle }?
+            .suppressionKey
+    }
+
+    static func normalized(_ key: String) -> String {
+        key.lowercased().replacing("-", with: "")
+    }
+
+    /// One line per finding, for stderr.
+    public static func notice(for names: [UnrecognizedSuppressionName]) -> String {
+        let lines = names.map { entry -> String in
+            let tail = entry.suggestion.map { " — did you mean '\($0)'?" }
+                ?? " — no rule by that name."
+            let effect = entry.directiveIsInert
+                ? " This directive now suppresses nothing."
+                : ""
+            return "  \(entry.filePath):\(entry.line): unknown rule '\(entry.name)'\(tail)\(effect)"
+        }
+        return """
+            Warning: \(names.count) suppression comment\(names.count == 1 ? "" : "s") \
+            name a rule that does not exist.
+            \(lines.joined(separator: "\n"))
+            Rule keys are the lowercased display name with spaces replaced by hyphens, \
+            which is the file name under Docs/rules/ — not always the spelling you would guess.
+            """
+    }
+}

--- a/Sources/App/ContentView.swift
+++ b/Sources/App/ContentView.swift
@@ -25,7 +25,7 @@ import UniformTypeIdentifiers
 /// - Expandable results with detailed issue information
 /// - Persistent rule preferences across app launches
 struct ContentView: View {
-    // swiftprojectlint:disable:next legacy-observable-object
+    // swiftprojectlint:disable:next legacy-observableobject
     @EnvironmentObject private var systemComponents: SystemComponents
     @State private var viewModel = ContentViewModel()
 
@@ -174,7 +174,7 @@ struct ContentViewPreviewHost: View {
     // SystemComponents uses ObservableObject intentionally — ViewInspector requires
     // @EnvironmentObject injection and does not support @Environment(Type.self) for
     // @Observable types. Migration is blocked until ViewInspector adds that support.
-    // swiftprojectlint:disable:next legacy-observable-object ios17-observation-migration
+    // swiftprojectlint:disable:next legacy-observableobject ios-17-observation-migration
     @StateObject private var systemComponents = SystemComponents()
     var body: some View {
         ContentView()

--- a/Sources/App/Models/SystemComponents.swift
+++ b/Sources/App/Models/SystemComponents.swift
@@ -7,10 +7,10 @@ import SwiftUI
 /// (ViewInspector only supports `@EnvironmentObject` injection, not `@Environment(Type.self)`.)
 /// Migration to @Observable is blocked until ViewInspector supports @Environment(Type.self) injection.
 @MainActor
-// swiftprojectlint:disable:next legacy-observable-object ios17-observation-migration
+// swiftprojectlint:disable:next legacy-observableobject ios-17-observation-migration
 class SystemComponents: ObservableObject {
     private(set) var visitorRegistry: PatternVisitorRegistry?
-    // swiftprojectlint:disable:next legacy-observable-object
+    // swiftprojectlint:disable:next legacy-observableobject
     @Published private(set) var patternRegistry: SourcePatternRegistry?
     private(set) var detector: SourcePatternDetector?
 

--- a/Sources/App/SwiftProjectLintApp.swift
+++ b/Sources/App/SwiftProjectLintApp.swift
@@ -25,7 +25,7 @@ struct SwiftProjectLintApp: App {
     // SystemComponents uses ObservableObject intentionally — ViewInspector requires
     // @EnvironmentObject injection and does not support @Environment(Type.self) for
     // @Observable types. Migration is blocked until ViewInspector adds that support.
-    // swiftprojectlint:disable:next legacy-observable-object ios17-observation-migration
+    // swiftprojectlint:disable:next legacy-observableobject ios-17-observation-migration
     @StateObject private var systemComponents = SystemComponents()
 
     init() {

--- a/Sources/CLI/SwiftProjectLintCLI.swift
+++ b/Sources/CLI/SwiftProjectLintCLI.swift
@@ -144,6 +144,16 @@ struct SwiftProjectLintCLI: AsyncParsableCommand {
             Self.printToStandardError(Self.nestedPackagesSkippedNotice)
         }
 
+        // A suppression comment naming a rule that does not exist used to disable
+        // *every* rule for its scope, because "named nothing" and "named only
+        // unknown things" were the same empty set. It now suppresses nothing, which
+        // is the conservative reading — and silent either way without this, since a
+        // suppression that stops working reports more findings rather than fewer.
+        // Five such comments existed in this repository alone, and 26 of the 208
+        // rule keys are not the spelling a reader would guess, so the notice carries
+        // the key it thinks was meant. Same stderr channel and reasoning as above.
+        Self.reportUnrecognizedSuppressionNames(projectRoot: absolutePath, configuration: configuration)
+
         // A seed-bearing finding with no resolved symbol cannot become a seed, so the manifest is
         // shorter than the run that produced it — silently, and while still exiting 0. That is the
         // shape of a confident zero, and it has happened: a lossy `LintIssue` rebuild once emptied
@@ -208,6 +218,44 @@ struct SwiftProjectLintCLI: AsyncParsableCommand {
         return TextFormatter(
             withheld: split.withheld, skippedNestedPackages: skippedNestedPackages
         ).format(issues: split.listed)
+    }
+
+    /// Audits the project's suppression comments and writes a notice when any name
+    /// matches no rule. Nothing is written when they all resolve.
+    private static func reportUnrecognizedSuppressionNames(projectRoot: String, configuration: LintConfiguration) {
+        let unrecognized = unrecognizedSuppressionNames(projectRoot: projectRoot, configuration: configuration)
+        guard !unrecognized.isEmpty else { return }
+        printToStandardError(SuppressionAudit.notice(for: unrecognized))
+    }
+
+    /// Audits the project's suppression comments for names that match no rule.
+    ///
+    /// A second walk of the tree rather than a value threaded out of `analyzeProject`,
+    /// matching how `skippedNestedPackages` above is obtained: the linter's return type
+    /// is `[LintIssue]` and has 59 call sites, so widening it to carry a diagnostic
+    /// costs more than reading the files again. The pass reads and scans lines — no
+    /// parsing — and the files are already in the page cache from the run above.
+    static func unrecognizedSuppressionNames(
+        projectRoot: String,
+        configuration: LintConfiguration
+    ) -> [UnrecognizedSuppressionName] {
+        let root = ProjectRoot(projectRoot)
+        return FileAnalysisUtils.findSwiftFiles(
+            in: projectRoot,
+            excludedPaths: configuration.excludedPaths,
+            excludedFilenames: configuration.excludedFilenames,
+            includeNestedPackages: configuration.includeNestedPackages
+        )
+        .sorted()
+        .flatMap { path -> [UnrecognizedSuppressionName] in
+            guard let content = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
+            // A file outside the root has no relative spelling, so the notice names
+            // the absolute path rather than a shortened one that would be wrong.
+            return SuppressionAudit.unrecognizedNames(
+                in: content,
+                filePath: root.relativePath(of: path)?.value ?? path
+            )
+        }
     }
 
     private static func printToStandardError(_ message: String) {

--- a/Tests/CLITests/SuppressionAuditWalkTests.swift
+++ b/Tests/CLITests/SuppressionAuditWalkTests.swift
@@ -1,0 +1,74 @@
+@testable import CLI
+import Foundation
+import SwiftProjectLintConfig
+import Testing
+
+/// The CLI half of the unrecognised-name diagnostic: walking the project and
+/// naming files relative to its root.
+///
+/// `SuppressionAudit` itself is covered in `CoreTests`. What is only testable
+/// here is that the walk honours the configuration's exclusions and reports a
+/// path a reader can act on — an absolute path would be correct and useless in
+/// a notice meant to be pasted into an editor.
+@Suite
+struct SuppressionAuditWalkTests {
+
+    private func makeProject(_ files: [String: String]) throws -> URL {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("spl-audit-\(UUID().uuidString)")
+        for (relative, contents) in files {
+            let path = root.appendingPathComponent(relative)
+            try FileManager.default.createDirectory(
+                at: path.deletingLastPathComponent(), withIntermediateDirectories: true
+            )
+            try contents.write(to: path, atomically: true, encoding: .utf8)
+        }
+        return root
+    }
+
+    @Test func reportsUnknownNamesWithRootRelativePaths() throws {
+        let root = try makeProject([
+            "Sources/Model.swift": "// swiftprojectlint:disable:next legacy-observable-object\nlet x = 1\n",
+            "Sources/Fine.swift": "// swiftprojectlint:disable:next force-try\nlet y = 1\n"
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let found = SwiftProjectLintCLI.unrecognizedSuppressionNames(
+            projectRoot: root.path, configuration: LintConfiguration()
+        )
+        #expect(found.count == 1)
+        // Root-relative, not absolute: the notice is meant to be actionable.
+        #expect(found.first?.filePath == "Sources/Model.swift")
+        #expect(found.first?.suggestion == "legacy-observableobject")
+    }
+
+    @Test func skipsExcludedPaths() throws {
+        let root = try makeProject([
+            "Vendor/Model.swift": "// swiftprojectlint:disable:next totally-fictional-rule\nlet x = 1\n"
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let audited = SwiftProjectLintCLI.unrecognizedSuppressionNames(
+            projectRoot: root.path, configuration: LintConfiguration()
+        )
+        #expect(audited.count == 1, "control: the file is found when nothing excludes it")
+
+        let excluded = SwiftProjectLintCLI.unrecognizedSuppressionNames(
+            projectRoot: root.path,
+            configuration: LintConfiguration(excludedPaths: ["Vendor"])
+        )
+        #expect(excluded.isEmpty)
+    }
+
+    @Test func reportsNothingWhenEveryNameResolves() throws {
+        let root = try makeProject([
+            "Sources/A.swift": "// swiftprojectlint:disable:next force-try magic-number\nlet x = 1\n",
+            "Sources/B.swift": "// swiftprojectlint:disable\nlet y = 1\n"
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(SwiftProjectLintCLI.unrecognizedSuppressionNames(
+            projectRoot: root.path, configuration: LintConfiguration()
+        ).isEmpty)
+    }
+}

--- a/Tests/CoreTests/Suppression/InlineSuppressionFilterTests.swift
+++ b/Tests/CoreTests/Suppression/InlineSuppressionFilterTests.swift
@@ -17,6 +17,54 @@ struct InlineSuppressionFilterTests {
         )
     }
 
+    // MARK: - Unrecognized names
+
+    @Test func testDirectiveNamingOnlyUnknownRulesSuppressesNothing() {
+        // The regression. `rules.isEmpty` meant "all rules", so this comment —
+        // which reads as targeting one rule — disabled every rule on the next
+        // line. Five such comments existed in this repository, and one of them
+        // was hiding the rule whose job is to report suppression comments.
+        // Written with escaped newlines rather than a multi-line literal, and every
+        // unknown-key fixture below is. `InlineSuppressionParser` scans lines, so it
+        // cannot tell a comment from a line inside a string literal — a triple-quoted
+        // fixture here is a directive *in this file* as far as the parser and the new
+        // audit are concerned, and the audit would report this repository's own tests
+        // on every run. Valid-key fixtures elsewhere stay multi-line; only the
+        // deliberately-wrong ones produce a notice.
+        let source = "// swiftprojectlint:disable:next totally-fictional-rule\ntry! riskyCall()"
+        let issues = [issue(rule: .forceTry, line: 2), issue(rule: .magicNumber, line: 2)]
+        let result = InlineSuppressionFilter.filter(issues, fileContent: source)
+        #expect(result.count == 2)
+    }
+
+    @Test func testDirectiveNamingNothingStillSuppressesEverything() {
+        // The control. Without it the test above passes for a filter that has
+        // simply stopped honouring blanket disables.
+        let source = """
+        // swiftprojectlint:disable:next
+        try! riskyCall()
+        """
+        let issues = [issue(rule: .forceTry, line: 2), issue(rule: .magicNumber, line: 2)]
+        let result = InlineSuppressionFilter.filter(issues, fileContent: source)
+        #expect(result.isEmpty)
+    }
+
+    @Test func testUnknownNameAlongsideAKnownOneSuppressesOnlyTheKnownOne() {
+        let source = "// swiftprojectlint:disable:next force-try rule-from-the-future\ntry! riskyCall()"
+        let issues = [issue(rule: .forceTry, line: 2), issue(rule: .magicNumber, line: 2)]
+        let result = InlineSuppressionFilter.filter(issues, fileContent: source)
+        #expect(result.map(\.ruleName) == [.magicNumber])
+    }
+
+    @Test func testUnknownNameDoesNotOpenABlanketDisableRegion() {
+        // `disable` opens a region to end of file, so getting this wrong is the
+        // widest version of the bug: every rule silenced from here down.
+        let source = "// swiftprojectlint:disable totally-fictional-rule\ntry! riskyCall()\nlet value = 42"
+        let issues = [issue(rule: .forceTry, line: 2), issue(rule: .magicNumber, line: 3)]
+        let result = InlineSuppressionFilter.filter(issues, fileContent: source)
+        #expect(result.count == 2)
+    }
+
     // MARK: - disable:this
 
     @Test func testDisableThisRemovesIssueOnSameLine() {

--- a/Tests/CoreTests/Suppression/InlineSuppressionParserTests.swift
+++ b/Tests/CoreTests/Suppression/InlineSuppressionParserTests.swift
@@ -35,6 +35,44 @@ struct InlineSuppressionParserTests {
         #expect(directives[0].rules == [.forceTry, .forceUnwrap, .magicNumber])
     }
 
+    // MARK: - Unrecognized names
+
+    @Test func testUnrecognizedNameIsKeptAndDoesNotTargetAllRules() {
+        // The bug this records: an empty `rules` used to mean "all rules", so a
+        // directive naming only an unknown rule became a blanket disable.
+        let source = "// swiftprojectlint:disable totally-fictional-rule"
+        let directives = InlineSuppressionParser.parse(fileContent: source)
+        #expect(directives.count == 1)
+        #expect(directives[0].rules.isEmpty)
+        #expect(directives[0].unrecognizedNames == ["totally-fictional-rule"])
+        #expect(directives[0].targetsAllRules == false)
+    }
+
+    @Test func testNamingNothingStillTargetsAllRules() {
+        let directives = InlineSuppressionParser.parse(fileContent: "// swiftprojectlint:disable")
+        #expect(directives[0].unrecognizedNames.isEmpty)
+        #expect(directives[0].targetsAllRules)
+    }
+
+    @Test func testUnknownNameAlongsideAKnownOneLeavesTheKnownOne() {
+        // Forward compatibility: a file naming a rule a newer build has must keep
+        // working on an older one, which is why unknown tokens are ignored *as
+        // rules*. That behaviour is unchanged; only the all-unknown case moved.
+        let source = "// swiftprojectlint:disable force-try rule-from-the-future"
+        let directives = InlineSuppressionParser.parse(fileContent: source)
+        #expect(directives[0].rules == [.forceTry])
+        #expect(directives[0].unrecognizedNames == ["rule-from-the-future"])
+        #expect(directives[0].targetsAllRules == false)
+    }
+
+    @Test func testUnrecognizedNamesKeepSourceOrderAndSpelling() {
+        // The audit quotes these back to the user, so case and order are the
+        // author's, not the parser's.
+        let source = "// swiftprojectlint:disable Zebra-Rule alpha-rule"
+        let directives = InlineSuppressionParser.parse(fileContent: source)
+        #expect(directives[0].unrecognizedNames == ["Zebra-Rule", "alpha-rule"])
+    }
+
     // MARK: - enable
 
     @Test func testEnableRule() {

--- a/Tests/CoreTests/Suppression/SuppressionAuditTests.swift
+++ b/Tests/CoreTests/Suppression/SuppressionAuditTests.swift
@@ -1,0 +1,112 @@
+@testable import Core
+import Testing
+
+/// Tests for the diagnostic half of the unresolved-name fix.
+///
+/// Making an unresolved-only directive inert is only safe if the user is told.
+/// A suppression that stops working does not throw — it reports *more* findings,
+/// which is the failure mode least likely to be noticed.
+@Suite
+struct SuppressionAuditTests {
+
+    // MARK: - The suggester
+
+    /// **The law that makes `suggestion(for:)` a fact rather than a guess.**
+    ///
+    /// It matches with hyphens removed, which is only sound if no two rule keys
+    /// collide that way. Stated as a round trip — every key suggests itself —
+    /// which catches any collision: `suggestion` returns the *first* match in
+    /// `allCases`, so of a colliding pair the later one is handed the earlier
+    /// one's key and fails here.
+    ///
+    /// Checked over all of `allCases` for the reason `RuleIdentifierKeyLawsTests`
+    /// gives: when the domain *is* the case list, enumerate it. A sampled run
+    /// over 208 cases would have to be lucky to draw the one colliding pair it
+    /// exists to find.
+    @Test func suggestionsAreUnambiguous() {
+        for rule in RuleIdentifier.allCases {
+            let key = rule.suppressionKey
+            #expect(SuppressionAudit.suggestion(for: key) == key, "\(rule) does not suggest its own key")
+        }
+    }
+
+    /// Both mistakes that actually existed in this repository, and both are
+    /// hyphen placement alone — which is why an exact hyphen-insensitive match
+    /// is enough and no edit distance is needed.
+    @Test func suggestsTheKeyForTheTwoRealWorldMisspellings() {
+        #expect(SuppressionAudit.suggestion(for: "legacy-observable-object") == "legacy-observableobject")
+        #expect(SuppressionAudit.suggestion(for: "ios17-observation-migration") == "ios-17-observation-migration")
+    }
+
+    /// The hostile half of the mapping: the key comes from the *display* name, so
+    /// `Legacy ObservableObject` spells one word where a reader writes two. 26 of
+    /// the 208 keys are not the kebab-case of their own identifier.
+    @Test func suggestsAcrossHyphenPlacementInEitherDirection() {
+        #expect(SuppressionAudit.suggestion(for: "anyviewusage") == "anyview-usage")
+        #expect(SuppressionAudit.suggestion(for: "any-view-usage") == "anyview-usage")
+        #expect(SuppressionAudit.suggestion(for: "FORCE-TRY") == "force-try")
+    }
+
+    @Test func offersNoSuggestionForANameThatResemblesNothing() {
+        #expect(SuppressionAudit.suggestion(for: "totally-fictional-rule") == nil)
+        #expect(SuppressionAudit.suggestion(for: "") == nil)
+    }
+
+    // MARK: - Auditing a file
+
+    @Test func reportsTheNameLineAndInertness() throws {
+        // Escaped newlines, not a multi-line literal — see the note in
+        // `InlineSuppressionFilterTests`: the parser scans lines, so a wrong-key
+        // fixture written the readable way is a directive in this very file.
+        let source = "let x = 1\n// swiftprojectlint:disable:next legacy-observable-object\nfinal class Model {}"
+        let found = SuppressionAudit.unrecognizedNames(in: source, filePath: "Model.swift")
+        #expect(found.count == 1)
+        let entry = try #require(found.first)
+        #expect(entry.filePath == "Model.swift")
+        #expect(entry.line == 2)
+        #expect(entry.name == "legacy-observable-object")
+        #expect(entry.suggestion == "legacy-observableobject")
+        #expect(entry.directiveIsInert)
+    }
+
+    @Test func aDirectiveWithOneGoodNameIsNotInert() {
+        // Still worth reporting — the author asked for two rules and got one —
+        // but the notice must not claim the comment does nothing.
+        let source = "// swiftprojectlint:disable:next force-try rule-from-the-future"
+        let found = SuppressionAudit.unrecognizedNames(in: source, filePath: "A.swift")
+        #expect(found.count == 1)
+        #expect(found.first?.directiveIsInert == false)
+    }
+
+    @Test func aFileWithNoDirectivesReportsNothing() {
+        #expect(SuppressionAudit.unrecognizedNames(in: "let x = 1\n", filePath: "A.swift").isEmpty)
+    }
+
+    @Test func aBareDisableIsNotAnUnrecognizedName() {
+        // It names nothing, which is the documented spelling of "suppress
+        // everything" and stays legal.
+        #expect(SuppressionAudit.unrecognizedNames(in: "// swiftprojectlint:disable", filePath: "A.swift").isEmpty)
+    }
+
+    // MARK: - The notice
+
+    @Test func noticeNamesEverythingAReaderNeedsToFixIt() {
+        let source = "// swiftprojectlint:disable:next legacy-observable-object"
+        let notice = SuppressionAudit.notice(
+            for: SuppressionAudit.unrecognizedNames(in: source, filePath: "Sources/App/Model.swift")
+        )
+        #expect(notice.contains("Sources/App/Model.swift:1"))
+        #expect(notice.contains("legacy-observable-object"))
+        #expect(notice.contains("did you mean 'legacy-observableobject'?"))
+        #expect(notice.contains("suppresses nothing"))
+    }
+
+    @Test func noticeSaysNoRuleByThatNameWhenItCannotSuggestOne() {
+        let source = "// swiftprojectlint:disable:next totally-fictional-rule"
+        let notice = SuppressionAudit.notice(
+            for: SuppressionAudit.unrecognizedNames(in: source, filePath: "A.swift")
+        )
+        #expect(notice.contains("no rule by that name"))
+        #expect(notice.contains("did you mean") == false)
+    }
+}


### PR DESCRIPTION
Closes #207.

## The defect

`SuppressionDirective.rules` being empty meant **"all rules"**, and a directive whose every name failed to resolve produced an empty set. So this:

```swift
// swiftprojectlint:disable:next legacy-observable-object
final class Model: ObservableObject {}
```

silenced *every* rule on the next line, with no signal. The comment reads as naming one rule.

Unknown names are still ignored **as rules** — that is what lets a file naming a rule from a newer build work on an older one, and it is unchanged. What changes is that they are no longer forgotten: `unrecognizedNames` is kept alongside `rules`, and a new `targetsAllRules` tells *named nothing* from *named only unknown things*. The second now targets nothing, which is the conservative reading: the author meant a specific rule, and a build that cannot tell which one should not answer "then all of them".

## What it was hiding

Five such comments existed — all in this repository's own App target, none anywhere else in the 26-repository corpus. Correcting their keys restores what they were for, and the repo's finding count goes **1221 → 1237**:

| delta | rule | why |
|---|---|---|
| +8 | `SwiftProjectLint Suppression` | intended — see below |
| +7 | candidate/inventory census rules | new source file, not defects |
| +1 | `Map Used For Side Effects` | a false positive, filed as #211 |

**The +8 is the point.** `SwiftProjectLint Suppression` exists so suppressions can be audited — *"tracking suppressions makes it easy to audit how often lint rules are bypassed"*. Its findings land on the suppressed line, so the blanket disable covered the meta-rule too. **A suppression comment was erasing the evidence of itself**, and it had been doing so for five comments in the tool's own source.

## The diagnostic, and why the fix needs one

Making a directive inert without saying so is the same class of silence: a suppression that stops working does not throw, it reports *more* findings. So the run now writes to stderr:

```
Warning: 1 suppression comment names a rule that does not exist.
  Sources/App/Model.swift:28: unknown rule 'legacy-observable-object' — did you mean
  'legacy-observableobject'? This directive now suppresses nothing.
```

Both real misspellings were **hyphen placement alone**, so the suggester is an exact comparison with hyphens removed rather than an edit distance. That is sound only because no two keys collide that way, which `suggestionsAreUnambiguous` pins exhaustively over `allCases` — stated as a round trip, so of any colliding pair the later one fails.

The keys deserve a suggester because they are genuinely hard to guess: derived from the **display** name, so `Legacy ObservableObject` gives `legacy-observableobject`. **26 of the 208 keys** differ this way from the kebab-case of the rule's own identifier.

## What a reviewer should scrutinise

1. **The audit is a separate pass, not a value threaded out of the filter.** Two reasons: `InlineSuppressionFilter.filter` returns early when a file has no issues, so a diagnostic riding along would report a file's bad directives only while that file happened to be failing something else — the files where a suppression is *working* would be exactly the quiet ones. And `analyzeProject` returns `[LintIssue]` at 59 call sites. The CLI already takes this shape for its skipped-packages notice. Cost measured: the run is unchanged at ~13s.
2. **Test fixtures with a deliberately wrong key use escaped newlines, not multi-line literals.** `InlineSuppressionParser` scans lines and cannot tell a comment from a line inside a string literal, so a readable fixture is a directive *in the test file* — the audit reported this repository's own tests on every run until they were rewritten. That is a pre-existing limitation of the line-based parser (a directive inside a string literal in production code is honoured too); this PR surfaces it rather than introducing it. Say if it deserves its own issue.
3. **The regression tests have controls.** `testDirectiveNamingOnlyUnknownRulesSuppressesNothing` would also pass against a filter that had simply stopped honouring blanket disables, so `testDirectiveNamingNothingStillSuppressesEverything` and the partial-resolution test sit next to it. Verified by reverting the one-line filter change: the two new assertions fail, the controls stay green.
4. **One finding in the new file is left standing deliberately.** `Map Used For Side Effects` reports the implicitly-returned `flatMap` in `SuppressionAudit.unrecognizedNames`, and SwiftLint's `implicit_return` rejects the explicit `return` that silences it — **two linters contradicting on one line.** SwiftLint is the pre-commit gate, so it wins; the SwiftProjectLint rule is wrong and is filed as #211 with a minimal repro.

3717 tests in 445 suites pass. `swiftlint` unchanged at 25 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeZ6uZMfPc3bgznF69r98K