### PR TITLE
Compare a secret against its own name ignoring separators

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Security/Visitors/SecurityVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Security/Visitors/SecurityVisitor.swift
@@ -218,7 +218,20 @@ class SecurityVisitor: BasePatternVisitor {
     /// `password` — which is the discrimination a length or wordiness test could not make.
     private func valueEchoesItsOwnName(_ value: String, variableName: String) -> Bool {
         guard !value.isEmpty else { return true }
-        return variableName.localizedCaseInsensitiveContains(value)
+        // Separators are spelling, not meaning: a Keychain account is written `encryption_key`
+        // and its property `encryptionKeyAccount`. Comparing verbatim missed that pair and left
+        // an `error` on the CORRECT pattern — the identifier a secret is stored UNDER is not the
+        // secret. Found on MacCloud_client_MacOS after #111 shipped.
+        let normalisedValue = Self.alphanumericsOnly(value)
+        // A value with no alphanumerics left is not an echo of anything — fall through and let the
+        // remaining heuristics judge it. Returning `true` here silently skipped `apiKey = "12345"`,
+        // because an earlier draft filtered on `isLetter` and normalised every digit away.
+        guard !normalisedValue.isEmpty else { return false }
+        return Self.alphanumericsOnly(variableName).contains(normalisedValue)
+    }
+
+    private static func alphanumericsOnly(_ text: String) -> String {
+        text.lowercased().filter { $0.isLetter || $0.isNumber }
     }
 
     private func isPlaceholder(_ value: String) -> Bool {

--- a/Tests/CoreTests/Security/SecurityVisitorTests.swift
+++ b/Tests/CoreTests/Security/SecurityVisitorTests.swift
@@ -277,4 +277,19 @@ struct SecurityVisitorTests {
         """)
         #expect(issues.count == 2)
     }
+
+    /// **Separators are spelling, not meaning.** A Keychain account is written `encryption_key`
+    /// and the property holding it `encryptionKeyAccount`; comparing the two verbatim missed the
+    /// pair and left an `error` on MacCloud_client_MacOS — on the *correct* pattern, since the
+    /// identifier a secret is stored UNDER is not the secret.
+    @Test
+    func ignoresASeparatorSpellingOfItsOwnName() {
+        let issues = secretIssues("""
+        class SecurityManager {
+            let encryptionKeyAccount = "encryption_key"
+            let keychainAccount = "auth_token"
+        }
+        """)
+        #expect(issues.isEmpty)
+    }
 }


### PR DESCRIPTION
Follow-up to #111, found by sweeping the corpus **after** it merged rather than from the issue.

## What it fixes

```swift
let encryptionKeyAccount = "encryption_key"
let keychainAccount = "auth_token"
```

Keychain account identifiers — the names a secret is stored **under**, which is the correct pattern — and the first was an `error` on MacCloud_client_MacOS. #111's self-name guard compared verbatim, so the underscore in `"encryption_key"` broke the match against `encryptionKeyAccount` and the finding stood.

Separators are spelling, not meaning. **MacCloud_client_MacOS: 1 → 0.**

The guard stays narrow: `password = "hunter2"` and `apiKey = "…"` are still reported, because neither value appears in its own name under any spelling.

## What a reviewer should scrutinise

**A bug in my first attempt, caught by an existing test** — which is exactly what it is for, and worth reading because the failure mode was silent suppression in a security rule.

The helper was named `alphanumericsOnly` and implemented `filter(\.isLetter)`. So `apiKey = "12345"` normalised to the **empty string**, and the empty case returned "this is an echo" — skipping a real finding the suite already pinned at 4. `testHardcodedSecretDetection` went 4 → 3 and named it.

Two corrections: the predicate now keeps digits, and an empty normalisation falls through to the remaining heuristics rather than suppressing. **A security rule's guard should fail toward reporting**, and that one failed toward silence.

## Verification

- `swift test` — **3,756 tests, 447 suites, passing**
- `swiftlint` — exit 0
- Corpus: SwiftUMLStudio 0, SwiftInferProperties 0, MacCloud_client_MacOS 0, SwiftAssist 0, SwiftProjectLint 0 — with `apiKey`/`password` still reported in the fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015C8BjaXXCA5DGkQCARErGL