### PR TITLE
Name the members that re-present, and refuse the rest

### DIFF
--- a/Docs/rules/non-injected-nondeterminism.md
+++ b/Docs/rules/non-injected-nondeterminism.md
@@ -178,26 +178,45 @@ sites this arm could not reach were receivers that merely change the value's typ
 `bind(Date.now.timeIntervalSince1970, at: 1)`, `R(identifier: UUID().uuidString, …)`. None of those is
 a decision.
 
-The distinction is whether the member's arguments **reach into the scope**:
+The gate is a **named set of members**, and everything outside it is combining:
 
-| expression | arguments | what it is |
-| --- | --- | --- |
-| `.uuidString` | none | the same identity as text |
-| `.timeIntervalSince1970` | none | the same instant as a number |
-| `.httpHeader` | none | the same instant as an RFC1123 header |
-| `.formatted(date: .abbreviated, time: .shortened)` | leading-dot style options | the same instant, formatted |
-| `.addingTimeInterval(timeout)` | **`timeout`** | a deadline |
-| `.timeIntervalSince(start)` | **`start`** | an elapsed time — a benchmark's whole output |
+| member | what it is |
+| --- | --- |
+| `.uuidString`, `.uuid` | the same identity in another type |
+| `.timeIntervalSince1970`, `.timeIntervalSinceReferenceDate` | the same instant as a number, measured from a constant |
+| `.formatted(…)`, `.ISO8601Format()`, `.description`, `.debugDescription` | the same instant as text |
+| `.addingTimeInterval(…)` | a deadline |
+| `.timeIntervalSince(…)`, `.timeIntervalSinceNow` | an elapsed time — a benchmark's whole output |
+| `.hashValue` | a *second* nondeterministic value; Swift seeds hashing per process |
+| anything else | unknown, so treated as combining |
 
-An argument may contain literals and leading-dot members and nothing else; one bare identifier and the
-member counts as combining, because resolving whether that identifier is a local, a parameter or a
-static constant is a scope walk, and guessing it wrong turns a deadline into an end state. A trailing
-closure is never inert.
+The two `timeIntervalSince` prefixes are the boundary worth reading twice. `…1970` and
+`…ReferenceDate` measure from a constant, so they restate the instant; `…Now` measures from a
+**second read of the clock** and `…(start)` from whatever the scope supplied.
+
+**The first version of this gate asked a different question and it leaked.** It tested whether the
+member's *arguments* reached into the scope, taking argument-inertness as a proxy for
+re-presentation. `Date().addingTimeInterval(3_600)` is the table's own counterexample with the
+timeout spelled as a literal — and a literal changes nothing about who decided to add an hour —
+while `Date().timeIntervalSinceNow` takes no arguments at all, because the value it combines with
+is the clock. Both were labelled composition roots.
+
+A curated vocabulary is a maintenance cost and this is one, so the default is **refusal**: an
+unlisted member that really does only re-present gets this rule's ordinary message, which is what
+it got before the arm existed. A list drifting the other way would tell a reader a deadline is
+nothing to worry about. Measured cost of the stricter gate: our corpus 31 → 31 with no
+reclassification, third-party 37 → 37 with two moving back to the ordinary message —
+Hummingbird's `Date.now.httpHeader`, that library's own extension on `Date`, which no syntactic
+rule can distinguish from `timeIntervalSinceNow`.
+
+Inertness is still required **on top of** the name. An argument may contain literals and
+leading-dot members and nothing else; one bare identifier and the member counts as combining,
+because resolving whether that identifier is a local, a parameter or a static constant is a scope
+walk. A trailing closure is never inert.
 
 **Re-presentation alone is not enough** — the result still has to be handed on. A formatted instant
 that is *returned* rather than passed keeps the ordinary message, as does one interpolated into a
