### PR TITLE
Require a hardcoded secret to have a value that could be one

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Security/Visitors/SecurityVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Security/Visitors/SecurityVisitor.swift
@@ -103,12 +103,15 @@ class SecurityVisitor: BasePatternVisitor {
               let stringLiteral = initializer.value.as(StringLiteralExprSyntax.self) else { return }
 
         let variableName = pattern.identifier.text
+        guard canHoldASecret(stringLiteral) else { return }
+
         let stringValue = extractStringValue(stringLiteral)
 
         if isPlaceholder(stringValue) { return }
         if isTestFile(), stringValue.count < 20 { return }
 
-        if Self.secretKeywords.contains(where: { variableName.localizedCaseInsensitiveContains($0) }) {
+        if Self.secretKeywords.contains(where: { variableName.localizedCaseInsensitiveContains($0) }),
+           !valueEchoesItsOwnName(stringValue, variableName: variableName) {
             reportHardcodedSecret(variableName: variableName, node: node)
             return
         }
@@ -173,10 +176,49 @@ class SecurityVisitor: BasePatternVisitor {
         )
     }
 
+    /// Whether this literal could hold a credential at all, judged on the literal rather than on
+    /// its text — which is the distinction the name-keyword arm below never makes.
+    ///
+    /// **Interpolation is decisive.** A secret is a fixed value; an interpolated literal is
+    /// computed per evaluation. `let token = "<<<\(tokens.count)>>>"` is a glob placeholder in a
+    /// brace-expansion parser, and it was the ONLY error in a 2,880-finding run — so under
+    /// `--threshold error` that single false positive decided the exit code, 2 against 0 (#111).
+    ///
+    /// It must be asked **before** `extractStringValue`, which drops interpolated segments: that
+    /// literal reaches the heuristics as `"<<<>>>"`, a string never written, with the evidence
+    /// that would exonerate it removed.
+    ///
+    /// There is deliberately **no minimum-length guard**, which was also proposed. A real
+    /// hardcoded password can be short — `"hunter2"` is seven characters and so is `"<<<0>>>"` —
+    /// so length cannot separate them and would buy quiet at the cost of the findings that matter.
+    private func canHoldASecret(_ literal: StringLiteralExprSyntax) -> Bool {
+        if literal.segments.contains(where: { $0.is(ExpressionSegmentSyntax.self) }) { return false }
+        // An empty literal is not a credential under any heuristic, the name match included.
+        return !extractStringValue(literal).isEmpty
+    }
+
+    /// The literal's static text. **Interpolated segments are dropped**, so callers must rule out
+    /// interpolation first — a partial string judged as a whole one is how `"<<<\(n)>>>"` became
+    /// `"<<<>>>"` and then a reported secret.
     private func extractStringValue(_ literal: StringLiteralExprSyntax) -> String {
         literal.segments.compactMap { segment -> String? in
             segment.as(StringSegmentSyntax.self)?.content.text
         }.joined()
+    }
+
+    /// Whether the value is a piece of its own variable's name — `let hashToken = "hash"`.
+    ///
+    /// The name-keyword arm reports without consulting the value, and `token`, `key`, `secret` and
+    /// `auth` are ordinary words in a parser, a lexer or a dictionary. This is the narrowest guard
+    /// that separates that vocabulary from a credential: **no secret is a substring of the name
+    /// that holds it.** `hashToken = "hash"` is the token identifying a hash function; it was an
+    /// `error` in SwiftInferProperties, found while fixing the interpolated case (#111).
+    ///
+    /// Narrow on purpose. `password = "hunter2"` is reported, because `hunter2` is nowhere in
+    /// `password` — which is the discrimination a length or wordiness test could not make.
+    private func valueEchoesItsOwnName(_ value: String, variableName: String) -> Bool {
+        guard !value.isEmpty else { return true }
+        return variableName.localizedCaseInsensitiveContains(value)
     }
 
     private func isPlaceholder(_ value: String) -> Bool {

--- a/Tests/CoreTests/Security/SecurityVisitorTests.swift
+++ b/Tests/CoreTests/Security/SecurityVisitorTests.swift
@@ -176,4 +176,105 @@ struct SecurityVisitorTests {
         let secretIss = allIssues.filter { $0.ruleName == .hardcodedSecret }
         #expect(secretIss.count == 1) // "token" keyword match
     }
+
+    // MARK: - Interpolation is not a secret (#111)
+
+    /// **A literal with interpolation has no fixed value, and a secret is a fixed value.**
+    ///
+    /// `let token = "<<<\\(tokens.count)>>>"` is a glob placeholder in a brace-expansion parser —
+    /// `<<<0>>>`, `<<<1>>>` — and `token` is the parser's vocabulary, not a credential. It was the
+    /// **only error** in a 2,880-finding run, so under `--threshold error` this single false
+    /// positive decided the exit code: 2 before, 0 after.
+    @Test
+    func ignoresInterpolatedValue() {
+        let issues = secretIssues("""
+        func expand(_ paths: inout String) {
+            let token = "<<<\\(tokens.count)>>>"
+            tokens[token] = "x"
+        }
+        """)
+        #expect(issues.isEmpty)
+    }
+
+    /// The name-keyword arm reports without consulting the value at all, so the interpolation
+    /// check has to come before it — and before `extractStringValue`, which drops interpolated
+    /// segments and would hand the later heuristics `"<<<>>>"`, a string that was never written.
+    @Test
+    func ignoresInterpolationEvenWhenTheNameIsASecretKeyword() {
+        for name in ["apiKey", "password", "secretKey", "accessToken"] {
+            let issues = secretIssues("""
+            func make(_ count: Int) -> String {
+                let \(name) = "prefix-\\(count)"
+                return \(name)
+            }
+            """)
+            #expect(issues.isEmpty, "\(name) holds an interpolated value")
+        }
+    }
+
+    @Test
+    func ignoresEmptyStringValue() {
+        let issues = secretIssues("""
+        struct Config {
+            let secret = ""
+        }
+        """)
+        #expect(issues.isEmpty)
+    }
+
+    /// **The reason there is no minimum-length guard**, which the issue also proposed. A real
+    /// hardcoded password can be short: `"hunter2"` is 7 characters and so is `"<<<0>>>"`, so
+    /// length cannot separate them. Interpolation can.
+    @Test
+    func stillFlagsAShortLiteralPassword() {
+        let issues = secretIssues("""
+        struct Config {
+            let password = "hunter2"
+        }
+        """)
+        #expect(issues.count == 1)
+    }
+
+    /// The value is a made-up token rather than a real-shaped provider key. An earlier draft used
+    /// Stripe's documentation example, and **GitHub Push Protection rejected the push of this very
+    /// file** — a hardcoded-secret test tripping a hardcoded-secret scanner. The name-keyword arm
+    /// fires on `apiKey` alone, so the prefix was never needed to exercise it.
+    @Test
+    func stillFlagsAFixedCredential() {
+        let issues = secretIssues("""
+        struct Config {
+            let apiKey = "Zm9vYmFyLWJheg1234567890"
+        }
+        """)
+        #expect(issues.count == 1)
+    }
+
+    /// **A credential is never a substring of the name that holds it.** `token`, `key`, `secret`
+    /// and `auth` are ordinary words in a parser or a lexer, and the name-keyword arm reports
+    /// without consulting the value at all — so `hashToken = "hash"`, the token identifying a hash
+    /// function, was an `error` in SwiftInferProperties.
+    @Test
+    func ignoresAValueThatEchoesItsOwnName() {
+        for (name, value) in [("hashToken", "hash"), ("authToken", "auth"), ("secretKey", "key")] {
+            let issues = secretIssues("""
+            struct Config {
+                let \(name) = "\(value)"
+            }
+            """)
+            #expect(issues.isEmpty, "\(name) = \"\(value)\" is vocabulary, not a credential")
+        }
+    }
+
+    /// The guard is narrow on purpose: `hunter2` appears nowhere in `password`, so it is still
+    /// reported. That is the discrimination a length or wordiness test could not make.
+    @Test
+    func stillFlagsAValueUnrelatedToItsName() {
+        let issues = secretIssues("""
+        struct Config {
+            let password = "hunter2"
+            let apiKey = "Zm9vYmFyLWJheg1234567890"
+        }
+        """)
+        #expect(issues.count == 2)
+    }
 }


### PR DESCRIPTION
Closes #111.

## What was wrong

The name-keyword arm reported **without consulting the value at all** — a variable called `token` was a finding whatever it held:

```swift
if Self.secretKeywords.contains(where: { variableName.localizedCaseInsensitiveContains($0) }) {
    reportHardcodedSecret(variableName: variableName, node: node)   // value never read
```

Two guards, both about the value rather than the name.

## 1. Interpolation

A secret is a fixed value; an interpolated literal is computed per evaluation. `let token = "<<<\(tokens.count)>>>"` is a glob placeholder in a brace-expansion parser — and it was the **only error in a 2,880-finding run** on SwiftUMLStudio.

| `--threshold error` | exit |
|---|---|
| before | **2** |
| after | **0** |

The check must come **before** `extractStringValue`, which drops interpolated segments: that literal reached the heuristics as `"<<<>>>"`, a string never written. The extraction discarded the very evidence that proves it is not a secret.

## 2. A value that echoes its own name

Found by sweeping the corpus after the first fix, not from the issue:

```swift
/// The token that identifies a hash function.
public static let hashToken = "hash"
```

An `error` in SwiftInferProperties. No interpolation, non-empty — the first guard does not reach it. **No credential is a substring of the name that holds it**, which is the narrowest rule that separates a parser's vocabulary from a secret. This is the issue's deeper point (*"`token`, `key`, `secret` and `auth` are all ordinary words in a parser"*) given a concrete, low-risk form.

## What a reviewer should scrutinise

**The declined minimum-length guard.** The issue proposed it; `password = "hunter2"` is seven characters and so is `"<<<0>>>"`, so length cannot separate them — it would buy quiet at the cost of the findings that matter. Both shipped guards are about what the value *is*. A test pins `hunter2` still being reported.

**Whether the self-name guard is too broad.** It skips `secretKey = "key"` as well as `hashToken = "hash"`. I judged that right — a literal that is part of its own name is vocabulary — but it is the judgement most worth a second opinion. `password = "hunter2"` and `apiKey = "…"` are unaffected, and a test asserts both.

**Entropy, key-prefix and placeholder heuristics are untouched.** They already judged the value and were never the problem.

## One thing worth knowing

**GitHub Push Protection rejected the first push of this branch** — a hardcoded-secret test tripping a hardcoded-secret scanner. My fixture used Stripe's documentation example key, which GitHub recognises as a Stripe API Key. I replaced it with a made-up token rather than allowlisting the secret: the name-keyword arm fires on `apiKey` alone, so the realistic prefix was never needed to exercise the test. The note is at the test so the next person does not reach for a real-shaped key either.

## Verification

- `swift test` — **3,755 tests, 447 suites, passing** (7 new)
- `swiftlint` — exit 0
- SwiftUMLStudio: 1 error → 0; `--threshold error` 2 → 0
- Fixture covering a fixed credential, a short literal password, an interpolated value, a self-name echo, and an empty literal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015C8BjaXXCA5DGkQCARErGL