### PR TITLE
Stop returning "no filtering" from a configuration that filters

### DIFF
--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/LintConfiguration.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/LintConfiguration.swift
@@ -151,9 +151,11 @@ public struct LintConfiguration: Sendable {
             return cliRuleIdentifiers
         }
 
-        var rules = Set(RuleIdentifier.allCases)
-        rules.remove(.unknown)
-        rules.remove(.fileParsingError)
+        // `selectableRules` is `allCases` minus the sentinels, and it exists so that the
+        // definition of "a rule" is written once — its own doc records the README disagreeing
+        // with the code by a quarter when it was re-derived inline. This was one of the sites
+        // re-deriving it.
+        var rules = RuleIdentifier.selectableRules
 
         // enabled_only restricts to a specific set
         if let enabledOnly = enabledOnlyRules {
@@ -172,10 +174,19 @@ public struct LintConfiguration: Sendable {
             rules = rules.filter { cliCategories.contains($0.category) }
         }
 
-        // nil means "no filtering" — return nil if we haven't actually restricted anything
-        let allRules = RuleIdentifier.selectableRules
-            .subtracting(Self.optInRules)
-        if rules == allRules, cliCategories == nil {
+        // `nil` means "no filtering" to the caller — `ProjectLinter` passes it straight through
+        // as `ruleIdentifiers`, where a nil runs every registered rule. So it may only be
+        // returned when the resolved set really is every selectable rule.
+        //
+        // It used to compare against `selectableRules.subtracting(Self.optInRules)` — a set that
+        // has already had the opt-in rules removed — so the test was true **precisely when the
+        // set had been restricted**, by removing them, and the caller then ran the 25 rules it
+        // was meant to exclude. A Swift-package root was immune only by accident:
+        // `ProjectLinter+FileAnalysis` rebuilds the configuration with `.publicInAppTarget`
+        // disabled, and that one insertion was enough to make the comparison false. An
+        // Xcode-project root got no such rebuild and ran every opt-in rule by default —
+        // 62% of one subject's findings (#217).
+        if rules == RuleIdentifier.selectableRules, cliCategories == nil {
             return nil
         }
 

--- a/Tests/CoreTests/Configuration/LintConfigurationTests.swift
+++ b/Tests/CoreTests/Configuration/LintConfigurationTests.swift
@@ -7,11 +7,20 @@ struct LintConfigurationTests {
 
     // MARK: - resolveRules
 
+    /// The default configuration **is** restricted: it removes the 25 opt-in rules. `nil` means
+    /// "no filtering" to `ProjectLinter`, so returning it here ran every opt-in rule by default
+    /// on any project whose root is not a Swift package (#217).
+    ///
+    /// This asserted `nil` and passed for as long as the defect existed.
     @Test
-    func testDefaultConfigReturnsNil() {
+    func testDefaultConfigIsRestrictedToNonOptInRules() throws {
         let config = LintConfiguration.default
-        let rules = config.resolveRules()
-        #expect(rules == nil, "Default config should return nil (no filtering)")
+        let rules = try #require(
+            config.resolveRules(),
+            "the default config removes the opt-in rules, so it must not report 'no filtering'"
+        )
+        #expect(Set(rules) == RuleIdentifier.selectableRules.subtracting(LintConfiguration.optInRules))
+        #expect(Set(rules).isDisjoint(with: LintConfiguration.optInRules))
     }
 
     @Test

--- a/Tests/CoreTests/Configuration/RuleResolutionLawsTests.swift
+++ b/Tests/CoreTests/Configuration/RuleResolutionLawsTests.swift
@@ -67,20 +67,38 @@ struct RuleResolutionLawsTests {
 
     /// **L6.6 — `nil` means exactly "nothing was restricted".**
     ///
-    /// The duplicated-expression law described above. A default configuration
-    /// with no CLI narrowing must return `nil`; any configuration that *does*
-    /// narrow must not.
+    /// The law is unchanged; what changed is the answer for the default configuration, which
+    /// **does** restrict — it removes the 25 opt-in rules, as `expectedDefaultSet` above has
+    /// always said. So it must not return `nil`.
+    ///
+    /// It used to, and this test asserted it. The comment on the next law states the hazard
+    /// exactly — *"a `nil` here would mean 'run everything'"* — having reasoned it through for
+    /// disabled rules and not for the opt-in rules the same function removes. On any project
+    /// whose root is not a Swift package, every opt-in rule ran by default: 62% of one subject's
+    /// findings (#217).
     @Test
-    func defaultConfigurationIsUnrestricted() {
-        #expect(LintConfiguration.default.resolveRules() == nil)
+    func theDefaultConfigurationIsRestrictedToNonOptInRules() throws {
+        let resolved = try #require(
+            LintConfiguration.default.resolveRules(),
+            "the default configuration removes the opt-in rules, so it restricts"
+        )
+        #expect(Set(resolved) == Self.expectedDefaultSet)
 
-        // And the two spellings agree on *what* the default set is: asking for
-        // every category explicitly forces the non-nil branch, and that answer
-        // must equal the independently-stated reference set.
+        // Both spellings agree on *what* the default set is: asking for every category
+        // explicitly must give the same answer as asking for none.
         let viaCategories = LintConfiguration.default.resolveRules(
             cliCategories: PatternCategory.allCases
         )
         #expect(Set(viaCategories ?? []) == Self.expectedDefaultSet)
+    }
+
+    /// The other half of L6.6, and the half that has no caller today: `nil` is still reachable,
+    /// and still means "every selectable rule". Without this the fix would read as "never return
+    /// nil", which is a different contract from the one the law states.
+    @Test
+    func nilIsReturnedOnlyWhenNothingWasRemoved() {
+        let everything = LintConfiguration(enabledOnlyRules: RuleIdentifier.selectableRules)
+        #expect(everything.resolveRules() == nil)
     }
 
     /// Any non-empty `disabledRules` genuinely restricts, so the result must be
@@ -94,8 +112,9 @@ struct RuleResolutionLawsTests {
             let resolved = LintConfiguration(disabledRules: disabled).resolveRules()
 
             if effective.isEmpty {
-                // Disabling only opt-in or sentinel rules changes nothing.
-                #expect(resolved == nil)
+                // Disabling only opt-in or sentinel rules changes nothing — but the default
+                // set is itself restricted, so the answer is that set rather than `nil`.
+                #expect(Set(try #require(resolved)) == Self.expectedDefaultSet)
             } else {
                 let result = try #require(resolved)
                 #expect(Set(result) == Self.expectedDefaultSet.subtracting(effective))

--- a/Tests/CoreTests/Export/CarrierSeedTests.swift
+++ b/Tests/CoreTests/Export/CarrierSeedTests.swift
@@ -45,7 +45,15 @@ struct CarrierSeedTests {
             )
         }
         let system = PatternRegistryFactory.createConfiguredSystem()
-        return await ProjectLinter().analyzeProject(at: root.path, detector: system.detector)
+        // `primitiveNamedForItsDomainType` is opt-in, so a default run does not include it and
+        // this fixture would find nothing. It used to be reached anyway, because `resolveRules`
+        // returned "no filtering" for a default configuration and every opt-in rule ran (#217).
+        // Naming the rule is what this suite always meant; relying on the default was the bug.
+        return await ProjectLinter().analyzeProject(
+            at: root.path,
+            ruleIdentifiers: [.primitiveNamedForItsDomainType, .primitiveBypassingItsDomainType],
+            detector: system.detector
+        )
     }
 
     @Test("the finding names the domain type as its symbol")


### PR DESCRIPTION
Closes #217.

## What was wrong

`resolveRules` computed the correct rule set — every selectable rule minus the 25 in `optInRules` — and then **discarded it**:

```swift
let allRules = RuleIdentifier.selectableRules
    .subtracting(Self.optInRules)
if rules == allRules, cliCategories == nil { return nil }
```

`allRules` has already had the opt-in rules removed, so `rules == allRules` was true **precisely when the set had been restricted** — by removing them. The comment says *"if we haven't actually restricted anything"*; the condition tested the opposite. `ProjectLinter` passes the result through as `ruleIdentifiers`, and a `nil` there is no filter at all.

**A Swift-package root was immune by accident.** `ProjectLinter+FileAnalysis` rebuilds the configuration for package projects with `.publicInAppTarget` disabled, and that single insertion made the comparison false — so the explicit array was returned and the gate worked. An Xcode-project root gets no such rebuild. **8 of the 18 repositories in the corpus have one.**

## Measured

`SwiftUMLStudio` (Xcode root), default run:

| | before | after |
|---|---|---|
| issues | 2,778 | **1,220** |
| tagged findings | 2,498 | 940 |
| **from opt-in rules** | **1,558 (62%)** | **0** |
| `Test Missing Require` | 1,354 | 0 |

Two-arm fixture, whose only difference is whether a `Package.swift` sits at the analysed root: **0** with, **2** without. Both are 0 after.

## What a reviewer should scrutinise

**That the fix does not simply disable 25 rules.** `nil` is still reachable and still means "every selectable rule" — a new law pins it, so the change cannot be read as "never return `nil`". And the control that matters: with `enabled_only: ["Test Missing Require"]` the rule **fires**, while a default run on the same fixture reports 0.

**The three tests that asserted the old behaviour.** They are corrected, not deleted, and this is the part worth reading:

`RuleResolutionLawsTests` states the law as **"`nil` means exactly 'nothing was restricted'"** — which is right. What was wrong is the premise that a default configuration restricts nothing. The same file already defined

```swift
private static let expectedDefaultSet =
    Set(RuleIdentifier.allCases).subtracting(sentinels)
        .subtracting(LintConfiguration.optInRules)
```

and the comment on the very next law states the hazard exactly: *"A `nil` here would mean 'run everything' — the disabled rules would come back to life."* It had reasoned that through for **disabled** rules and not for the **opt-in** rules the same function removes. The suite contained its own refutation.

`CarrierSeedTests` exercises `primitiveNamedForItsDomainType`, itself opt-in, and reached it only through this defect. It now names the rules it exercises — which is what it always meant.

**What this reframes, and what it does not.** #109 reports `Test Missing Require` at 1,341 findings (47% of a run); that rule is opt-in and should have contributed **zero**. The same applies to #110 and to `Hardcoded Strings`. Each remains a real observation about its rule *when deliberately enabled* — #109's narrowing case in particular measures 13,194 findings against 226 corpus-wide — but their volumes were a symptom of this, not of the rules.

## Verification

- `swift test` — **3,731 tests, 446 suites, passing**
- `swiftlint` — exit 0 on all changed files
- Default run, package root: unchanged (0 opt-in findings before and after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015C8BjaXXCA5DGkQCARErGL