### PR TITLE
Stop reading an implicit return as a discarded result

### DIFF
--- a/Docs/rules/map-used-for-side-effects.md
+++ b/Docs/rules/map-used-for-side-effects.md
@@ -10,7 +10,18 @@
 `map`, `compactMap`, and `flatMap` return a transformed collection. Using them as bare statements throws that collection away, making the transformation meaningless. This is almost always a `forEach` mistake — common in AI-generated code and among developers from imperative languages.
 
 ### Discussion
-`MapUsedForSideEffectsVisitor` visits every `FunctionCallExprSyntax`. It fires when the callee is a member access named `map`, `compactMap`, or `flatMap` and the call is the direct item of a `CodeBlockItemSyntax` — meaning the result is not assigned, returned, or passed anywhere.
+`MapUsedForSideEffectsVisitor` visits every `FunctionCallExprSyntax`. It fires when the callee is a member access named `map`, `compactMap`, or `flatMap`, the call is the direct item of a `CodeBlockItemSyntax`, **and that item is not an implicit return**.
+
+That last clause is load-bearing and was missing. A bare statement is a `CodeBlockItem` — but so is the sole expression of a body that returns it, and Swift code omitting `return` is the common case rather than the exception. Without the check the rule fired on the ordinary shape: 38 findings across five repositories, **all 38 false positives**.
+
+An item is an implicit return when it is the *sole* statement of its block (a statement among several cannot be one, since Swift admits the implicit form only for a single expression) and the block belongs to:
+
+- a function with a return clause — `func f() -> [T] { items.map { … } }`
+- a getter, in either spelling
+- a closure — the expected type is not knowable from syntax, so this errs toward silence
+- an `if` / `switch` **expression** branch, which defers to wherever the `if`/`switch` itself sits
+
+`func f() { items.map { … } }` — a sole statement in a body returning nothing — is still flagged. That is the case the rule exists for.
 
 `filter`, `reduce`, `sorted`, and other non-transform methods are not flagged.
 
@@ -21,6 +32,12 @@ let names = users.map { $0.name }          // result captured
 return items.compactMap { $0.value }       // result returned
 
 items.forEach { save($0) }                 // correct API for side effects
+
+func doubled(_ items: [Int]) -> [Int] {    // implicit return — the result IS the value
+    items.map { $0 * 2 }
+}
+
+var doubled: [Int] { items.map { $0 * 2 } }   // implicit return from a getter
 ```
 
 ### Violating Examples
@@ -30,6 +47,14 @@ items.map { save($0) }                     // result thrown away — use forEach
 users.compactMap { $0.profile }            // result discarded
 
 nodes.flatMap { $0.children }              // result never used
+
+func f(_ items: [Int]) {                   // sole statement, but nothing is returned
+    items.map { save($0) }
+}
+
+if flag {                                  // a branch of an if STATEMENT, not an expression
+    items.map { save($0) }
+}
 ```
 
 ---

