### PR TITLE
Stop claiming a tiling where the rule declines to claim a partition

### DIFF
--- a/Docs/rules/extractable-total-kernel.md
+++ b/Docs/rules/extractable-total-kernel.md
@@ -132,7 +132,7 @@ Gates 1 and 2 apply to both shapes; gate 3 is what each shape has to satisfy.
 |---|---|---|
 | Derivation | `let total = (count + size - 1) / size` | `let prefix = root.hasSuffix("/") ? root : root + "/"` |
 | Governing use | loop bound, index, slice with an operator, fraction | slice driven by a `.count`, membership test, or a comparison **naming** the binding |
-| Law it owes | the parts tile the whole; progress terminates at 1.0 | see **Which law the string shape is told it owes** below |
+| Law it owes | see **Which law each shape is told it owes** below | see **Which law each shape is told it owes** below |
 | Bug it catches | off-by-one counts, unclamped resume index | off-by-one prefixes, a suffix stripped from the wrong end |
 
 The second shape exists because the rule was run over a 60k-line linter and reported **nothing at
@@ -149,7 +149,7 @@ comparison containing an arithmetic operator, whatever names it mentions; since 
 concatenation, reusing it here vouched for derivations it had nothing to do with. The path shape
 requires the comparison to actually name the binding.
 
-### Which law the string shape is told it owes
+### Which law each shape is told it owes
 
 **The gate is a string derivation; the advice used to be about a path under a root regardless.**
 Those are not the same set. Measured over the 26-repository corpus, of the six findings on this
@@ -171,6 +171,33 @@ and the rest. With one, the message is unchanged. Without, it states what the sh
 separators — and then, conditionally, recombination *or* idempotence. It names both as conditional
 because the corpus contains both and the gate cannot tell them apart: a lossy canonicalisation
 like `lowercased()` is idempotent and does **not** round-trip.
+
+**The arithmetic shape had the same defect, and a wider one.** Its law fell through to *"the
+parts should tile the whole exactly — no gap, no overlap — and the count should be exactly
+`ceil(total / size)`"* whenever there was no fraction — **including where `hasSlicingArithmetic`
+is false, which is exactly when `role` returns `nil` rather than `.partition`.** The two disagreed
+inside one type: the seed manifest declined to call it a partition while the sentence the reader
+acts on said it owed a tiling. Measured, **7 of 20 findings** were in that state:
+
+| site | what it derives | what it is |
+|---|---|---|
+| `GitCloneHelper.swift:67` | `512 * 1_024` against a file size | a threshold |
+| `SnapshotManager.swift:81` | `summary.totalTypes - snapshot.typeCount` ×4 | a difference |
+| `ToolInvocation.swift:115` | `index + 1` against `arguments.count` | a bounds check |
+| `Enumeration.swift:147` | `(low + high + 1) / 2` | a binary search |
+| `MLXRunCommand.swift:65`, `VerifyInteractionSurvey.swift:203`, `HTMLReportGenerator.swift:213` | — | — |
+
+None cuts anything up. That branch now states what arithmetic governing a **comparison** owes:
+totality — an answer for every input including an empty collection, a zero bound and a negative
+difference — and correctness **at** the boundary, plus antisymmetry where it is a difference of two
+measurements. `SnapshotManager.computeDiff` is the case that shows why this matters: its real law
+is antisymmetry and a zero at equality, and its real hazard is iterating one side's keys instead of
+the union, so a removed entry vanishes instead of showing as negative. The tiling law names none of
+that.
+
+`SeedRoleEmissionTests.theLawAndTheRoleAgreeAboutWhatTheKernelIs` now pins the biconditional:
+the message states the tiling law **if and only if** the role is `.partition`, and the root law if
+and only if the role is `.normalizer`.
 
 **This was not cosmetic.** An earlier run carried this advice at
 `AgentRunner+ProjectGuidance.swift:14`, naming a binding called `url`, while the kernel two lines

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ExtractableTotalKernelVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/ExtractableTotalKernelVisitor.swift
@@ -358,9 +358,33 @@ private struct KernelScan {
             return "progress should be monotonic, stay within 0...1, and terminate at 1.0 — "
                 + "including for an empty input."
         }
+        guard hasSlicingArithmetic else { return Self.boundedComparisonLaw }
         return "the parts should tile the whole exactly — no gap, no overlap — and the count should "
             + "be exactly `ceil(total / size)`."
     }
