### PR TITLE
Find executable targets in nested packages, and before the early return

### DIFF
--- a/Docs/rules/print-statement.md
+++ b/Docs/rules/print-statement.md
@@ -19,6 +19,13 @@
 
 This rule is also suppressed for test files and executable targets in Swift Packages (where `print()` is the correct stdout mechanism).
 
+### Executable targets are excluded
+`print` to stdout is a command-line tool's interface, not logging — routing it to `os.Logger` would send the output to the unified log and print nothing. Source under an `.executableTarget` is therefore excluded, and that now includes executable targets declared in **nested** packages: an Xcode project has no manifest at its root, so a CLI living in a package beside the app used to be reported for the output the user asked for.
+
+**A library target is not excluded**, even in a package that also ships a CLI. `print(error)` inside a `catch` is exactly what this rule is for, wherever it lives.
+
+**Known gap.** The common swift-argument-parser layout puts a thin `@main` in the executable target and all the command logic — including the program's output — in a *library* target it depends on. The exclusion covers the stub and not the code that prints: 37 findings in one such package. A suppression comment is the tool for that today.
+
 ### Non-Violating Examples
 ```swift
 // Structured logging

--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/ExecutableTargetDetector.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/ExecutableTargetDetector.swift
@@ -19,6 +19,18 @@ public struct ExecutableTargetDetector {
         return parseExecutableTargets(from: content)
     }
 
+    /// The same, for every **nested** package, with each result made relative to `projectRoot`.
+    ///
+    /// `executableSourcePaths(in:)` reads the manifest at the analysed root and nothing else. An
+    /// Xcode project has no manifest there, so a CLI living in a package beside the app was never
+    /// found and `print` — the program's actual output — was reported as production logging: five
+    /// findings in `swiftumlbridge` on one subject (#112).
+    public static func nestedExecutableSourcePaths(in projectRoot: String) -> [String] {
+        NestedPackageWalker.packageDirectories(in: projectRoot).flatMap { relative, absolute in
+            executableSourcePaths(in: absolute).map { relative + $0 }
+        }
+    }
+
     private static func parseExecutableTargets(from content: String) -> [String] {
         guard let markerRegex = try? NSRegularExpression(
             pattern: #"\.executableTarget\s*\("#

--- a/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/NestedPackageWalker.swift
+++ b/Packages/SwiftProjectLintConfig/Sources/SwiftProjectLintConfig/Configuration/NestedPackageWalker.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Finds nested SwiftPM packages once, for the detectors that need to read their manifests.
+///
+/// Written out because two of them now do — `LibraryPackageDetector` and
+/// `ExecutableTargetDetector` — and a second copy of "what counts as a nested package" is how the
+/// two would come to disagree about the same directory.
+enum NestedPackageWalker {
+
+    /// Each nested package as `(rootRelativePrefix, absolutePath)`, e.g.
+    /// `("SwiftUMLBridge/", "/…/SwiftUMLBridge")`. The analysed root itself is never included.
+    static func packageDirectories(in projectRoot: String) -> [(relative: String, absolute: String)] {
+        let fileManager = FileManager.default
+        let rootURL = URL(fileURLWithPath: projectRoot, isDirectory: true)
+        guard let enumerator = fileManager.enumerator(
+            at: rootURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: .skipsHiddenFiles
+        ) else {
+            return []
+        }
+
+        var found: [(relative: String, absolute: String)] = []
+        for case let itemURL as URL in enumerator {
+            let isDirectory = (try? itemURL.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+            guard isDirectory else { continue }
+
+            if FileAnalysisUtils.skippedDirectories.contains(itemURL.lastPathComponent) {
+                enumerator.skipDescendants()
+                continue
+            }
+            guard fileManager.fileExists(
+                atPath: itemURL.appendingPathComponent("Package.swift").path
+            ) else { continue }
+
+            // A package's own subdirectories are inside it, not beside it.
+            enumerator.skipDescendants()
+
+            let rootPath = rootURL.standardizedFileURL.path
+            let itemPath = itemURL.standardizedFileURL.path
+            guard itemPath.hasPrefix(rootPath + "/") else { continue }
+            found.append((
+                relative: String(itemPath.dropFirst(rootPath.count + 1)) + "/",
+                absolute: itemPath
+            ))
+        }
+        return found.sorted { $0.relative < $1.relative }
+    }
+}

--- a/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
+++ b/Packages/SwiftProjectLintEngine/Sources/SwiftProjectLintEngine/ProjectLinter+FileAnalysis.swift
@@ -136,8 +136,22 @@ extension ProjectLinter {
             ? LibraryPackageDetector.libraryPackagePaths(in: path)
             : []
 
+        // Executable sources, from the root manifest AND from nested packages. `print` to stdout
+        // is a CLI's interface, not logging, and routing it to `os.Logger` would print nothing.
+        //
+        // Computed here for the reason the comment above gives about `publicInAppTarget`: it used
+        // to sit after the early return, so an app root — an `.xcodeproj` with a package beside it
+        // — never reached it. Five findings on `swiftumlbridge` for output the user asked for
+        // (#112). The precedent this file cites for the library-path fix had the same defect.
+        let execPaths = ExecutableTargetDetector.executableSourcePaths(in: path)
+            + (configuration.includeNestedPackages
+                ? ExecutableTargetDetector.nestedExecutableSourcePaths(in: path)
+                : [])
+
         guard isLibrary else {
-            return Self.excludingPublicInAppTarget(libraryPaths, from: configuration)
+            return Self.excluding(
+                libraryPaths: libraryPaths, executablePaths: execPaths, from: configuration
+            )
         }
 
         var disabledRules = configuration.disabledRules
@@ -155,7 +169,6 @@ extension ProjectLinter {
             disabledRules.insert(.unusedProtocolAbstraction)
         }
 
-        let execPaths = ExecutableTargetDetector.executableSourcePaths(in: path)
         var overrides = configuration.ruleOverrides
         if execPaths.isEmpty == false {
             let existing = overrides[.printStatement]
@@ -187,18 +200,28 @@ extension ProjectLinter {
     /// Path exclusion rather than a per-file target type: the rule is already suppressed by path
     /// for executables (`printStatement`), the mechanism is tested, and the alternative — resolving
     /// a `TargetType` per file — would put a filesystem walk behind every visitor.
-    private static func excludingPublicInAppTarget(
-        _ libraryPaths: [String],
+    private static func excluding(
+        libraryPaths: [String],
+        executablePaths: [String],
         from configuration: LintConfiguration
     ) -> LintConfiguration {
-        guard !libraryPaths.isEmpty else { return configuration }
+        guard !libraryPaths.isEmpty || !executablePaths.isEmpty else { return configuration }
 
         var overrides = configuration.ruleOverrides
-        let existing = overrides[.publicInAppTarget]
-        overrides[.publicInAppTarget] = LintConfiguration.RuleOverride(
-            severity: existing?.severity,
-            excludedPaths: (existing?.excludedPaths ?? []) + libraryPaths
-        )
+        if !libraryPaths.isEmpty {
+            let existing = overrides[.publicInAppTarget]
+            overrides[.publicInAppTarget] = LintConfiguration.RuleOverride(
+                severity: existing?.severity,
+                excludedPaths: (existing?.excludedPaths ?? []) + libraryPaths
+            )
+        }
+        if !executablePaths.isEmpty {
+            let existing = overrides[.printStatement]
+            overrides[.printStatement] = LintConfiguration.RuleOverride(
+                severity: existing?.severity,
+                excludedPaths: (existing?.excludedPaths ?? []) + executablePaths
+            )
+        }
         return LintConfiguration(
             disabledRules: configuration.disabledRules,
             enabledOnlyRules: configuration.enabledOnlyRules,

--- a/Tests/CoreTests/Configuration/NestedExecutablePathsTests.swift
+++ b/Tests/CoreTests/Configuration/NestedExecutablePathsTests.swift
@@ -1,0 +1,102 @@
+@testable import Core
+import Foundation
+@testable import SwiftProjectLintConfig
+import Testing
+
+/// `print` to stdout is a CLI's interface, not logging — and a CLI is often a package *beside* an
+/// Xcode app rather than the analysed root.
+///
+/// `executableSourcePaths(in:)` reads the manifest at the root and nothing else, so an
+/// `.xcodeproj` root never found the executable target in a nested package: five findings on
+/// `swiftumlbridge` for the `--list` output the user asked for (#112).
+@Suite("Executable sources are found in nested packages too")
+struct NestedExecutablePathsTests {
+
+    private func makeTree(_ packages: [(name: String, manifest: String)]) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("NestedExec-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        for package in packages {
+            let directory = root.appendingPathComponent(package.name)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            try package.manifest.write(
+                to: directory.appendingPathComponent("Package.swift"),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+        return root
+    }
+
+    private static let cliManifest = """
+    // swift-tools-version: 6.1
+    import PackageDescription
+    let package = Package(
+        name: "Bridge",
+        products: [
+            .library(name: "Framework", targets: ["Framework"]),
+            .executable(name: "tool", targets: ["tool"])
+        ],
+        targets: [
+            .target(name: "Framework"),
+            .executableTarget(name: "tool")
+        ]
+    )
+    """
+
+    /// The path is reported **relative to the analysed root**, since that is what an
+    /// `excludedPaths` override matches against.
+    @Test("a nested package's executable target is found, root-relative")
+    func findsNestedExecutableTarget() throws {
+        let root = try makeTree([("Bridge", Self.cliManifest)])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(
+            ExecutableTargetDetector.nestedExecutableSourcePaths(in: root.path)
+                == ["Bridge/Sources/tool/"]
+        )
+    }
+
+    /// The library target in the same package is **not** excluded. A framework that prints is a
+    /// separate question, and two of the three remaining findings on the subject are genuine —
+    /// `print(error)` in a `catch` is exactly what this rule is for.
+    @Test("a nested package's library target is not treated as executable")
+    func doesNotExcludeTheLibraryTarget() throws {
+        let root = try makeTree([("Bridge", Self.cliManifest)])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let paths = ExecutableTargetDetector.nestedExecutableSourcePaths(in: root.path)
+        #expect(!paths.contains { $0.contains("Framework") })
+    }
+
+    @Test("a package with no executable product contributes nothing")
+    func ignoresLibraryOnlyPackages() throws {
+        let libraryOnly = """
+        // swift-tools-version: 6.1
+        import PackageDescription
+        let package = Package(
+            name: "Lib",
+            products: [.library(name: "Lib", targets: ["Lib"])],
+            targets: [.target(name: "Lib")]
+        )
+        """
+        let root = try makeTree([("Lib", libraryOnly)])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(ExecutableTargetDetector.nestedExecutableSourcePaths(in: root.path).isEmpty)
+    }
+
+    /// The analysed root's own manifest stays `executableSourcePaths(in:)`'s job, so it must not
+    /// be reported twice.
+    @Test("the analysed root is not reported as a nested package")
+    func rootIsNotNested() throws {
+        let root = try makeTree([])
+        defer { try? FileManager.default.removeItem(at: root) }
+        try Self.cliManifest.write(
+            to: root.appendingPathComponent("Package.swift"), atomically: true, encoding: .utf8
+        )
+
+        #expect(ExecutableTargetDetector.nestedExecutableSourcePaths(in: root.path).isEmpty)
+        #expect(ExecutableTargetDetector.executableSourcePaths(in: root.path) == ["Sources/tool/"])
+    }
+}


### PR DESCRIPTION
Closes #112.

## What was wrong

`print` to stdout is a CLI's interface, not logging, and the rule **already** excluded executable sources. Two gaps meant it never fired where it was needed.

**1. The exclusion sat after the early return.** `guard isLibrary else { return }` means an app root — an `.xcodeproj` with a package beside it — never reached it. That is the same structural defect fixed for `publicInAppTarget` in #108, and the comment added there cites *this* override as its precedent while the precedent still had the bug.

**2. `executableSourcePaths` read only the root manifest.** An Xcode project has none, so the nested `SwiftUMLBridge/Package.swift` declaring `.executableTarget(name: "swiftumlbridge")` was never opened.

**SwiftUMLStudio: 8 → 3.** The five removed are in `Sources/swiftumlbridge` — the `--list` output the user asked for.

## What a reviewer should scrutinise

**That the three remaining are deliberate, and two of them are correct.** I read each rather than counting them as false positives:

| | verdict |
|---|---|
| `String+Extensions.swift:39` — `print("invalid regex: …")` in a `catch` | **true positive** — diagnostic logging, exactly what this rule is for |
| `FileCollector.swift:99` — `catch { print(error, fileURL) }` | **true positive**, same reason |
| `ConsolePresenter.swift:8` | program output — a library type whose job is the `--output consoleOnly` destination |

The issue describes all the Bridge findings as deliberate program output; two of them are not. A conformance heuristic for the `ConsolePresenter` case is **declined** — one finding against a fragile protocol-name signal — and a suppression comment is the right tool for a single deliberate case.

**`NestedPackageWalker` is written out rather than copied.** Two detectors now walk for nested packages, and a second definition of what counts as one is how they would come to disagree about the same directory.

## A known gap, recorded in the docs rather than left implicit

The common swift-argument-parser layout puts a thin `@main` in the executable target and all the command logic — including every `print` — in a **library** target it depends on. The exclusion covers the stub and not the code that prints.

Measured: **37 findings in SwiftInferProperties, all in `SwiftInferCLI`**, whose own manifest comment says the executable *"only forwards to `SwiftInferCommand.main()`; no logic lives here"*. So the existing exclusion covers the one file that does not print.

Closing that means deciding how far into an executable's dependencies to reach — direct only, sole-dependency, or transitive — and the answers differ: `soundness-probe` depends on both `SwiftInferCLI` and `SwiftInferCore`, and excluding a general-purpose library because a probe links it would silence real findings. That is a design question, not this one, so it is written down with its number instead of guessed at.

## Verification

- `swift test` — **3,760 tests, 448 suites, passing** (4 new)
- `swiftlint` — exit 0
- Fixture: a nested package's executable target found root-relative, its library target not excluded, a library-only package contributing nothing, and the analysed root not double-reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015C8BjaXXCA5DGkQCARErGL