-string. Measured: 3 of our 34 findings reclassified and 2 of 37 in third-party checkouts, with none
-added or removed in either set.
+string.
 
 The bound spelling counts too — `let now = Date()` then only `f(asOf: now)` — and it demands that
 **every** reference to the binding is itself an argument. One comparison, one piece of arithmetic,

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor+Placement.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Testability/Visitors/NonInjectedNondeterminismVisitor+Placement.swift
@@ -259,24 +259,48 @@ extension NonInjectedNondeterminismVisitor {
     ///
     /// None of those is a decision. The instant or the identity is the same fact in a `String` or a
     /// `Double`, handed to something that takes it as a parameter — which is the shape this arm
-    /// exists to name.
+    /// exists to name. What separates them from the members that must not be reached through is
+    /// whether a new fact was produced:
     ///
-    /// **The distinction is whether the member's arguments reach into the scope.** Combining the
-    /// value with a local or a parameter produces a *new* fact, and that is where every defect lives:
+    /// | expression | what it is |
+    /// | --- | --- |
+    /// | `.uuidString` | the same identity as text |
+    /// | `.timeIntervalSince1970` | the same instant as a number |
+    /// | `.formatted(date: .abbreviated, time: .shortened)` | the same instant, formatted |
+    /// | `.addingTimeInterval(timeout)` | a deadline |
+    /// | `.timeIntervalSince(start)` | an elapsed time — a benchmark's whole output |
     ///
-    /// | expression | arguments | what it is |
-    /// | --- | --- | --- |
-    /// | `.uuidString` | none | the same identity as text |
-    /// | `.timeIntervalSince1970` | none | the same instant as a number |
-    /// | `.formatted(date: .abbreviated, time: .shortened)` | leading-dot style options | the same instant, formatted |
-    /// | `.addingTimeInterval(timeout)` | **`timeout`** | a deadline |
-    /// | `.timeIntervalSince(start)` | **`start`** | an elapsed time — a benchmark's whole output |
+    /// ## The member is named, and the default is refusal
     ///
-    /// Deliberately strict about what counts as inert: an argument may contain literals and
-    /// leading-dot members and **nothing else**. One bare identifier and the member is treated as
-    /// combining, because resolving whether that identifier is a local, a parameter or a static
-    /// constant is a scope walk, and guessing it wrong turns a deadline into an end state.
+    /// The first version of this gate asked **whether the member's arguments reach into the
+    /// scope** and took argument-inertness as a proxy for re-presentation. The proxy leaks, and it
+    /// leaks toward accepting:
+    ///
+    /// ```swift
+    /// expire(at: Date().addingTimeInterval(3_600))   // a deadline — and the table above says so
+    /// record(elapsed: Date().timeIntervalSinceNow)   // an elapsed time, second read ambient
+    /// ```
+    ///
+    /// Both were labelled composition roots. The first is the table's own counterexample with the
+    /// timeout spelled as a literal instead of a binding, and the literal changes nothing about
+    /// who decided to add an hour. The second needs no arguments at all, because the value it
+    /// combines with is the clock — so a rule that inspects arguments cannot see it.
+    ///
+    /// So the question is *which member*, not *what it was given*. `restatingMembers` is the set
+    /// that only re-presents; anything else is combining until someone shows otherwise.
+    ///
+    /// **A curated vocabulary, and the direction it fails in is the reason it is spelled this
+    /// way.** SwiftProjectLint#193 called this move out as the kind of hand-maintained list this
+    /// project keeps finding drifted, and it is one. An unlisted member that really does only
+    /// re-present gets this rule's ordinary message, which is what it got before the arm existed.
+    /// A denylist drifting the other way tells a reader a deadline is nothing to worry about.
+    ///
+    /// Inertness is still required *on top of* the name, so `.formatted(date: style)` stays
+    /// refused: an argument may contain literals and leading-dot members and **nothing else**. One
+    /// bare identifier and the member is treated as combining, because resolving whether that
+    /// identifier is a local, a parameter or a static constant is a scope walk.
     private func representation(of member: MemberAccessExprSyntax) -> Syntax? {
+        guard Self.restatingMembers.contains(member.declName.baseName.text) else { return nil }
         guard let call = member.parent?.as(FunctionCallExprSyntax.self),
               Syntax(call.calledExpression).id == Syntax(member).id else {
             // A bare member with no call: `.uuidString`, `.timeIntervalSince1970`. Nothing was
@@ -288,6 +312,29 @@ extension NonInjectedNondeterminismVisitor {
               call.additionalTrailingClosures.isEmpty else { return nil }
         return Syntax(call)
     }
+
+    /// Members of a clock or identity value that answer with the same fact in another type.
+    ///
+    /// Everything Foundation offers on `Date` and `UUID` that restates rather than computes. The
+    /// two epochs are the boundary worth reading twice: `timeIntervalSince1970` and
+    /// `timeIntervalSinceReferenceDate` measure from a constant, so they are the instant as a
+    /// number, while `timeIntervalSinceNow` measures from a *second clock read* and
+    /// `timeIntervalSince(_:)` from whatever the scope supplied. Same prefix, three different
+    /// things, and only the first two are on this list.
+    ///
+    /// `hashValue` is deliberately absent even though it takes nothing and reads like a
+    /// projection. Swift seeds hashing per process, so it is a second source of nondeterminism
+    /// layered on the first rather than a restatement of it.
+    private static let restatingMembers: Set<String> = [
+        "uuidString",
+        "uuid",
+        "timeIntervalSince1970",
+        "timeIntervalSinceReferenceDate",
+        "formatted",
+        "ISO8601Format",
+        "description",
+        "debugDescription"
+    ]
 
     /// An argument that supplies no value from the surrounding scope.
     ///

--- a/Tests/CoreTests/Testability/NonInjectedNondeterminismCompositionRootTests.swift
+++ b/Tests/CoreTests/Testability/NonInjectedNondeterminismCompositionRootTests.swift
@@ -173,6 +173,47 @@ struct NonInjectedNondeterminismCompositionRootTests {
         #expect(!isCompositionRoot("func f() { send(Date.now.transformed { $0 }) }"))
     }
 
+    // MARK: - The member is named, and the default is refusal
+
+    /// **Argument-inertness was the wrong question and these are the two shapes that show it**
+    /// (SwiftProjectLint#193). The first is the arm's own documented counterexample —
+    /// `.addingTimeInterval(timeout)` is a deadline — with the timeout spelled as a literal, and a
+    /// literal changes nothing about who decided to add an hour. The second combines the read with
+    /// a *second clock read*, so it needs no arguments at all and a rule that inspects arguments
+    /// cannot see it. Both were reported as composition roots until the gate started naming the
+    /// member.
+    @Test("a member that computes is refused however inert its arguments", arguments: [
+        "func f() { expire(at: Date().addingTimeInterval(3_600)) }",
+        "func f() { record(elapsed: Date().timeIntervalSinceNow) }",
+        "func f() { schedule(Date().addingTimeInterval(60 * 60)) }"
+    ])
+    func computingMemberIsNotACompositionRoot(source: String) {
+        #expect(analyze(source).count == 1)
+        #expect(!isCompositionRoot(source))
+    }
+
+    /// `timeIntervalSince1970` measures from a constant and is on the list; `timeIntervalSinceNow`
+    /// measures from a second read of the clock and is not. Same prefix, and the whole difference
+    /// between restating a value and computing one.
+    @Test func theTwoTimeIntervalPrefixesAreSeparated() {
+        #expect(isCompositionRoot("func f() { bind(Date().timeIntervalSince1970, at: 1) }"))
+        #expect(!isCompositionRoot("func f() { bind(Date().timeIntervalSinceNow, at: 1) }"))
+    }
+
+    /// The default is refusal, which is what makes the list safe to maintain: an unlisted member
+    /// that really does only re-present gets this rule's ordinary message — what it got before the
+    /// arm existed — rather than being told there is nothing to inject.
+    @Test func anUnlistedMemberIsRefused() {
+        #expect(!isCompositionRoot("func f(_ c: C) { store(DateContainer(date: Date.now.httpHeader), in: c) }"))
+    }
+
+    /// `hashValue` takes nothing and reads like a projection, and is deliberately off the list:
+    /// Swift seeds hashing per process, so it layers a second source of nondeterminism on the
+    /// first rather than restating it.
+    @Test func hashValueIsNotARestatement() {
+        #expect(!isCompositionRoot("func f() { bucket(UUID().hashValue) }"))
+    }
+
     // MARK: - Arm order
 
     /// The fresh-read arm is about where the read is *declared*; this one is about what the


### PR DESCRIPTION
Refs #193. Does not close it — see the last section.

## The defect

The composition-root arm reaches *through* a receiver when the member only restates the value, so `bind(Date.now.timeIntervalSince1970, at: 1)` is recognised as a hand-off. #200 decided which members qualify by asking whether **the member's arguments reach into the scope**, taking argument-inertness as a proxy for re-presentation.

The proxy leaks, and it leaks toward accepting:

```swift
expire(at: Date().addingTimeInterval(3_600))   // reported: "nothing to inject"
record(elapsed: Date().timeIntervalSinceNow)   // reported: "nothing to inject"
```

- The first is the arm's **own documented counterexample** — the doc table says `.addingTimeInterval(timeout)` is a deadline — with the timeout spelled as a literal rather than a binding. The literal changes nothing about who decided to add an hour.
- The second takes **no arguments at all**, because the value it combines with is the clock. A rule that inspects arguments cannot see it in principle. It is `.timeIntervalSince(start)` — which the docs name as "a benchmark's whole output" and correctly refuse — with the second operand ambient.

#193 states the invariant these break: a false composition root is the one direction this arm must never fail in, because the message closes a finding exactly where the decision is.

## The fix

Ask **which member**, not what it was given. `restatingMembers` is Foundation's set on `Date` and `UUID` that answers with the same fact in another type. Argument-inertness is still required *on top of* the name, so `.formatted(date: style)` stays refused.

Two entries are worth arguing with and both are commented at the code:

- **The two `timeIntervalSince` prefixes are separated.** `…1970` and `…ReferenceDate` measure from a constant and restate the instant; `…Now` measures from a second read of the clock and computes one.
- **`hashValue` is off the list** even though it takes nothing and reads like a projection. Swift seeds hashing per process, so it layers a second nondeterministic value on the first.

## What a reviewer should scrutinise

- **This is a hand-maintained vocabulary and #193 called the move out in advance** as exactly the kind this project keeps finding drifted. What makes it maintainable is the **default**: unlisted → refused → the rule's ordinary message, which is what every site got before the arm existed. A denylist drifting the other way tells a reader a deadline is fine. If you disagree with the direction, that is the argument to have.
- **The list's completeness.** `description`/`debugDescription`/`ISO8601Format` are included on reasoning, not on corpus evidence — nothing in either measured set exercises them.
- **The measured cost is real and is a loss.** See below.

## Measurement

| set | before | after | reclassified |
|---|---|---|---|
| our 13 repos | 31 | 31 | **0** |
| SwiftLint, SwiftPlantUML, swift-argument-parser, Hummingbird, swift-aws-lambda-runtime | 37 | 37 | **2**, both back to the ordinary message |

Our corpus is unchanged because the only two members it exercises through this path — `.uuidString` and `.formatted(date:time:)` — are on the list.

The two third-party moves are both `Date.now.httpHeader` in Hummingbird's `DateCache`. **That is a correct re-presentation being downgraded**, and it is the honest price: `httpHeader` is that library's own extension on `Date`, and nothing syntactic distinguishes it from `timeIntervalSinceNow`. A per-project extension to the list would recover it and is declined here — SwiftProjectLint has no per-rule configuration surface, and building one for this is a larger change than the defect warrants.

**Neither leaked shape occurs live in the corpus.** All three `Date().addingTimeInterval(<literal>)` sites are inside `#Preview` bodies, which this rule already excludes, and `timeIntervalSinceNow` appears nowhere. The gate was wrong before it was ever reached, which is why this lands as negative tests rather than as a count change.

## Verification

- `swift test` — 3,771 tests in 449 suites, green.
- `swiftlint` on the changed files — exit 0. (A whole-repo run exits 2 on `.swiftinfer/verify-workdir/**` scratch output, which is untracked and pre-existing.)
- Six new assertions in `NonInjectedNondeterminismCompositionRootTests`, all of which fail on `main`.

## Why #193 stays open

Its remaining content is the permanent record of what the arm refuses on purpose — class A, assignment to storage, which must stay refused because `MacCloudFile.init`'s invented-stamp defect and its repair wear the same shape. Closing the issue would lose that. I will post the re-measurement there separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015C8BjaXXCA5DGkQCARErGL