+
+    /// What arithmetic that governs a **comparison** owes, as opposed to arithmetic that cuts a
+    /// whole into parts.
+    ///
+    /// The tiling law used to be the fallback for the arithmetic shape, claimed whenever there was
+    /// no fraction — including where `hasSlicingArithmetic` is false, which is exactly when `role`
+    /// declines to say `.partition`. **The two disagreed inside this type**: the seed manifest said
+    /// "I will not call this a partition" while the message told the reader it owed a tiling.
+    ///
+    /// Measured over the 26-repository corpus: **7 of 20 findings** were on this branch. None of
+    /// them cuts anything up. `GitCloneHelper.listSwiftFiles` derives `maxFileSize = 512 * 1_024`
+    /// and compares a file size against it — a threshold. `SnapshotManager.computeDiff` derives
+    /// `summary.totalTypes - snapshot.typeCount` and four siblings — a difference, whose real law
+    /// is antisymmetry and a zero at equality, and whose real bug is iterating one side's keys
+    /// instead of the union. `ToolInvocation.requireValue` derives `index + 1` and bounds-checks
+    /// it. "The count should be exactly `ceil(total / size)`" is not a statement about any of them.
+    static let boundedComparisonLaw =
+        "the derivation should be TOTAL — an answer for every input the types admit, including an "
+        + "empty collection, a zero bound, and a negative difference — and the decision it governs "
+        + "should be right AT the boundary, which is where the off-by-one lives: a value exactly "
+        + "equal to the bound, a count of zero, a count of one. If it is a difference of two "
+        + "measurements, it also owes ANTISYMMETRY — swapping the operands negates it — and zero "
+        + "when they agree."
 
     /// What to actually build — and for a **tiler**, the shape matters as much as the fact.
     ///
@@ -396,8 +420,9 @@ private struct KernelScan {
                 + "not over the lookup."
         }
         guard hasSlicingArithmetic else {
-            return "Extract the arithmetic into a value type constructed from those inputs alone. "
-                + "The method keeps the I/O and asks the value type where the bytes are."
+            return "Extract the arithmetic into a free function or value type constructed from "
+                + "those inputs alone, so the boundary cases can be generated against rather than "
+                + "eyeballed. The method keeps the I/O and asks the value type for the answer."
         }
         var advice = "Extract a value type whose key method maps a part INDEX to its slice of the "
             + "whole — `func chunk(of whole: …, at index: Int) -> …` returning the part, or "

--- a/Tests/CoreTests/Testability/ExtractableTotalKernelStringLawTests.swift
+++ b/Tests/CoreTests/Testability/ExtractableTotalKernelStringLawTests.swift
@@ -148,4 +148,68 @@ struct ExtractableTotalKernelStringLawTests {
 
         #expect(issue.message.contains("rebuilding the whole from the root"))
     }
+
+    // MARK: - The arithmetic arm does not claim a tiling it cannot see
+
+    @Test("a threshold comparison is not told the parts tile the whole")
+    func thresholdGetsTheComparisonLaw() throws {
+        // `GitCloneHelper.listSwiftFiles`. `maxFileSize` is a bound, and nothing is cut up.
+        let issue = try #require(analyze("""
+        func listSwiftFiles(in directory: URL) throws -> [URL] {
+            let enumerator = FileManager.default.enumerator(at: directory, includingPropertiesForKeys: nil)
+            let maxFileSize = 512 * 1_024
+            var found: [URL] = []
+            for case let fileURL as URL in enumerator! {
+                guard let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path) else { continue }
+                let size = (attrs[.size] as? Int) ?? 0
+                if size > maxFileSize { continue }
+                found.append(fileURL)
+            }
+            return found
+        }
+        """).first)
+
+        #expect(issue.message.contains("right AT the boundary"))
+        #expect(issue.message.contains("tile the whole") == false)
+        #expect(issue.message.contains("ceil(total / size)") == false)
+    }
+
+    @Test("a difference of two measurements is told it owes antisymmetry")
+    func differenceGetsTheComparisonLaw() throws {
+        // `SnapshotManager.computeDiff`. The law worth writing here is antisymmetry and a zero at
+        // equality; the bug worth catching is iterating one side's keys instead of the union, so a
+        // removed entry disappears from the diff instead of showing as negative.
+        let issue = try #require(analyze("""
+        func report(current summary: ProjectSummary, previous snapshot: ProjectSnapshot) throws {
+            let typeDelta = summary.totalTypes - snapshot.typeCount
+            let fileDelta = summary.totalFiles - snapshot.fileCount
+            if typeDelta != 0 || fileDelta != 0 {
+                let data = try Data(contentsOf: reportURL)
+                try data.write(to: reportURL, options: .atomic)
+            }
+        }
+        """).first)
+
+        #expect(issue.message.contains("ANTISYMMETRY"))
+        #expect(issue.message.contains("tile the whole") == false)
+    }
+
+    @Test("a real tiler still owes the tiling")
+    func slicingArithmeticKeepsTheTilingLaw() throws {
+        // The control. Without it the two above pass against a rule that has simply stopped
+        // stating the tiling law at all.
+        let issue = try #require(analyze("""
+        func upload(_ data: Data, chunkSize: Int) async throws {
+            let totalChunks = (data.count + chunkSize - 1) / chunkSize
+            var index = 0
+            while index < totalChunks {
+                _ = try await send(data.dropFirst(index * chunkSize).prefix(chunkSize))
+                index += 1
+            }
+        }
+        """).first)
+
+        #expect(issue.message.contains("tile the whole exactly"))
+        #expect(issue.message.contains("ceil(total / size)"))
+    }
 }

--- a/Tests/CoreTests/Testability/ExtractableTotalKernelVisitorTests.swift
+++ b/Tests/CoreTests/Testability/ExtractableTotalKernelVisitorTests.swift
@@ -223,7 +223,7 @@ struct ExtractableTotalKernelVisitorTests {
         """).first)
 
         let suggestion = try #require(issue.suggestion)
