### PR TITLE
Carry the skipped-package scope in the seed manifest, and fix the hint

### DIFF
--- a/Sources/CLI/SwiftProjectLintCLI.swift
+++ b/Sources/CLI/SwiftProjectLintCLI.swift
@@ -202,6 +202,13 @@ struct SwiftProjectLintCLI: AsyncParsableCommand {
         selectedCategories: [PatternCategory]?,
         skippedNestedPackages: [String] = []
     ) -> String {
+        // `pbt-seeds` is a machine channel and the only one a consumer reads, so the skip has to
+        // travel as DATA. The text formatter's caveat and stderr's notice both reach a human and
+        // neither reaches `swift-infer discover --seeds`, which is the thing that acts on the file.
+        guard format != .pbtSeeds else {
+            return PBTSeedsFormatter(skippedNestedPackages: skippedNestedPackages)
+                .format(issues: issues)
+        }
         guard format == .text else {
             return format.formatter.format(issues: issues)
         }

--- a/Sources/Core/Export/PBTSeedsFormatter.swift
+++ b/Sources/Core/Export/PBTSeedsFormatter.swift
@@ -213,9 +213,50 @@ public struct PBTSeedManifest: Codable, Sendable {
     public let version: Int
     public let seeds: [PBTSeed]
 
-    public init(seeds: [PBTSeed], version: Int = Self.currentVersion) {
+    /// First-party packages this run did **not** analyse, so the manifest is short by whatever they
+    /// hold.
+    ///
+    /// The text output has said this since #95, and stderr has said it for longer. Neither reaches
+    /// a consumer: `swift-infer discover --seeds` reads the JSON and nothing else, so a manifest
+    /// missing 103 of 149 candidates was indistinguishable from a complete one. Measured on
+    /// SwiftFormatRuleStudio, where the default run seeds 46 and `--include-nested-packages` seeds
+    /// 149 — 69% absent, and 100% of the library's.
+    ///
+    /// Encoded only when non-empty, so a run that analysed everything writes a byte-identical
+    /// manifest to one written before this field existed. That is what lets it ship without a
+    /// version bump, on the same terms as `role`, `restriction` and `effect`.
+    public let skippedPackages: [String]
+
+    public init(
+        seeds: [PBTSeed],
+        version: Int = Self.currentVersion,
+        skippedPackages: [String] = []
+    ) {
         self.version = version
         self.seeds = seeds
+        self.skippedPackages = skippedPackages
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.version = try container.decode(Int.self, forKey: .version)
+        self.seeds = try container.decode([PBTSeed].self, forKey: .seeds)
+        self.skippedPackages = try container.decodeIfPresent([String].self, forKey: .skippedPackages) ?? []
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(version, forKey: .version)
+        try container.encode(seeds, forKey: .seeds)
+        if !skippedPackages.isEmpty {
+            try container.encode(skippedPackages, forKey: .skippedPackages)
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case seeds
+        case skippedPackages
     }
 
     /// The schema version emitted by this build.
@@ -351,7 +392,13 @@ public struct PBTSeedsFormatter: IssueFormatterProtocol {
         return counts.isEmpty ? nil : DroppedSeedReport(countsByRule: counts)
     }
 
-    public init() { /* no-op */ }
+    /// Packages this run skipped, written into the manifest so a consumer can know the file is
+    /// partial. Defaulted, so every existing construction site is unchanged.
+    private let skippedNestedPackages: [String]
+
+    public init(skippedNestedPackages: [String] = []) {
+        self.skippedNestedPackages = skippedNestedPackages
+    }
 
     public func format(issues: [LintIssue]) -> String {
         let seeds: [PBTSeed] = issues.compactMap { issue in
@@ -372,7 +419,7 @@ public struct PBTSeedsFormatter: IssueFormatterProtocol {
             )
         }
 
-        let manifest = PBTSeedManifest(seeds: seeds)
+        let manifest = PBTSeedManifest(seeds: seeds, skippedPackages: skippedNestedPackages)
 
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]

--- a/Sources/Core/Export/TextFormatter.swift
+++ b/Sources/Core/Export/TextFormatter.swift
@@ -91,8 +91,13 @@ public struct TextFormatter: IssueFormatterProtocol {
             "  They are an inventory of what COULD be property-tested — a pure function is not a "
                 + "defect, and there is nothing to fix per line.",
             "  See them:  --categories testability",
-            "  Use them:  --format pbt-seeds > .pbt/seeds.json   "
-                + "(then `swift-infer discover --seeds .pbt/seeds.json`)"
+            // `discover` requires exactly one of --target / --sources in addition to --seeds, so
+            // the command as printed used to fail: "no `Sources/` here, so there is no layout to
+            // infer." Its error is a good one — it names the fix and says why guessing would be
+            // worse — but a hint that sends a reader into an error is a hint that was not run.
+            "  Use them:  --format pbt-seeds > .pbt/seeds.json",
+            "             then `swift-infer discover --seeds .pbt/seeds.json --target <Target>`",
+            "             (or --sources <dir> for an Xcode project, which has no SwiftPM target)"
         ]
     }
 

--- a/Tests/CLITests/PBTSeedsFormatterTests.swift
+++ b/Tests/CLITests/PBTSeedsFormatterTests.swift
@@ -229,4 +229,41 @@ struct PBTSeedsFormatterTests {
         // draws the boundary. Narrowing to it would report a confident zero.
         #expect(manifest.analysableSeeds.isEmpty)
     }
+
+    // MARK: - Skipped-package scope (#95)
+
+    /// The manifest is the only channel a consumer reads, so a partial run must say so **in the
+    /// JSON**. The text caveat and the stderr notice both reach a human and neither reaches
+    /// `swift-infer discover --seeds`, which is the thing that acts on the file.
+    @Test func aPartialRunNamesTheSkippedPackagesInTheManifest() throws {
+        let json = PBTSeedsFormatter(skippedNestedPackages: ["Core", "Extras"])
+            .format(issues: [candidate(symbol: "add")])
+        let manifest = try JSONDecoder().decode(PBTSeedManifest.self, from: Data(json.utf8))
+
+        #expect(manifest.skippedPackages == ["Core", "Extras"])
+        #expect(manifest.seeds.count == 1, "the seeds themselves are unaffected")
+    }
+
+    /// A complete run writes a manifest byte-identical to one written before the field existed.
+    /// That is the whole compatibility argument for shipping it without a version bump, so it is
+    /// asserted on the text rather than on the decoded value — an empty array that encodes as
+    /// `"skippedPackages": []` would decode equal and still break an older consumer's expectations.
+    @Test func aCompleteRunWritesNoSkippedPackagesKeyAtAll() throws {
+        let json = PBTSeedsFormatter().format(issues: [candidate(symbol: "add")])
+
+        #expect(!json.contains("skippedPackages"))
+        let manifest = try JSONDecoder().decode(PBTSeedManifest.self, from: Data(json.utf8))
+        #expect(manifest.skippedPackages.isEmpty)
+        #expect(manifest.version == PBTSeedManifest.currentVersion)
+    }
+
+    /// A manifest written before this field existed still decodes, with the absence read as
+    /// "nothing was skipped" rather than as a parse error.
+    @Test func aManifestWithoutTheKeyStillDecodes() throws {
+        let legacy = #"{"version":2,"seeds":[]}"#
+        let manifest = try JSONDecoder().decode(PBTSeedManifest.self, from: Data(legacy.utf8))
+
+        #expect(manifest.skippedPackages.isEmpty)
+        #expect(manifest.version == 2)
+    }
 }


### PR DESCRIPTION
Closes the two halves of #95 that were still open. Companion to SwiftInferProperties#425, which landed first.

## Why the earlier fixes did not close it

Suggestions 1 and 2 shipped: the summary line and the candidate-inventory line both name the skipped package now. Both remaining items are on the **machine** side of the hand-off, and that is the whole point — `swift-infer discover --seeds` reads the JSON and nothing else. It does not read the summary line, and it does not read stderr.

Re-measured on `SwiftFormatRuleStudio`, the subject #95 used:

| | seeds | App | Core |
|---|---|---|---|
| default | **46** | 46 | **0** |
| `--include-nested-packages` | **149** | 46 | 103 |

**103 absent, 69%** — worse than the 66% reported — and 100% of the library's. A manifest two thirds short was indistinguishable from a complete one.

## What changed

`PBTSeedManifest` gains `skippedPackages`. `PBTSeedsFormatter` takes the list; `render` special-cases `pbt-seeds` to pass it, because every non-`.text` format went through a stateless `format.formatter` with nowhere to put it.

And the printed hint is now runnable. It was `swift-infer discover --seeds .pbt/seeds.json`, which dies with *"no `Sources/` here, so there is no layout to infer"* — `discover` requires one of `--target`/`--sources` as well. Its error is a good one; a hint that sends a reader into it is not.

## What a reviewer should scrutinise

**The encode-only-when-non-empty rule, which is the compatibility argument.** A run that analysed everything must write a manifest byte-identical to one written before this field existed — that is what lets it ship without a version bump, on the same terms as `role`, `restriction` and `effect`. The test asserts it on the **text**, because an empty array encoding as `"skippedPackages": []` would decode equal and still break the claim for an older consumer.

**That the consumer landed first, and why it had to.** Shipping this alone would make the field write-only — the failure SwiftInferProperties already paid for when `restriction` shipped here on 2026-08-03 and sat unread there for three days. Worse, that repo's parity guard would not have caught it: it enumerates the keys of a *seed* and the keys inside `effect`, never the manifest's own. Verified by handing `discover --seeds` a manifest with two invented top-level keys — **both silently ignored**. #425 closes that level before this field arrives.

**Whether the default should flip** is still not decided here, which #95 explicitly left open. This makes the default's cost legible to the consumer rather than arguing about the default.

## Verification

- `swift test` — **3,730 tests, 446 suites, passing**
- `swiftlint` — exit 0 on all changed files
- End-to-end: default run emits `skippedPackages: ["SwiftFormatRuleStudioCore"]`; `--include-nested-packages` omits the key entirely at 149 seeds; `discover` reads it and warns, naming the package; a legacy `{"version":2,"seeds":[]}` still decodes with the absence read as "nothing skipped"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015C8BjaXXCA5DGkQCARErGL