### PR TITLE
Split Extractable Total Kernel's advice on whether a path is involved

### DIFF
--- a/Docs/rules/extractable-total-kernel.md
+++ b/Docs/rules/extractable-total-kernel.md
@@ -132,7 +132,7 @@ Gates 1 and 2 apply to both shapes; gate 3 is what each shape has to satisfy.
 |---|---|---|
 | Derivation | `let total = (count + size - 1) / size` | `let prefix = root.hasSuffix("/") ? root : root + "/"` |
 | Governing use | loop bound, index, slice with an operator, fraction | slice driven by a `.count`, membership test, or a comparison **naming** the binding |
-| Law it owes | the parts tile the whole; progress terminates at 1.0 | the derivation round-trips; normalisation is idempotent |
+| Law it owes | the parts tile the whole; progress terminates at 1.0 | see **Which law the string shape is told it owes** below |
 | Bug it catches | off-by-one counts, unclamped resume index | off-by-one prefixes, a suffix stripped from the wrong end |
 
 The second shape exists because the rule was run over a 60k-line linter and reported **nothing at
@@ -148,6 +148,49 @@ Its governing test is deliberately stricter than the arithmetic shape's. That on
 comparison containing an arithmetic operator, whatever names it mentions; since `+` on strings is
 concatenation, reusing it here vouched for derivations it had nothing to do with. The path shape
 requires the comparison to actually name the binding.
+
+### Which law the string shape is told it owes
+
+**The gate is a string derivation; the advice used to be about a path under a root regardless.**
+Those are not the same set. Measured over the 26-repository corpus, of the six findings on this
+arm two derive no path at all:
+
+| site | what it derives | law it owes |
+|---|---|---|
+| `Scan.swift:73` | exclusion by path prefix | round-trip from the root |
+| `SkillLinter.swift:79` | files under a directory | round-trip from the root |
+| `XcodeIntegrationService.swift:134` | walk up from a directory | round-trip from the root |
+| `EditTools.swift:120` | a parent directory **and** a line count | round-trip, for `parent` only |
+| `AppleDocsIngester.swift:159` | `path.lowercased()` as a dedup key | idempotence — and **not** round-trip |
+| `SkillConflictDetector+Pipeline.swift:144` | first line / rest | recombination — but no root |
+
+So the advice splits on whether a **path-specific** operation appears —
+`appendingPathComponent`, `deletingLastPathComponent`, `lastPathComponent`, `standardizingPath`
+and the rest. With one, the message is unchanged. Without, it states what the shape actually owes:
+**totality at the boundaries** — the empty string, no separator, a trailing separator, repeated
+separators — and then, conditionally, recombination *or* idempotence. It names both as conditional
+because the corpus contains both and the gate cannot tell them apart: a lossy canonicalisation
+like `lowercased()` is idempotent and does **not** round-trip.
+
+**This was not cosmetic.** An earlier run carried this advice at
+`AgentRunner+ProjectGuidance.swift:14`, naming a binding called `url`, while the kernel two lines
+below was a byte budget whose guard counted UTF-8 bytes and whose truncation counted `Character`s —
+a 16 KB cap that passed 410 KB of emoji. A reader who wrote the suggested round-trip laws would
+have proved something true about `url` and walked past the bug. Advice specific enough to follow,
+pointing away from the defect, is worse than silence.
+
+**The evidence is looked for across the whole body, not just in the derived bindings**, and the
+canonical fixture is why. `DirectoryScanner.scanSync` binds
+`prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"` and
+`relativePath = item.hasPrefix(prefix) ? String(item.dropFirst(prefix.count)) : item` — every
+operation generic. What makes it a path derivation is the `lastPathComponent` on the next line. A
+binding-scoped check gets the most canonical case in the corpus wrong. The search also descends
+into closures, unlike the kernel walk: in `Sitrep.detectFiles` the entire derivation sits inside a
+`contains { … }`.
+
+**When only some bindings are path-derived, the message says which.** `EditTools.swift:120` derives
+a parent directory and a line count in one method, and one finding covers both; without the caveat
+a reader is told to check round-trip from a root about a line count.
 
 The change is a net gain in findings rather than a narrowing: tightening the path shape lost
 nothing and surfaced kernels the looser test had been talking past. Most of what it surfaced was