-        #expect(suggestion.contains("Extract the arithmetic into a value type"))
+        #expect(suggestion.contains("Extract the arithmetic into a free function or value type"))
         #expect(suggestion.contains("maps a part INDEX to its slice") == false)
     }
 

--- a/Tests/CoreTests/Testability/SeedRoleEmissionTests.swift
+++ b/Tests/CoreTests/Testability/SeedRoleEmissionTests.swift
@@ -160,6 +160,77 @@ struct SeedRoleEmissionTests {
         """) == nil)
     }
 
+    // MARK: - The message and the role must agree
+
+    private func kernelIssue(_ source: String) -> LintIssue? {
+        let visitor = ExtractableTotalKernelVisitor(patternCategory: .testability)
+        let syntax = Parser.parse(source: source)
+        visitor.setSourceLocationConverter(SourceLocationConverter(fileName: "S.swift", tree: syntax))
+        visitor.setFilePath("S.swift")
+        visitor.walk(syntax)
+        return visitor.detectedIssues.first { $0.ruleName == .extractableTotalKernel }
+    }
+
+    /// **The message states a law if and only if the role claims it.**
+    ///
+    /// These two came apart inside one type and stayed apart. `role` returned `nil` whenever
+    /// `hasSlicingArithmetic` was false — "I will not call this a partition" — while `law` fell
+    /// through to *"the parts should tile the whole exactly … `ceil(total / size)`"* on the same
+    /// branch. Measured over 26 repositories, **7 of 20 findings** were in that state: a size
+    /// threshold, a bounds check, a diff of two counts, a binary search. The seed manifest was
+    /// right and the sentence the reader acts on was wrong.
+    ///
+    /// Stated as a biconditional over one fixture per arm, because either direction alone passes
+    /// against a rule that has stopped claiming anything at all.
+    @Test func theLawAndTheRoleAgreeAboutWhatTheKernelIs() throws {
+        let fixtures: [(name: String, source: String)] = [
+            ("tiler", """
+            func upload(_ data: Data, chunkSize: Int) async throws {
+                let totalChunks = (data.count + chunkSize - 1) / chunkSize
+                var index = 0
+                while index < totalChunks {
+                    _ = try await send(data.dropFirst(index * chunkSize).prefix(chunkSize))
+                    index += 1
+                }
+            }
+            """),
+            ("threshold", """
+            func listSwiftFiles(in directory: URL) throws -> [URL] {
+                let enumerator = FileManager.default.enumerator(at: directory, includingPropertiesForKeys: nil)
+                let maxFileSize = 512 * 1_024
+                var found: [URL] = []
+                for case let fileURL as URL in enumerator! {
+                    guard let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path) else { continue }
+                    let size = (attrs[.size] as? Int) ?? 0
+                    if size > maxFileSize { continue }
+                    found.append(fileURL)
+                }
+                return found
+            }
+            """),
+            ("path", """
+            func scanSync(rootPath: String) -> DirectoryNode {
+                let enumerator = FileManager.default.enumerator(atPath: rootPath)
+                let prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+                while let item = enumerator?.nextObject() as? String {
+                    let relativePath = item.hasPrefix(prefix) ? String(item.dropFirst(prefix.count)) : item
+                    let dirName = (relativePath as NSString).lastPathComponent
+                    if skipped.contains(dirName) { continue }
+                }
+                return root
+            }
+            """)
+        ]
+
+        for fixture in fixtures {
+            let issue = try #require(kernelIssue(fixture.source), "\(fixture.name) stopped firing")
+            let claimsTiling = issue.message.contains("tile the whole exactly")
+            let claimsRoot = issue.message.contains("rebuilding the whole from the root")
+            #expect(claimsTiling == (issue.role == .partition), "\(fixture.name): tiling vs .partition")
+            #expect(claimsRoot == (issue.role == .normalizer), "\(fixture.name): root vs .normalizer")
+        }
+    }
+
     // MARK: - How many rules classify, and which
 
     /// The third classifier, and the one this suite had no coverage for.


### PR DESCRIPTION
Found while working #205's findings, and it is the same defect one arm over.

## The contradiction

`role` returns `nil` whenever `hasSlicingArithmetic` is false — *"I will not call this a partition"* — while `law` fell through on the same branch to:

> the parts should tile the whole exactly — no gap, no overlap — and the count should be exactly `ceil(total / size)`

The seed manifest and the sentence the reader acts on disagreed **inside one type**, and the manifest was the one that was right.

## Measured

**7 of 20 findings** across the 26-repository corpus were in that state, and not one cuts anything up:

| site | what it derives | what it is |
|---|---|---|
| `GitCloneHelper.swift:67` | `512 * 1_024` against a file size | a threshold |
| `SnapshotManager.swift:81` | `summary.totalTypes - snapshot.typeCount` ×4 | a difference |
| `ToolInvocation.swift:115` | `index + 1` against `arguments.count` | a bounds check |
| `Enumeration.swift:147` | `(low + high + 1) / 2` | a binary search |
| `MLXRunCommand.swift:65` | — | — |
| `VerifyInteractionSurvey.swift:203` | — | — |
| `HTMLReportGenerator.swift:213` | — | — |

`ToolInvocation.requireValue` is the one that started this — a three-line bounds check being told it owes a partition.

`SnapshotManager.computeDiff` is the one that shows the cost. Its real law is **antisymmetry and a zero at equality**; its real hazard is iterating one side's keys instead of the union, so a removed entry vanishes from the diff rather than showing as negative. The tiling law names none of that, and a reader who followed it would have written `ceil(total / size)` over a diff.

## What that branch says now

> the derivation should be **TOTAL** — an answer for every input the types admit, including an empty collection, a zero bound, and a negative difference — and the decision it governs should be right **AT** the boundary, which is where the off-by-one lives: a value exactly equal to the bound, a count of zero, a count of one. If it is a difference of two measurements, it also owes **ANTISYMMETRY** — swapping the operands negates it — and zero when they agree.

**Corpus effect: no finding gained or lost.** 7 move from the tiling law to the boundary law; the 2 genuine tilers are exactly the 2 `.partition` seeds, and the 4 root-law findings are exactly the 4 `.normalizer` seeds.

## What a reviewer should scrutinise

1. **The agreement is now a law rather than a coincidence.** `theLawAndTheRoleAgreeAboutWhatTheKernelIs` asserts the biconditional over one fixture per arm — the message states the tiling law **iff** the role is `.partition`, the root law **iff** it is `.normalizer`. Stated both ways deliberately: either direction alone passes against a rule that has stopped claiming anything at all.
2. **The generic `suggestion` fallback changed too.** It said *"asks the value type where the bytes are"* — tiler language, reached by both the fraction-only and comparison-only shapes. It now says "asks the value type for the answer" and names why the extraction helps (the boundary cases become generatable). One existing assertion was updated to match.
3. **Whether "antisymmetry" belongs in a law sentence that also covers thresholds and bounds checks.** It is conditional (*"if it is a difference of two measurements"*), which is the same hedging the string arm uses, and for the same reason: the gate cannot tell the shapes apart. If you would rather split the arm again on whether the arithmetic is a subtraction of two same-typed measurements, that is a further gate and needs its own measurement.

3727 tests in 446 suites pass. `swiftlint` unchanged at 25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeZ6uZMfPc3bgznF69r98K