### PR TITLE
Require a forwarding key to name something specific

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ConcreteTypeUsageVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ConcreteTypeUsageVisitor.swift
@@ -260,7 +260,7 @@ class ConcreteTypeUsageVisitor: BasePatternVisitor {
             // The nominal form is if anything better than the alias: it can carry named
             // factories, and `DateProvider.system` is the one place in its package allowed to
             // read a clock. Requires the project-wide closure-wrapper prescan.
-            Exemption { self.knownClosureWrapperTypes.wraps($0) },
+            Exemption { self.knownClosureWrapperTypes.contains($0) },
 
             // An `Equatable` type is a value, and a value is substituted by constructing a
             // different one. Nothing in this corpus that is genuinely a dependency conforms:

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/CollectionOperation.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/CollectionOperation.swift
@@ -382,11 +382,43 @@ enum ForwardingCall {
         }
     }
 
-    /// Reconstruct the callee's Swift name from the call site: `search.matches(name: x)` →
-    /// `matches(name:)`, `FileListing.precedes(a, b)` → `precedes(_:_:)`.
+    /// Reconstruct the callee's Swift name from the call site: `precedes(a, b)` → `precedes(_:_:)`.
+    ///
+    /// **Free-shape callees only** (`foo(…)`, not `base.foo(…)`), which is the same restriction
+    /// `PackagePurityJoin` placed on itself for the same reason, in this package, next door:
+    ///
+    /// > name-keying has been the dominant defect in three separate measurements of this seam,
+    /// > most sharply when a cascade let one refuted `classify` speak for six unrelated ones.
+    ///
+    /// A member call cannot be resolved here — this is a per-file visitor with no type
+    /// information — so `set.contains(x)` and `myCatalog.contains(x)` were the same key. Adding
+    /// `ClosureWrapperTypeCatalog.contains(_:)` to an unrelated file removed **49 closure
+    /// candidates** from this repository's census, silently, with a falling number as the only
+    /// symptom (#185).
+    ///
+    /// ## The cost, measured before choosing
+    ///
+    /// Restricting to free shape restores **86** closures across three repositories — 3 here, 61 in
+    /// SwiftInferProperties, 22 in SwiftAssist. Reading what they forward to:
+    ///
+    /// | name | count | |
+    /// |---|---|---|
+    /// | `contains` | 53 | the standard library's |
+    /// | `first`, `lowercased`, `map`, `min`, `sorted` | ~24 | also the standard library's |
+    /// | `matches`, `isCollection`, `isOptional`, … | ~13 | genuinely project-declared |
+    ///
+    /// So the member arm was **roughly six collisions for every genuine forward**. The ~13 lose
+    /// their exemption and are reported again, which is the honest price: a closure forwarding to
+    /// a distinctively-named project method now earns a "consider extracting" it does not need.
+    /// The alternative was 77 candidates hidden by a name nobody chose for that reason.
+    ///
+    /// A denylist of standard-library names was the other candidate and is **not** taken: the
+    /// `ConcreteTypeUsage` pass found denylists failing twice on exactly this kind of question,
+    /// and a list needs an entry for every collision anyone will ever write.
     private static func labelledName(of call: FunctionCallExprSyntax) -> String? {
         let base: String
         if let member = call.calledExpression.as(MemberAccessExprSyntax.self) {
+            guard memberCallIsResolvable(member, call: call) else { return nil }
             base = member.declName.baseName.text
         } else if let reference = call.calledExpression.as(DeclReferenceExprSyntax.self) {
             base = reference.baseName.text
@@ -396,6 +428,32 @@ enum ForwardingCall {
 
         let labels = call.arguments.map { "\($0.label?.text ?? "_"):" }.joined()
         return "\(base)(\(labels))"
+    }
+
+    /// Whether a member call names something specific enough to key on.
+    ///
+    /// `set.contains(x)` and `myCatalog.contains(x)` produce the same key, and this is a per-file
+    /// visitor with no type information to tell them apart. Two shapes are specific enough:
+    ///
+    /// - **A capitalized base** — `FileOrdering.precedes(a, b)` is a static call on a type, and a
+    ///   type name is not something a value happens to share with `Set`.
+    /// - **At least one argument label** — `search.matches(name: $0.name)` is `matches(name:)`,
+    ///   which the project must also declare for the exemption to apply. A labelled name is a far
+    ///   narrower coincidence than a bare one.
+    ///
+    /// What is excluded is the unlabelled call on a lowercase base — `contains(_:)`, `map(_:)`,
+    /// `lowercased()` — which is where every collision in #185 lived. Adding
+    /// `ClosureWrapperTypeCatalog.contains(_:)` to an unrelated file removed 49 closure candidates
+    /// from this repository's census, silently.
+    private static func memberCallIsResolvable(
+        _ member: MemberAccessExprSyntax,
+        call: FunctionCallExprSyntax
+    ) -> Bool {
+        if let base = member.base?.as(DeclReferenceExprSyntax.self),
+           base.baseName.text.first?.isUppercase == true {
+            return true
+        }
+        return call.arguments.contains { $0.label != nil }
     }
 
     /// An argument passed straight through: `$0`, `$0.name`, `file.path`, a capture, a literal —

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/ClosureWrapperTypeCollector.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/ClosureWrapperTypeCollector.swift
@@ -51,19 +51,22 @@ public struct ClosureWrapperTypeCatalog: Sendable, Equatable {
 
     /// Whether `name` is one of them.
     ///
-    /// **Named `wraps` rather than `contains` on purpose, and the reason is measured.** While it
-    /// was `contains(_:)`, that labelled name entered `knownProjectFunctions` — and
-    /// `PureClosureCandidateVisitor`'s forwarding check suppresses any single-expression closure
-    /// calling a project-declared name, keying on the *member* name plus labels. So a one-line
-    /// method here silenced every closure in the package that calls `.contains(…)`:
-    /// `{ stylingModifierNames.contains($0) }`, `{ $0.description.contains("#Preview") }`, and 47
-    /// others. **The closure census went 249 → 200 because of this method's name**, measured both
-    /// ways.
+    /// **This was renamed to `wraps` for a while, and the rename is now retired.** While it was
+    /// `contains(_:)` the first time, that labelled name entered `knownProjectFunctions` — and
+    /// `PureClosureCandidateVisitor`'s forwarding check suppressed any single-expression closure
+    /// calling a project-declared name, keying on the *member* name plus labels. A one-line method
+    /// here silenced every closure in the package calling `.contains(…)`:
+    /// `{ stylingModifierNames.contains($0) }`, `{ $0.description.contains("#Preview") }` and 47
+    /// others. **The closure census went 249 → 200 because of this method's name.**
     ///
-    /// The rename is a workaround and is recorded as one — the defect is that the forwarding check
-    /// resolves a callee by bare name through a member access, which `PackagePurityJoin` in this
-    /// same package already refuses to do and documents at length. Filed as SwiftProjectLint#185.
-    public func wraps(_ name: String) -> Bool { names.contains(name) }
+    /// The rename was recorded as a workaround rather than a fix, and #185 fixed the defect: the
+    /// forwarding check no longer keys on an unlabelled member call against a lowercase base, so
+    /// `set.contains(x)` and this are no longer the same key. Verified by renaming back — the
+    /// census holds at 255 with `contains(_:)` restored, where it used to fall.
+    ///
+    /// Left here as the record. A workaround kept after its reason is gone reads as a constraint
+    /// that still binds, and the next person to touch this name would have no way to know.
+    public func contains(_ name: String) -> Bool { names.contains(name) }
 
     public var isEmpty: Bool { names.isEmpty }
 

--- a/Tests/CoreTests/Architecture/ConcreteTypeUsageSeamTests.swift
+++ b/Tests/CoreTests/Architecture/ConcreteTypeUsageSeamTests.swift
@@ -70,7 +70,7 @@ struct ConcreteTypeUsageSeamTests {
     @Test("a property typed with a closure wrapper is not reported")
     func closureWrapperIsNotReported() {
         let built = catalog(providerSource)
-        #expect(built.wraps("DateProvider"))
+        #expect(built.contains("DateProvider"))
         #expect(issues(providerSource, wrappers: built).isEmpty)
     }
 
@@ -90,7 +90,7 @@ struct ConcreteTypeUsageSeamTests {
         // every real instance of this shape fail to qualify — which is exactly what a first,
         // cruder version of the detector did.
         let built = catalog(providerSource)
-        #expect(built.wraps("DateProvider"))
+        #expect(built.contains("DateProvider"))
     }
 
     @Test("two closures is not a wrapper")
@@ -103,7 +103,7 @@ struct ConcreteTypeUsageSeamTests {
             let save: @Sendable (Data) -> Void
         }
         """)
-        #expect(!built.wraps("EditingService"))
+        #expect(!built.contains("EditingService"))
     }
 
     @Test("a struct holding a value is not a wrapper")
@@ -111,7 +111,7 @@ struct ConcreteTypeUsageSeamTests {
         let built = catalog("""
         struct SnapshotManager { let root: URL }
         """)
-        #expect(!built.wraps("SnapshotManager"))
+        #expect(!built.contains("SnapshotManager"))
     }
 
     @Test("a non-final class is not a wrapper")
@@ -121,7 +121,7 @@ struct ConcreteTypeUsageSeamTests {
         let built = catalog("""
         class DiffLoader { let load: () -> Data }
         """)
-        #expect(!built.wraps("DiffLoader"))
+        #expect(!built.contains("DiffLoader"))
     }
 
     // MARK: - The file-local type

--- a/Tests/CoreTests/Testability/ForwardingCallKeyTests.swift
+++ b/Tests/CoreTests/Testability/ForwardingCallKeyTests.swift
@@ -1,0 +1,78 @@
+@testable import Core
+import SwiftParser
+@testable import SwiftProjectLintRules
+@testable import SwiftProjectLintVisitors
+import SwiftSyntax
+import Testing
+
+/// The forwarding gate keys a callee by name, and a name has to be specific enough to key on.
+///
+/// Split from `PureClosureCandidateVisitorTests` because it is about `ForwardingCall` rather than
+/// about the census, and because adding it there took that type past the body-length limit.
+@Suite("The forwarding key must name something specific")
+struct ForwardingCallKeyTests {
+
+    /// **A project method named `contains(_:)` must not silence every `.contains(…)` in the
+    /// package.** One such method removed 49 closure candidates from this repository's census,
+    /// silently, and a falling number was the only symptom.
+    ///
+    /// `set.contains(x)` and `myCatalog.contains(x)` are the same key to a per-file visitor with no
+    /// type information, so an unlabelled member call on a lowercase base is no longer keyed on.
+    @Test("an unlabelled member call on a value base is not treated as a forward")
+    func unlabelledMemberCallOnAValueIsNotAForward() {
+        #expect(!analyzeClosureCandidates("""
+        struct Model {
+            func filtered() -> [String] {
+                names.filter { stylingModifierNames.contains($0) }
+            }
+        }
+        """, projectFunctions: ["contains(_:)"]).isEmpty)
+    }
+
+    /// The same for the other standard-library names a project might happen to declare.
+    ///
+    /// Every case is a **predicate** call site on purpose: a single-expression `map` closure is
+    /// never a candidate anyway (`hidesALawWorthStating` requires two statements for a transform),
+    /// so a `map`-shaped case would have passed while checking nothing — which is how the first
+    /// draft of this test failed.
+    @Test("common standard-library member names do not exempt a closure", arguments: [
+        ("map(_:)", "values.filter { transformer.map($0) }"),
+        ("first(_:)", "values.filter { registry.first($0) }"),
+        ("hasPrefix(_:)", "values.filter { matcher.hasPrefix($0) }")
+    ])
+    func standardLibraryNamesDoNotExempt(declared: String, body: String) {
+        #expect(!analyzeClosureCandidates("""
+        struct Model {
+            func run() -> [String] {
+                \(body)
+            }
+        }
+        """, projectFunctions: [declared]).isEmpty)
+    }
+
+    /// **What the narrowing must not lose.** A labelled member call is a far narrower coincidence
+    /// than a bare one, and this is the rule's own motivating example — the convergence case three
+    /// cold readers walked in a loop.
+    @Test("a labelled member call is still a forward")
+    func labelledMemberCallIsStillAForward() {
+        #expect(analyzeClosureCandidates("""
+        struct Model {
+            func filtered() -> [File] {
+                files.filter { search.matches(name: $0.name) }
+            }
+        }
+        """, projectFunctions: ["matches(name:)"]).isEmpty)
+    }
+
+    /// A capitalized base is a type, not a value that happens to share a name with `Set`.
+    @Test("a static call on a project type is still a forward")
+    func staticCallOnATypeIsStillAForward() {
+        #expect(analyzeClosureCandidates("""
+        struct Model {
+            func ordered() -> [File] {
+                files.filter { FileRules.admits($0) }
+            }
+        }
+        """, projectFunctions: ["admits(_:)"]).isEmpty)
+    }
+}

--- a/Tests/CoreTests/Testability/PureClosureCandidateVisitorTests.swift
+++ b/Tests/CoreTests/Testability/PureClosureCandidateVisitorTests.swift
@@ -14,7 +14,9 @@ import Testing
 /// `projectFunctions` is what `ProjectLinter`'s pre-scan injects in a real run — the functions
 /// this codebase declares, which is the one fact that tells a closure still hiding logic from one
 /// merely forwarding to a function the reader already extracted.
-private func analyze(
+/// Shared with `ForwardingCallKeyTests`, which was split out of this file. Internal rather than
+/// duplicated: two copies of a harness are how two suites come to disagree about what they measure.
+func analyzeClosureCandidates(
     _ source: String,
     filePath: String = "Logic.swift",
     projectFunctions: Set<String> = []
@@ -53,7 +55,7 @@ struct PureClosureCandidateVisitorTests {
         // `isImmediateChild(_ path: String, of parent: String)` and the capture becomes a
         // parameter. Refusing captured state would refuse the best finding this rule has — this is
         // the bug site.
-        let issues = analyze("""
+        let issues = analyzeClosureCandidates("""
         func fetch() {
             let children = allFiles.filter { file in
                 let relativePath = file.path.replacingOccurrences(of: currentPath, with: "")
@@ -69,7 +71,7 @@ struct PureClosureCandidateVisitorTests {
 
     @Test("a comparator earns the strict-weak-ordering law by name")
     func comparatorNamesItsLaw() throws {
-        let issues = analyze("""
+        let issues = analyzeClosureCandidates("""
         func fetch() {
             files = children.sorted { file1, file2 in
                 if file1.isFolder != file2.isFolder { return file1.isFolder }
@@ -91,8 +93,8 @@ struct PureClosureCandidateVisitorTests {
         // `$0.date > $1.date` inherits its ordering from `Comparable` and cannot be got wrong. There
         // is no law left to state, so there is nothing to name — and a rule that fires on every
         // `sorted` in the codebase is the noise that teaches people to switch the category off.
-        #expect(analyze("func recent() { let recent = files.sorted { $0.date > $1.date } }").isEmpty)
-        #expect(analyze("func ordered() { let ordered = names.sorted { $0 < $1 } }").isEmpty)
+        #expect(analyzeClosureCandidates("func recent() { let recent = files.sorted { $0.date > $1.date } }").isEmpty)
+        #expect(analyzeClosureCandidates("func ordered() { let ordered = names.sorted { $0 < $1 } }").isEmpty)
     }
 
     @Test("a non-strict comparator is flagged — it is not even irreflexive")
@@ -100,7 +102,7 @@ struct PureClosureCandidateVisitorTests {
         // The size floor cannot catch this one: it is the *shortest* a comparator gets, and it is
         // wrong. `<=` is reflexive, so it is not a strict weak ordering, and `sorted(by:)` is within
         // its rights to crash on it.
-        let issues = analyze("func ordered() { let ordered = files.sorted { $0.name <= $1.name } }")
+        let issues = analyzeClosureCandidates("func ordered() { let ordered = files.sorted { $0.name <= $1.name } }")
 
         #expect(issues.count == 1)
         #expect(issues.first?.message.contains("strict weak ordering") == true)
@@ -109,7 +111,7 @@ struct PureClosureCandidateVisitorTests {
     @Test("a comparator over two keys is flagged")
     func multiKeyComparatorIsFlagged() {
         // The classic way to break transitivity, and it fits on one line.
-        let issues = analyze("""
+        let issues = analyzeClosureCandidates("""
         func ordered() {
             let ordered = tasks.sorted { $0.priority > $1.priority || $0.name < $1.name }
         }
@@ -122,7 +124,7 @@ struct PureClosureCandidateVisitorTests {
     func comparatorOverAComputedKeyIsFlagged() {
         // The ordering is only free when the key is plain stored access. `localizedCaseInsensitive`
         // ordering is locale-dependent, and the syntax cannot tell us it is total.
-        let issues = analyze("""
+        let issues = analyzeClosureCandidates("""
         func ordered() {
             let ordered = files.sorted {
                 $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
@@ -143,7 +145,7 @@ struct PureClosureCandidateVisitorTests {
         // Deliberately a `map` and not a `forEach`: `forEach` is not on the operation list at all, so
         // a `forEach` here would be refused before purity was ever consulted, and this test would
         // pass without exercising the thing it names.
-        #expect(analyze("""
+        #expect(analyzeClosureCandidates("""
         func total() {
             let flags = items.map { item in
                 runningTotal += item.amount
@@ -159,9 +161,9 @@ struct PureClosureCandidateVisitorTests {
     func plainBooleanReadIsNotFlagged() {
         // Nothing is being decided here, only surfaced. A stored property cannot disagree with
         // itself, so there is no law to state and nothing to generate inputs against.
-        #expect(analyze("func active() { let active = items.filter { $0.isEnabled } }").isEmpty)
-        #expect(analyze("func shown() { let shown = items.filter { !$0.isHidden } }").isEmpty)
-        #expect(analyze("func folders() { let folders = items.filter { $0.file.isFolder } }").isEmpty)
+        #expect(analyzeClosureCandidates("func active() { let active = items.filter { $0.isEnabled } }").isEmpty)
+        #expect(analyzeClosureCandidates("func shown() { let shown = items.filter { !$0.isHidden } }").isEmpty)
+        #expect(analyzeClosureCandidates("func folders() { let folders = items.filter { $0.file.isFolder } }").isEmpty)
     }
 
     @Test("an equality predicate is identity, not a decision")
@@ -169,17 +171,17 @@ struct PureClosureCandidateVisitorTests {
         // `removeAll { $0 == fileURL }` means "remove this element" and nothing more. Equatable
         // already guarantees everything there is to guarantee, so there is no law left to state and
         // no off-by-one for a generator to find.
-        #expect(analyze("func drop() { selected.removeAll { $0 == fileURL } }").isEmpty)
-        #expect(analyze("func busy() { let busy = status.values.contains { $0 == .uploading } }")
+        #expect(analyzeClosureCandidates("func drop() { selected.removeAll { $0 == fileURL } }").isEmpty)
+        #expect(analyzeClosureCandidates("func busy() { let busy = status.values.contains { $0 == .uploading } }")
             .isEmpty)
-        #expect(analyze("func others() { let others = files.filter { $0.path != parent } }").isEmpty)
+        #expect(analyzeClosureCandidates("func others() { let others = files.filter { $0.path != parent } }").isEmpty)
     }
 
     @Test("a relational predicate is a decision, and still a candidate")
     func relationalPredicateIsFlagged() {
         // Unlike `==`, a threshold or an ordering is exactly the decision that comes out one boundary
         // wrong. `>` or `>=`? `updated` before `created`, or after?
-        #expect(analyze("func full() { let full = items.filter { $0.count > 0 } }").count == 1)
+        #expect(analyzeClosureCandidates("func full() { let full = items.filter { $0.count > 0 } }").count == 1)
     }
 
     @Test("a one-line predicate with a rule in it is a candidate")
@@ -187,7 +189,7 @@ struct PureClosureCandidateVisitorTests {
         // The bug the old size floor allowed through. This is one statement — so the floor of two
         // dropped it — and it is one off-by-one from wrong. Exactly the lesson the comparators
         // taught, which had not been applied to predicates.
-        let issues = analyze("""
+        let issues = analyzeClosureCandidates("""
         func children() {
             let children = files.filter { $0.path.hasPrefix(parent) && $0.path != parent }
         }
@@ -202,7 +204,7 @@ struct PureClosureCandidateVisitorTests {
         // Errs towards firing, symmetrically with the comparators: the analyser cannot see that the
         // call is total, and the interesting predicates in real code are call-shaped — every locale
         // bug lives in one.
-        let issues = analyze("""
+        let issues = analyzeClosureCandidates("""
         func matching() {
             let matching = files.filter { $0.name.localizedCaseInsensitiveContains(query) }
         }
@@ -213,18 +215,18 @@ struct PureClosureCandidateVisitorTests {
 
     @Test("a one-line predicate comparing two keys is a candidate")
     func comparingPredicateIsFlagged() {
-        #expect(analyze("func stale() { let stale = items.filter { $0.updated < $0.created } }")
+        #expect(analyzeClosureCandidates("func stale() { let stale = items.filter { $0.updated < $0.created } }")
             .count == 1)
     }
 
     @Test("min and max take comparators too, and the free ordering still applies")
     func freeOrderingHoldsAcrossComparatorOperations() {
-        #expect(analyze("func fewest() { let fewest = items.min { $0.count < $1.count } }").isEmpty)
+        #expect(analyzeClosureCandidates("func fewest() { let fewest = items.min { $0.count < $1.count } }").isEmpty)
     }
 
     @Test("a transform with logic in it is a candidate")
     func transformWithLogicIsCandidate() {
-        let issues = analyze("""
+        let issues = analyzeClosureCandidates("""
         func labels() {
             let labels = files.map { file in
                 let size = Double(file.byteCount) / 1_000_000
@@ -239,7 +241,7 @@ struct PureClosureCandidateVisitorTests {
 
     @Test("a reducer's combine step is a candidate")
     func reducerIsCandidate() {
-        let issues = analyze("""
+        let issues = analyzeClosureCandidates("""
         func total() {
             let total = items.reduce(Money.zero) { running, item in
                 let taxed = item.price * (1 + item.taxRate)
@@ -254,7 +256,7 @@ struct PureClosureCandidateVisitorTests {
 
     @Test("a closure doing I/O is refused")
     func impureClosureIsRefused() {
-        #expect(analyze("""
+        #expect(analyzeClosureCandidates("""
         func log() {
             items.filter { item in
                 print(item)
@@ -268,14 +270,14 @@ struct PureClosureCandidateVisitorTests {
     func trivialProjectionIsNotFlagged() {
         // `map { $0.name }` is a projection, not a property. Naming it buys nothing, and a rule
         // that fires on every `map` in the codebase teaches people to switch the category off.
-        #expect(analyze("func names() { let names = items.map { $0.name } }").isEmpty)
+        #expect(analyzeClosureCandidates("func names() { let names = items.map { $0.name } }").isEmpty)
     }
 
     @Test("a closure not passed to a collection operation is ignored")
     func nonCollectionClosureIsIgnored() {
         // `Task { }` takes a closure too. A closure run for its effects is not a property waiting
         // to be named, and the operation list is a fixed one for exactly that reason.
-        #expect(analyze("""
+        #expect(analyzeClosureCandidates("""
         func start() {
             Task {
                 let value = compute()
@@ -287,7 +289,7 @@ struct PureClosureCandidateVisitorTests {
 
     @Test("test files are skipped")
     func testFilesAreSkipped() {
-        #expect(analyze("""
+        #expect(analyzeClosureCandidates("""
         func fetch() {
             let children = allFiles.filter { file in
                 let relative = file.path
@@ -304,7 +306,7 @@ struct PureClosureCandidateVisitorTests {
     /// would share it — a consumer narrowing to `filter` narrows to nothing.
     @Test("the symbol is the enclosing function, not the collection operation")
     func symbolIsTheEnclosingFunction() {
-        let issues = analyze("""
+        let issues = analyzeClosureCandidates("""
         func fetchLocalFiles() {
             files = allFiles.sorted { lhs, rhs in
                 if lhs.isFolder != rhs.isFolder { return lhs.isFolder }
@@ -323,7 +325,7 @@ struct PureClosureCandidateVisitorTests {
     /// wrong.
     @Test("a closure bound to a local `let` is still named for the enclosing function")
     func localBindingIsNotTheSymbol() {
-        let issues = analyze("""
+        let issues = analyzeClosureCandidates("""
         func fetchLocalFiles() {
             let immediateChildren = allFiles.filter { file in
                 let relativePath = file.path.replacingOccurrences(of: currentPath, with: "")
@@ -342,7 +344,7 @@ struct PureClosureCandidateVisitorTests {
     /// reader does not care about.
     @Test("a closure inside a computed property is named for the property")
     func computedPropertyIsTheSymbol() {
-        let issues = analyze("""
+        let issues = analyzeClosureCandidates("""
         struct Model {
             var filteredFiles: [File] {
                 files.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
@@ -364,7 +366,7 @@ struct PureClosureCandidateVisitorTests {
     /// times before stopping.
     @Test("a closure forwarding to an already-extracted function is NOT reported")
     func forwardingClosureIsNotReported() {
-        #expect(analyze("""
+        #expect(analyzeClosureCandidates("""
         struct Model {
             func filtered() -> [File] {
                 files.filter { search.matches(name: $0.name) }
@@ -379,7 +381,7 @@ struct PureClosureCandidateVisitorTests {
     /// every locale bug that hides in one is why the rule fires on call-shaped predicates at all.
     @Test("a closure calling a function we did NOT declare still fires")
     func closureCallingForeignFunctionStillFires() {
-        #expect(analyze("""
+        #expect(analyzeClosureCandidates("""
         struct Model {
             func filtered() -> [File] {
                 files.filter { $0.name.localizedCaseInsensitiveContains(query) }
@@ -391,7 +393,7 @@ struct PureClosureCandidateVisitorTests {
     /// The instant the closure does work of its own around the call, it is expressing a rule again.
     @Test("forwarding plus logic of its own still fires")
     func forwardingPlusLogicStillFires() {
-        #expect(analyze("""
+        #expect(analyzeClosureCandidates("""
         struct Model {
             func filtered() -> [File] {
                 files.filter { search.matches(name: $0.name) && !$0.isHidden }
@@ -404,7 +406,7 @@ struct PureClosureCandidateVisitorTests {
     /// never converges — extracting the projection just yields another nested call, forever.
     @Test("a coherent projection into an extracted comparator is plumbing, not a finding")
     func coherentProjectionIsNotReported() {
-        #expect(analyze("""
+        #expect(analyzeClosureCandidates("""
         struct Model {
             func ordered() -> [File] {
                 files.sorted { a, b in
@@ -424,7 +426,7 @@ struct PureClosureCandidateVisitorTests {
     /// adapter. Exempting it would silence the only rule that could have spoken.
     @Test("a projection that never uses one of the closure's parameters still fires")
     func projectionIgnoringAParameterStillFires() {
-        #expect(analyze("""
+        #expect(analyzeClosureCandidates("""
         struct Model {
             func ordered() -> [File] {
                 files.sorted { a, b in
@@ -441,7 +443,7 @@ struct PureClosureCandidateVisitorTests {
     /// A projection that *combines* two values is a decision, not an adapter.
     @Test("a projection mixing two parameters in one key still fires")
     func projectionMixingParametersStillFires() {
-        #expect(analyze("""
+        #expect(analyzeClosureCandidates("""
         struct Model {
             func ordered() -> [File] {
                 files.sorted { a, b in


### PR DESCRIPTION
Closes #185.

## What was wrong

`ForwardingCall.describes` exempts a closure that merely forwards to a function the reader already extracted, and keys the callee on its **member** name plus labels. So `set.contains(x)` and `myCatalog.contains(x)` were the same key — and adding a one-line `contains(_:)` to an unrelated file removed **49 closure candidates** from this repository's census, silently, with a falling number as the only symptom.

## The measurement the issue asked for

It listed three approaches and said *"none measured"*, so they were measured before choosing.

**Free-shape callees only** — what `PackagePurityJoin` already does next door — restores **86** closures across three repositories (3 here, 61 in SwiftInferProperties, 22 in SwiftAssist). It also **breaks two tests, and both are load-bearing**:

- `{ search.matches(name: $0.name) }` — the rule's own documented example, and the convergence case *"all three cold readers hit; one walked the loop three times"*
- `FileOrdering.precedes(…)` — a static call on a project type

So free-shape-only is too blunt, exactly as the issue suspected.

## What shipped

Not free shape, but **specific enough to key on**. A member call still counts when:

- **its base is capitalized** — a type name is not something a value happens to share with `Set`
- **the call carries at least one argument label** — `matches(name:)` must also be declared by the project for the exemption to apply, and a labelled name is a far narrower coincidence than a bare one

Excluded is the unlabelled call on a lowercase base, which is where every collision lived.

| repo | baseline | free-shape only | **shipped** |
|---|---|---|---|
| SwiftProjectLint | 255 | 258 | **255** |
| SwiftInferProperties | 273 | 334 | **320** |
| SwiftAssist | 80 | 102 | **102** |

**Restores 69 of the 86, keeping 17 genuine forwards suppressed** that free-shape-only would have re-reported.

**The denylist approach is not taken**, for the reason the issue gives: the `ConcreteTypeUsage` pass found denylists failing twice on this kind of question, and a list needs an entry for every collision anyone will ever write.

## What a reviewer should scrutinise

**The interim workaround is retired**, and that is the regression proof. `ClosureWrapperTypeCatalog.wraps` is `contains(_:)` again, and the census **holds at 255** with it — where it used to fall by 49. The declaration keeps the history rather than the workaround, because a workaround left after its reason is gone reads as a constraint that still binds.

**A test of mine was wrong before it was right.** A `map`-shaped case would have passed while checking nothing: `hidesALawWorthStating` requires two statements for a transform, so a single-expression `map` closure is never a candidate in the first place. Every case is a predicate call site now, and the reason is recorded at the test — it is the shape of test that looks like coverage and is not.

**The new tests live in their own suite.** `PureClosureCandidateVisitorTests` went past the body-length limit, and they are about `ForwardingCall` rather than about the census. The harness is shared rather than copied — two copies of a harness are how two suites come to disagree about what they measure.

## Verification

- `swift test` — **3,764 tests, 449 suites, passing**
- `swiftlint` — exit 0
- Census measured on three repositories under all three rules, and with the original collision re-introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015C8BjaXXCA5DGkQCARErGL