@@ -240,6 +283,11 @@ A finding contributes a seed whose `role` names the kernel's shape: a tiler is a
 derivation is a `normalizer`. A progress-only kernel claims **no** role — "monotone and terminates
 at 1.0" is not one of the vocabulary's names, and inventing one to fill the field would have the
 consumer act on a classification nobody made.
+
+**A string derivation with no path evidence claims no role either, for the same reason.**
+`normalizer` is "derives one value from another in the same domain… owes a round-trip and an
+idempotent normalisation". A head/tail split leaves the domain, and `lowercased()` is idempotent
+but lossy, so it cannot round-trip. Neither owes what the role names.
 
 `partition` is role-*entailed*: a partition owes a tiling by virtue of being one, so a correct
 implementation cannot fail that law. `normalizer` is a conjecture — its round-trip and idempotence

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ExtractableTotalKernelVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ExtractableTotalKernelVisitor.swift
@@ -158,6 +158,8 @@ private struct KernelScan {
     /// and both were unreachable from a test because the derivation was welded to a `FileManager`
     /// enumeration.
     private var derivedPathBindings: [String] = []
+    private var pathSpecificBindings: [String] = []
+    private var bodyMentionsAPath = false
 
     /// `dropFirst(prefix.count)` — a slice driven by a **count** rather than by an arithmetic
     /// expression. `hasSlicingArithmetic` requires an operator, so it does not see this.
@@ -187,6 +189,8 @@ private struct KernelScan {
         hasResumableIndex = collector.hasResumableIndex
 
         derivedPathBindings = collector.derivedPathBindings
+        pathSpecificBindings = collector.pathSpecificBindings
+        bodyMentionsAPath = PathEvidence.occurs(in: Syntax(body))
         hasCountDrivenSlice = collector.hasCountDrivenSlice
         hasGoverningMembershipTest =
             collector.membershipTestReferences(collector.derivedPathBindings)
@@ -247,8 +251,66 @@ private struct KernelScan {
     /// "monotone and terminates at 1.0" is not one of the roles this vocabulary names, and inventing
     /// a role to fill the field would be worse than leaving it empty.
     var role: PBTSeedRole? {
-        if !isArithmeticKernel, isPathKernel { return .normalizer }
+        if !isArithmeticKernel, isPathKernel {
+            // `.normalizer` is "derives one value from another in the same domain… owes a
+            // round-trip and an idempotent normalisation". Without path-specific evidence the
+            // shape does not entail that: `output.split(maxSplits: 1)` leaves the same domain,
+            // and `path.lowercased()` is idempotent but lossy, so it cannot round-trip. Claiming
+            // the role anyway would put a derivation in the seed manifest under a law it does not
+            // owe. `nil` is the same answer a fraction-only kernel gets, for the same reason —
+            // inventing a role to fill the field is worse than leaving it empty.
+            return hasPathSpecificEvidence ? .normalizer : nil
+        }
         return hasSlicingArithmetic ? .partition : nil
+    }
+
+    /// What a derived string that governs a decision owes when nothing says it is a *path*.
+    ///
+    /// Deliberately does not choose between round-trip and idempotence, because the corpus shows
+    /// both shapes here and the gate cannot tell them apart: `output.split(maxSplits: 1)` into a
+    /// name and a body owes that the parts rejoin to the whole; `path.lowercased()` used as a
+    /// dedup key owes idempotence and does **not** round-trip, lowercasing being lossy. Naming
+    /// both as conditional is weaker than the path arm's advice and is the honest strength.
+    ///
+    /// What it does state unconditionally is the boundary set, because that is what actually
+    /// catches these: `"a\n".components(separatedBy: "\n").count` is 2, a `split(maxSplits: 1)`
+    /// on input with no separator yields one part where the reader expected two, and a trailing
+    /// separator is the difference between every off-by-one in this shape and none.
+    static let stringDerivationLaw =
+        "the derivation should be TOTAL over the strings it names — an answer, not a trap or a "
+        + "wrong one, for the empty string, for input with no separator, for a separator at the "
+        + "very end, and for repeated separators. Then whichever applies: if it cuts a whole into "
+        + "parts, the parts should RECOMBINE into what you started with; if it canonicalises, it "
+        + "should be IDEMPOTENT. Note these are not both true of every derivation — a lossy "
+        + "canonicalisation like `lowercased()` is idempotent and does not round-trip."
+
+    static let stringDerivationSuggestion =
+        "Extract the derivation into a free function over the strings alone, named for what it "
+        + "produces rather than for the method it came from. Strings in, strings out is "
+        + "constructible in a test with no I/O, which is the whole point: the boundary cases above "
+        + "can then be generated against rather than eyeballed. Do NOT lift the decision this "
+        + "feeds — a `Set.contains` or a `count >` is already correct by construction, and the law "
+        + "is over the value being DERIVED, not over the test applied to it."
+
+    /// Named when only *some* of the bindings are path-derived, because the root law is not
+    /// about the others and the summary lists them all.
+    ///
+    /// `EditTools.swift:120` is the measured case: `parent = url.deletingLastPathComponent()`
+    /// beside `lineCount = content.components(separatedBy: "\n").count`. Two unrelated
+    /// derivations in one method, one finding, and a reader told to check round-trip from a root
+    /// is being told it about a line count. The empty string for the whole-shape case keeps the
+    /// message unchanged where the advice was already exactly right.
+    private var mixedShapeCaveat: String {
+        // Silent unless the path evidence is attached to *named bindings* and covers only some of
+        // them. When the evidence is elsewhere in the body — `scanSync`, whose bindings are all
+        // generic string operations and whose `lastPathComponent` is on the following line —
+        // there is no subset to name, and guessing one would be worse than saying nothing.
+        guard !pathSpecificBindings.isEmpty,
+              pathSpecificBindings.count < derivedPathBindings.count else { return "" }
+        let named = pathSpecificBindings.prefix(3).map { "`\($0)`" }.joined(separator: ", ")
+        return " That law is over \(named); the other names here derive strings that are not "
+            + "paths, and what those owe is totality at the boundaries — the empty string, no "
+            + "separator, a trailing separator."
     }
 
     var summary: String {
@@ -262,12 +324,31 @@ private struct KernelScan {
         return hasUnnamedFraction ? "\(named) and the progress fraction" : named
     }
 
+    /// Whether the derivation used an operation that identifies a **path**, which is what
+    /// licenses advice about a root.
+    ///
+    /// The gate for the shape is a *string* derivation that governs a decision, and the advice
+    /// used to talk about a path under a root regardless. Measured over 26 repositories: of the
+    /// six findings on this arm, two derived no path at all — `path.lowercased()` used as a
+    /// dedup key, and `output.split(separator: "\n", maxSplits: 1)` cut into a name and a body.
+    /// Telling a reader to check round-trip *from the root* at either is advice specific enough
+    /// to follow and pointing at nothing.
+    ///
+    /// This is not hypothetical. `AgentRunner+ProjectGuidance.swift:14` carried the path advice
+    /// naming a binding called `url`, while the kernel two lines below was a byte budget whose
+    /// guard counted UTF-8 bytes and whose truncation counted `Character`s — a 16 KB cap that
+    /// passed 410 KB of emoji. A reader who wrote the suggested round-trip laws would have proved
+    /// something true about `url` and walked past the bug.
+    private var hasPathSpecificEvidence: Bool { bodyMentionsAPath }
+
     var law: String {
         if !isArithmeticKernel, isPathKernel {
+            guard hasPathSpecificEvidence else { return Self.stringDerivationLaw }
             return "the derivation should ROUND-TRIP — rebuilding the whole from the root and the "
                 + "derived part should give back what you started with — and normalising should be "
                 + "IDEMPOTENT: applying it twice must equal applying it once. Both are checkable "
                 + "over generated roots and paths, and both are where off-by-one prefix bugs live."
+                + mixedShapeCaveat
         }
         if hasFraction, hasSlicingArithmetic {
             return "the parts should tile the whole exactly, and progress should terminate at 1.0 — "
@@ -304,6 +385,7 @@ private struct KernelScan {
     /// then, so a plain `var i = 0` tiler with no resume concept keeps the shorter advice.
     var suggestion: String {
         if !isArithmeticKernel, isPathKernel {
+            guard hasPathSpecificEvidence else { return Self.stringDerivationSuggestion }
             return "Extract the derivation into a free function or value type over the strings "
                 + "alone — `func relativePath(of item: String, under root: String) -> String` — and "
                 + "let the method keep the enumeration and ask it what to call each item. Two "
@@ -334,6 +416,44 @@ private struct KernelScan {
                 + "the clamp is the property the tiler owes."
         }
         return advice
+    }
+}
+
+/// Operations that identify a **path**, as opposed to any string.
+///
+/// `Collector.pathCalls` is the gate for the *shape*, and it is deliberately broad —
+/// `lowercased`, `split`, `joined`, `trimmingCharacters` are string operations that happen to be
+/// how paths get built. This narrower set is what licenses the *advice* to talk about a root.
+///
+/// **Looked for across the whole body, not only in the derived bindings.** The canonical fixture
+/// is `DirectoryScanner.scanSync`, and its two bindings are
+/// `prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"` and
+/// `relativePath = item.hasPrefix(prefix) ? String(item.dropFirst(prefix.count)) : item` — both
+/// built entirely from generic string operations. What makes it a path derivation is the
+/// `(relativePath as NSString).lastPathComponent` on the next line. A binding-scoped check gets
+/// the most canonical case in the corpus wrong, which is how this scope was chosen.
+enum PathEvidence {
+
+    static let names: Set<String> = [
+        "appendingPathComponent", "appendingPathExtension", "deletingLastPathComponent",
+        "deletingPathExtension", "standardizingPath", "standardizedFileURL",
+        "lastPathComponent", "pathExtension", "pathComponents", "relativePath",
+        "resolvingSymlinksInPath", "absoluteString"
+    ]
+
+    /// Deliberately descends into closures, unlike the kernel walk. A closure body belongs to a
+    /// different rule *as a kernel*; as **evidence that this method handles paths** it counts —
+    /// `excludedPath.contains { url.deletingLastPathComponent().relativePath.hasPrefix($0) }` is
+    /// the whole shape the path advice is for, and all of it sits inside the closure.
+    static func occurs(in node: Syntax) -> Bool {
+        if let member = node.as(MemberAccessExprSyntax.self),
+           names.contains(member.declName.baseName.text) {
+            return true
+        }
+        for child in node.children(viewMode: .sourceAccurate) where occurs(in: child) {
+            return true
+        }
+        return false
     }
 }
 
@@ -383,6 +503,10 @@ private struct Collector {
     // MARK: - The path/string shape
 
     private(set) var derivedPathBindings: [String] = []
+
+    /// The subset of `derivedPathBindings` whose derivation used an operation that
+    /// identifies a **path** rather than any string — see `pathSpecificNames`.
+    private(set) var pathSpecificBindings: [String] = []
     private(set) var hasCountDrivenSlice = false
 
     /// Identifiers passed to a membership test — `dirName` in `skipped.contains(dirName)`.
@@ -486,6 +610,7 @@ private struct Collector {
         _ name: String, value: ExprSyntax, at declaration: VariableDeclSyntax
     ) {
         guard containsPathOperation(Syntax(value)), onlyPathSafeCalls(Syntax(value)) else { return }
+        if PathEvidence.occurs(in: Syntax(value)) { pathSpecificBindings.append(name) }
         derivedPathBindings.append(name)
         if firstArithmeticSite == nil { firstArithmeticSite = Syntax(declaration) }
     }

--- a/Tests/CoreTests/Testability/ExtractableTotalKernelStringLawTests.swift
+++ b/Tests/CoreTests/Testability/ExtractableTotalKernelStringLawTests.swift
@@ -1,0 +1,151 @@
+@testable import Core
+import Foundation
+import SwiftParser
+@testable import SwiftProjectLintRules
+import SwiftSyntax
+import Testing
+
+/// Which of the two laws the path/string arm states, and on what evidence.
+///
+/// Split from `ExtractableTotalKernelVisitorTests` only to keep either half under
+/// `type_body_length`; the fixtures belong to the same suite of silences and fires.
+///
+/// The arm's gate is a **string** derivation that governs a decision, and its advice used to talk
+/// about a path under a root regardless. Measured over 26 repositories, two of its six findings
+/// derive no path at all, and one of the eight it carried in an earlier run pointed a reader at
+/// `url` while the live bug two lines below was a byte budget that let 410 KB through a 16 KB cap.
+@Suite("Extractable Total Kernel — the law the string shape is told it owes")
+struct ExtractableTotalKernelStringLawTests {
+
+    private func analyze(_ source: String, filePath: String = "Service.swift") -> [LintIssue] {
+        let visitor = ExtractableTotalKernelVisitor(patternCategory: .testability)
+        let syntax = Parser.parse(source: source)
+        visitor.setSourceLocationConverter(
+            SourceLocationConverter(fileName: filePath, tree: syntax)
+        )
+        visitor.setFilePath(filePath)
+        visitor.walk(syntax)
+        return visitor.detectedIssues.filter { $0.ruleName == .extractableTotalKernel }
+    }
+
+    //
+    // The gate is a *string* derivation that governs a decision; the advice used to be about a
+    // path under a root regardless. Measured over 26 repositories, two of the six findings on this
+    // arm derive no path at all. Both fixtures below are those two, reduced.
+
+    @Test("a lossy canonicalisation used as a dedup key is not told to round-trip from a root")
+    func canonicalisationGetsTheStringLaw() throws {
+        // `AppleDocsIngester.crawlFramework`. `lowercased()` is idempotent and does NOT
+        // round-trip, so half the path advice is false here and the other half mentions a root
+        // that does not exist.
+        let issue = try #require(analyze("""
+        func crawl(_ framework: String) async throws {
+            var visited: Set<String> = []
+            var queue: [(path: String, depth: Int)] = [("/documentation/" + framework.lowercased(), 0)]
+            while !queue.isEmpty {
+                let (path, depth) = queue.removeFirst()
+                let normalizedPath = path.lowercased()
+                guard !visited.contains(normalizedPath) else { continue }
+                visited.insert(normalizedPath)
+            }
+        }
+        """).first)
+
+        #expect(issue.message.contains("TOTAL over the strings it names"))
+        #expect(issue.message.contains("IDEMPOTENT"))
+        #expect(issue.message.contains("rebuilding the whole from the root") == false)
+    }
+
+    @Test("a head/tail split is not told to round-trip from a root")
+    func headTailSplitGetsTheStringLaw() throws {
+        // `SkillConflictDetector.tier3MergeProposal`. This one DOES owe a recombination law — the
+        // name and the body rejoin to the output — which is why the string advice states that as a
+        // conditional rather than dropping round-trip altogether.
+        //
+        // The `await` is load-bearing, not decoration. This rule is *the kernel trapped in an
+        // impure method*; take the I/O away and the whole function is pure, which is
+        // `pureFunctionCandidate`'s finding instead and this rule correctly says nothing.
+        let issue = try #require(analyze("""
+        func propose(_ rationale: String) async throws -> MergeProposal {
+            let output = try await collectResponse(task: .merge, prompt: rationale)
+            guard !output.isEmpty else { throw SkillError.empty }
+            let lines = output.split(separator: "\n", maxSplits: 1)
+            let mergedName = String(lines.first ?? "merged-skill")
+            let mergedPrompt = lines.count > 1 ? String(lines[1]) : output
+            return MergeProposal(name: mergedName, draft: mergedPrompt)
+        }
+        """).first)
+
+        #expect(issue.message.contains("RECOMBINE"))
+        #expect(issue.message.contains("no separator"))
+        #expect(issue.message.contains("rebuilding the whole from the root") == false)
+    }
+
+    @Test("a method deriving both a path and a plain string says which the root law is over")
+    func mixedShapeNamesThePathBindings() throws {
+        // `EditTools.execute`. Two unrelated derivations in one method, one finding. Without the
+        // caveat a reader is told to check round-trip from a root about a line count.
+        let issue = try #require(analyze("""
+        func execute(_ url: URL, content: String) throws {
+            let parent = url.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+            try content.write(to: url, atomically: true, encoding: .utf8)
+            let lineCount = content.components(separatedBy: "\n").count
+            if lineCount > 0 { log(lineCount) }
+        }
+        """).first)
+
+        #expect(issue.message.contains("rebuilding the whole from the root"))
+        #expect(issue.message.contains("That law is over `parent`"))
+        #expect(issue.message.contains("`lineCount`"))
+    }
+
+    @Test("path evidence anywhere in the body keeps the root law")
+    func pathEvidenceIsBodyWideNotBindingScoped() throws {
+        // The scope choice, pinned. `scanSync`'s two bindings are built entirely from generic
+        // string operations — `hasSuffix`, `hasPrefix`, `dropFirst` — and what makes it a path
+        // derivation is the `lastPathComponent` on the following line. A binding-scoped check
+        // gets the most canonical case in the corpus wrong, which is how the scope was chosen.
+        let issue = try #require(analyze("""
+        func scanSync(rootPath: String) -> DirectoryNode {
+            let enumerator = FileManager.default.enumerator(atPath: rootPath)
+            let prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+            while let item = enumerator?.nextObject() as? String {
+                let relativePath = item.hasPrefix(prefix)
+                    ? String(item.dropFirst(prefix.count))
+                    : item
+                let dirName = (relativePath as NSString).lastPathComponent
+                if skipped.contains(dirName) { continue }
+            }
+            return root
+        }
+        """).first)
+
+        #expect(issue.message.contains("rebuilding the whole from the root"))
+        // No named subset to report: the evidence is not attached to a binding.
+        #expect(issue.message.contains("That law is over") == false)
+    }
+
+    @Test("path evidence inside a closure counts, though the kernel walk stops there")
+    func pathEvidenceDescendsIntoClosures() throws {
+        // `Sitrep.detectFiles`. The whole path derivation sits inside the `contains` closure —
+        // the exclusion-by-prefix shape, where `["Sources/App"]` also excludes `Sources/AppExtension`.
+        let issue = try #require(analyze("""
+        func detectFiles(excludedPath: [String]) -> [URL] {
+            let enumerator = FileManager.default.enumerator(at: rootURL)
+            while let objectURL = enumerator?.nextObject() as? URL {
+                let isExcluded = excludedPath.contains {
+                    objectURL.deletingLastPathComponent().relativePath.hasPrefix($0)
+                }
+                let other = excludedPath.contains {
+                    objectURL.deletingLastPathComponent().relativePath.hasPrefix($0)
+                }
+                guard isExcluded == false, other == false else { continue }
+            }
+            return []
+        }
+        """).first)
+
+        #expect(issue.message.contains("rebuilding the whole from the root"))
+    }
+}

--- a/Tests/CoreTests/Testability/SeedRoleEmissionTests.swift
+++ b/Tests/CoreTests/Testability/SeedRoleEmissionTests.swift
@@ -140,6 +140,26 @@ struct SeedRoleEmissionTests {
         """) == nil)
     }
 
+    @Test("a string derivation with no path evidence claims no role")
+    func stringKernelWithoutPathEvidenceHasNoRole() {
+        // `.normalizer` is "derives one value from another in the same domain… owes a round-trip
+        // and an idempotent normalisation". `path.lowercased()` used as a dedup key is idempotent
+        // and **lossy**, so it cannot round-trip; claiming the role would put it in the manifest
+        // under a law it does not owe. Same answer as the progress kernel above, same reason.
+        #expect(kernelRole("""
+        func crawl(_ framework: String) async throws {
+            var visited: Set<String> = []
+            var queue: [(path: String, depth: Int)] = [("/documentation/" + framework.lowercased(), 0)]
+            while !queue.isEmpty {
+                let (path, depth) = queue.removeFirst()
+                let normalizedPath = path.lowercased()
+                guard !visited.contains(normalizedPath) else { continue }
+                visited.insert(normalizedPath)
+            }
+        }
+        """) == nil)
+    }
+
     // MARK: - How many rules classify, and which
 
     /// The third classifier, and the one this suite had no coverage for.


### PR DESCRIPTION
Closes #205.

## The defect

The arm's gate is a **string** derivation that governs a decision. Its advice was about a **path under a root** regardless:

> the derivation should ROUND-TRIP — rebuilding the whole **from the root** and the derived part should give back what you started with

Measured over the 26-repository corpus, of the six findings on this arm **two derive no path at all**:

| site | what it derives | law it owes |
|---|---|---|
| `Scan.swift:73` | exclusion by path prefix | round-trip from the root |
| `SkillLinter.swift:79` | files under a directory | round-trip from the root |
| `XcodeIntegrationService.swift:134` | walk up from a directory | round-trip from the root |
| `EditTools.swift:120` | a parent directory **and** a line count | round-trip, for `parent` only |
| `AppleDocsIngester.swift:159` | `path.lowercased()` as a dedup key | idempotence — and **not** round-trip |
| `SkillConflictDetector+Pipeline.swift:144` | first line / rest | recombination — but no root |

**Not cosmetic.** An earlier run carried this advice at `AgentRunner+ProjectGuidance.swift:14`, naming a binding called `url`, while the kernel two lines below was a byte budget whose guard counted UTF-8 bytes and whose truncation counted `Character`s — a 16 KB cap that passed 410 KB of emoji. A reader who wrote the suggested round-trip laws would have proved something true about `url` and walked past the bug. Advice specific enough to follow, pointing away from the defect, is worse than silence.

## What changed

Split on whether a **path-specific** operation appears — `appendingPathComponent`, `deletingLastPathComponent`, `lastPathComponent`, `standardizingPath`, and the rest. With one, the message is unchanged. Without, it states what the shape actually owes:

> the derivation should be **TOTAL** over the strings it names — an answer, not a trap or a wrong one, for the empty string, for input with no separator, for a separator at the very end, and for repeated separators. Then whichever applies: if it cuts a whole into parts, the parts should **RECOMBINE**; if it canonicalises, it should be **IDEMPOTENT**.

Both are named as conditional because the corpus contains both shapes and the gate cannot tell them apart — a lossy canonicalisation like `lowercased()` is idempotent and does **not** round-trip. That is weaker than the path arm's advice, and the weakness is the honest part.

The seed role follows the same line: `.normalizer` is *"derives one value from another in the same domain… owes a round-trip and an idempotent normalisation"*. A head/tail split leaves the domain; a lossy canonicalisation cannot round-trip. Neither owes what the role names, so both get `nil` — the answer a progress-only kernel already gets, for the reason the file already gives.

**Corpus effect: no finding gained or lost.** Four keep the root law, two get the string law, one of the four gains the mixed-shape caveat.

## What a reviewer should scrutinise

1. **The evidence scope is body-wide, not binding-scoped, and that was forced by a test.** My first implementation checked only the derived bindings' initialisers — and it put `DirectoryScanner.scanSync`, the canonical fixture the path arm was built for, on the string arm. Its bindings are `prefix = rootPath.hasSuffix("/") ? …` and `relativePath = item.hasPrefix(prefix) ? String(item.dropFirst(prefix.count)) : item`: every operation generic. What makes it a path derivation is the `lastPathComponent` on the next line. The corpus could not have shown this — that function was refactored into `ProjectRoot`/`RelativePath` last session — so the existing test caught what the measurement could not. `pathEvidenceIsBodyWideNotBindingScoped` pins it.
2. **The search descends into closures, unlike the kernel walk.** A closure body belongs to another rule *as a kernel*; as evidence that this method handles paths it counts. `Sitrep.detectFiles` is the case — the whole derivation sits inside `excludedPath.contains { … }`.
3. **The mixed-shape caveat is silent when the evidence is not attached to a binding.** Otherwise `scanSync` would print "That law is over ;" with nothing named. Guessing a subset would be worse than saying nothing.
4. **Option 2 from the issue — a separate truncation arm — is deliberately not built.** The three sites that motivated it (`FilesystemTools:103`, `:178`, `AgentRunner+ProjectGuidance:14`) were all extracted into `CappedList` and `String.prefix(utf8Bytes:)` last session, so **the corpus now contains zero truncation-shaped sites**. Building a gate with no positives to validate against is the thing this project's standard argues against. Worth reopening if the shape recurs.
5. **One test fixture needed an `await` to fire at all**, and the reason is worth knowing: this rule is *the kernel trapped in an impure method*. Take the I/O away and the whole function is pure, which is `pureFunctionCandidate`'s finding instead. My first reduction of the `SkillConflictDetector` site was silently a pure function.

3723 tests in 446 suites pass. `swiftlint` unchanged at 25 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeZ6uZMfPc3bgznF69r98K