--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Suppression/SuppressionAudit.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Suppression/SuppressionAudit.swift
@@ -37,10 +37,11 @@ public enum SuppressionAudit {
     /// **Two linters disagree about this body and SwiftLint wins**, because it is
     /// the pre-commit gate. SwiftProjectLint's own `Map Used For Side Effects`
     /// reports the implicitly-returned `flatMap` here as a discarded result;
-    /// SwiftLint's `implicit_return` rejects the explicit `return` that silences
-    /// it. The SwiftProjectLint rule is wrong — it cannot see that a lone
-    /// expression in a body *is* the return value — and the two findings this
-    /// leaves are tracked rather than worked around.
+    /// This carried a note that `Map Used For Side Effects` was wrong here — that it could not
+    /// see a lone expression in a body *is* the return value — and that the two findings it left
+    /// were tracked rather than worked around, because SwiftLint's `implicit_return` rejects the
+    /// explicit `return` that would have silenced them. The rule now makes that distinction
+    /// (#107), so the findings are gone and there is nothing left to track.
     public static func unrecognizedNames(in fileContent: String, filePath: String) -> [UnrecognizedSuppressionName] {
         InlineSuppressionParser.parse(fileContent: fileContent).flatMap { directive in
             directive.unrecognizedNames.map { name in

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/MapUsedForSideEffects.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/PatternRegistrars/MapUsedForSideEffects.swift
@@ -15,7 +15,8 @@ struct MapUsedForSideEffects: PatternRegistrarProtocol {
                 + "or assign the result to a variable.",
             description: "Detects map, compactMap, and flatMap calls used as bare statements "
                 + "where the transformed collection is immediately discarded. Almost always a "
-                + "mistake — use forEach for side effects."
+                + "mistake — use forEach for side effects. An implicit return is not a discard "
+                + "and is not flagged."
         )
     }
 }

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/MapUsedForSideEffectsVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/MapUsedForSideEffectsVisitor.swift
@@ -14,6 +14,13 @@ import SwiftSyntax
 /// - `let results = items.map { … }` — result captured
 /// - `return items.map { … }` — result returned
 /// - `items.forEach { … }` — correct API for side effects
+/// - `func f() -> [T] { items.map { … } }` — **implicit return**
+///
+/// The implicit-return case is the one this rule got wrong, and it was 8 of 8 findings on one
+/// subject (#107). The discard test was `node.parent?.is(CodeBlockItemSyntax.self)`, and a bare
+/// statement is a `CodeBlockItem` — but so is the sole expression of a body that returns it.
+/// Swift code omitting `return` is the common case, not the exception, so the rule fired on the
+/// normal shape and stayed silent about nothing.
 final class MapUsedForSideEffectsVisitor: BasePatternVisitor {
 
     private static let transformMethodNames: Set<String> = ["map", "compactMap", "flatMap"]
@@ -28,8 +35,9 @@ final class MapUsedForSideEffectsVisitor: BasePatternVisitor {
             return .visitChildren
         }
 
-        // Result discarded — the call is a bare statement
-        guard node.parent?.is(CodeBlockItemSyntax.self) == true else {
+        // Result discarded — the call is a bare statement whose value goes nowhere.
+        guard let item = node.parent?.as(CodeBlockItemSyntax.self),
+              !Self.valueIsUsed(of: item) else {
             return .visitChildren
         }
 
@@ -45,5 +53,74 @@ final class MapUsedForSideEffectsVisitor: BasePatternVisitor {
         )
 
         return .visitChildren
+    }
+
+    /// Whether the value of `item` is the result of the body that holds it — an implicit return.
+    ///
+    /// The first question is the cheap one and it settles most cases: **a statement among several
+    /// cannot be an implicit return.** Swift admits the implicit form only for a body whose sole
+    /// statement is an expression, and that is true of `if`/`switch` expression branches too.
+    ///
+    /// Where the sole statement *is* the body, the answer depends on what owns it:
+    ///
+    /// - a **closure** — the value is its result. The expected type is not knowable from syntax
+    ///   alone (a `() -> Void` closure really does discard it), so this errs toward silence. That
+    ///   is the right side for a rule whose message asserts a mistake.
+    /// - a **getter**, in either spelling — the value is the property's.
+    /// - a **function** — only when it returns something. `func f() { items.map { … } }` is the
+    ///   true positive this rule exists for, and it survives.
+    /// - an **`if` / `switch` branch** — undecidable here, so it defers to wherever the
+    ///   `if`/`switch` itself sits. That recursion is what stops
+    ///   `func f() -> [T] { if c { a.map { … } } else { [] } }` from being the same false positive
+    ///   one level down.
+    private static func valueIsUsed(of item: CodeBlockItemSyntax) -> Bool {
+        guard let list = item.parent?.as(CodeBlockItemListSyntax.self),
+              list.count == 1,
+              let owner = list.parent else {
+            return false
+        }
+
+        // A closure body and a shorthand getter hold their statements directly.
+        if owner.is(ClosureExprSyntax.self) || owner.is(AccessorBlockSyntax.self) { return true }
+        // A `switch` case holds them directly too, and defers to the `switch`.
+        if owner.is(SwitchCaseSyntax.self) { return deferToEnclosingExpression(of: owner) }
+
+        guard let block = owner.as(CodeBlockSyntax.self), let holder = block.parent else {
+            return false
+        }
+
+        if let function = holder.as(FunctionDeclSyntax.self) {
+            return function.signature.returnClause != nil
+        }
+        if let accessor = holder.as(AccessorDeclSyntax.self) {
+            return accessor.accessorSpecifier.tokenKind == .keyword(.get)
+        }
+        if holder.is(IfExprSyntax.self) {
+            return deferToEnclosingExpression(of: holder)
+        }
+        // An initializer, a deinitializer, a `for` body, a `do` block: the value goes nowhere.
+        return false
+    }
+
+    /// Whether an `if`/`switch` used as a value has its own value used — asked of whatever
+    /// encloses it, so a branch inherits the answer rather than guessing one.
+    private static func deferToEnclosingExpression(of node: Syntax) -> Bool {
+        var current: Syntax? = node
+        while let candidate = current {
+            if let item = candidate.as(CodeBlockItemSyntax.self) { return valueIsUsed(of: item) }
+            // Transparent wrappers on the way out. `ExpressionStmtSyntax` is the one that matters
+            // and the one this first missed: a bare `if` STATEMENT is an `IfExprSyntax` wrapped in
+            // an `ExpressionStmt`, so treating the wrapper as "somewhere a value is used" silenced
+            // `if flag { items.map { … } }` — a genuine discard, and the control fixture caught it.
+            guard candidate.is(ExpressionStmtSyntax.self) || candidate.is(SwitchCaseListSyntax.self)
+                    || candidate.is(SwitchExprSyntax.self) || candidate.is(IfExprSyntax.self)
+                    || candidate.is(CodeBlockItemListSyntax.self)
+            else {
+                // Anywhere else — an initializer clause, an argument — the value IS used.
+                return true
+            }
+            current = candidate.parent
+        }
+        return false
     }
 }

--- a/Tests/CoreTests/CodeQuality/MapUsedForSideEffectsVisitorTests.swift
+++ b/Tests/CoreTests/CodeQuality/MapUsedForSideEffectsVisitorTests.swift
@@ -83,4 +83,72 @@ struct MapUsedForSideEffectsVisitorTests {
         run(visitor2, source: "items.reduce(0) { $0 + $1 }")
         #expect(visitor2.detectedIssues.isEmpty)
     }
+
+    // MARK: - Implicit return (#107)
+
+    /// **The case that made 8 of 8 findings on one subject false positives.** A bare statement is
+    /// a `CodeBlockItem` and so is the sole expression of a body that returns it, and the rule
+    /// could not tell them apart — so it fired on the ordinary Swift shape that omits `return`.
+    ///
+    /// Nothing here distinguished the two before this, which is why the suite stayed green
+    /// through it.
+    @Test("No issue for an implicit return", arguments: [
+        "func doubled(_ items: [Int]) -> [Int] {\n    items.map { $0 * 2 }\n}",
+        "var doubled: [Int] {\n    items.map { $0 * 2 }\n}",
+        "var doubled: [Int] {\n    get { items.map { $0 * 2 } }\n}",
+        "func nested(_ items: [Int]) -> [[Int]] {\n    [items].map { $0.map { $1 } }\n}",
+        "func maybe(_ value: Int?) -> Int? {\n    value.map { $0 * 2 }\n}"
+    ])
+    func noIssueForImplicitReturn(source: String) {
+        let visitor = makeVisitor()
+        run(visitor, source: source)
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    /// An `if`/`switch` **expression** branch is an implicit return one level down, and defers to
+    /// where the `if`/`switch` itself sits rather than guessing.
+    @Test("No issue for an if/switch expression branch", arguments: [
+        "func pick(_ items: [Int], _ flag: Bool) -> [Int] {\n"
+            + "    if flag {\n        items.map { $0 * 2 }\n    } else {\n        []\n    }\n}",
+        "func pick(_ items: [Int], _ flag: Bool) -> [Int] {\n"
+            + "    switch flag {\n    case true: items.map { $0 * 2 }\n    case false: []\n    }\n}"
+    ])
+    func noIssueForExpressionBranch(source: String) {
+        let visitor = makeVisitor()
+        run(visitor, source: source)
+        #expect(visitor.detectedIssues.isEmpty)
+    }
+
+    /// The true positives the narrowing must not silence — every body shape where the value has
+    /// nowhere to go. The `if`-STATEMENT case is the one the first version of the fix broke: a
+    /// bare `if` is an `IfExprSyntax` inside an `ExpressionStmtSyntax`, and treating that wrapper
+    /// as "somewhere a value is used" made a genuine discard silent.
+    @Test("Still flags a genuine discard", arguments: [
+        "func f(_ items: [Int]) {\n    items.map { save($0) }\n}",
+        "init(_ items: [Int]) {\n    items.map { save($0) }\n}",
+        "func f(_ rows: [[Int]]) {\n    for row in rows {\n        row.map { save($0) }\n    }\n}",
+        "func f(_ items: [Int]) {\n    do {\n        items.map { save($0) }\n    }\n}",
+        "func f(_ items: [Int], _ flag: Bool) {\n    if flag {\n        items.map { save($0) }\n    }\n}"
+    ])
+    func stillFlagsAGenuineDiscard(source: String) {
+        let visitor = makeVisitor()
+        run(visitor, source: source)
+        #expect(visitor.detectedIssues.count == 1)
+    }
+
+    /// A statement among several cannot be an implicit return, whatever the body returns — Swift
+    /// admits the implicit form only for a sole expression. This is the cheap check that settles
+    /// most cases, and it must not be weakened into "the last statement counts".
+    @Test("Flags a discard beside other statements even when the body returns")
+    func flagsDiscardAmongStatementsInAReturningBody() {
+        let source = """
+        func f(_ items: [Int]) -> [Int] {
+            items.map { save($0) }
+            return []
+        }
+        """
+        let visitor = makeVisitor()
+        run(visitor, source: source)
+        #expect(visitor.detectedIssues.count == 1)
+    }
 }


### PR DESCRIPTION
Closes #107.

## What was wrong

The discard test was one line:

```swift
guard node.parent?.is(CodeBlockItemSyntax.self) == true else { return .visitChildren }
```

A bare statement is a `CodeBlockItem` — but so is the sole expression of a body that returns it. Swift code omitting `return` is the common case, so the rule fired on the ordinary shape.

## Measured, before and after

| repo | before | after |
|---|---|---|
| SwiftUMLStudio | 8 | **0** |
| SwiftProjectLint | 23 | **0** |
| SwiftLintRuleStudio | 5 | **0** |
| SwiftMarkdownWiki | 1 | **0** |
| SwiftFormatRuleStudio | 1 | **0** |

**38 of 38 were implicit returns.** Nothing had been suppressed to hide them — the rule appears in no suppression directive anywhere in the corpus, checked.

**Two of this repo's 23 sat under a comment that diagnosed the defect and chose to live with it:**

> SwiftLint's `implicit_return` rejects the explicit `return` that silences it. The SwiftProjectLint rule is wrong — it cannot see that a lone expression in a body *is* the return value — and the two findings this leaves are tracked rather than worked around.

That comment is now false and is replaced.

## What a reviewer should scrutinise

**The closure arm, which is a deliberate recall loss.** A closure's expected type is not knowable from syntax — a `() -> Void` closure really does discard the result — so sole-statement closure bodies are skipped. That is the right side to err on for a rule whose message asserts a mistake, but it is a choice, and `{ items.map { save($0) } }` passed to a `Void` closure is now silent.

**The `if`/`switch` deferral.** A branch defers to wherever the `if`/`switch` itself sits, which is what stops `func f() -> [T] { if c { a.map { … } } else { [] } }` from being the same false positive one level down. **The first version of this broke a true positive and the control fixture caught it**: a bare `if` *statement* is an `IfExprSyntax` wrapped in an `ExpressionStmtSyntax`, and treating that wrapper as "somewhere a value is used" silenced `if flag { items.map { … } }`.

**That the suite passed before this change and after it**, because nothing distinguished the two cases. Nine tests now do, in three groups: implicit returns silent, expression branches silent, and five genuine discards still flagged — void function, initializer, `for` body, `do` block, `if`-statement branch. A sixth pins that a discard *beside other statements* is flagged even in a body that returns, so the sole-statement check cannot later be weakened into "the last statement counts".

## Docs

Three places, because the false inference was stated as fact in the rule page's Discussion — *"the direct item of a `CodeBlockItemSyntax` — **meaning** the result is not assigned, returned, or passed anywhere"*. Updated there, in the registrar `description`, and in the stale comment above. The page gains the implicit-return shapes under Non-Violating and the sole-statement-in-a-`Void`-body shape under Violating.

## Verification

- `swift test` — **3,735 tests, 446 suites, passing**
- `swiftlint` — exit 0 on all changed files
- The issue's fixture: 4 findings before (1 true, 3 false), **1 after** — the true positive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015C8BjaXXCA5DGkQCARErGL