### PR TITLE
Give every cross-file aggregation walk a stated order

### DIFF
--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/DuplicateEnumMappingVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/DuplicateEnumMappingVisitor.swift
@@ -203,7 +203,8 @@ final class DuplicateEnumMappingVisitor: CrossFileVisitorBase, CrossFilePatternV
             groups[groupKey(for: site), default: []].append(site)
         }
 
-        for group in groups.values {
+        // Ordered by key so the walk is a fact about the code — see `AggregationDeterminismTests`.
+        for (_, group) in groups.sorted(by: { $0.key < $1.key }) {
             // Distinct source locations — the same switch is never counted twice.
             let distinct = dedupedByLocation(group)
             guard distinct.count >= Self.minSites else { continue }

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/DuplicateStructShapeVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/DuplicateStructShapeVisitor.swift
@@ -182,7 +182,9 @@ final class DuplicateStructShapeVisitor: CrossFileVisitorBase, CrossFilePatternV
         var clusters: [Int: [Int]] = [:]
         for index in shapes.indices { clusters[find(index), default: []].append(index) }
 
-        for indices in clusters.values where indices.count >= Self.minimumClusterSize {
+        // Ordered by key so the walk is a fact about the code — see `AggregationDeterminismTests`.
+        for (_, indices) in clusters.sorted(by: { $0.key < $1.key })
+        where indices.count >= Self.minimumClusterSize {
             let members = indices.map { shapes[$0] }
             let core = members.dropFirst().reduce(members[0].signatures) {
                 $0.intersection($1.signatures)

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/HoistableConformerMemberVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/HoistableConformerMemberVisitor.swift
@@ -135,7 +135,8 @@ final class HoistableConformerMemberVisitor: CrossFileVisitorBase, CrossFilePatt
             groups[record.signatureKey + "\u{1}" + record.body, default: []].append(record)
         }
 
-        for group in groups.values {
+        // Ordered by key so the walk is a fact about the code — see `AggregationDeterminismTests`.
+        for (_, group) in groups.sorted(by: { $0.key < $1.key }) {
             let owners = Set(group.map(\.owner))
             guard owners.count >= Self.minimumTypes else { continue }
             guard let sample = group.first else { continue }

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ParallelEnumShapeVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ParallelEnumShapeVisitor.swift
@@ -192,7 +192,9 @@ final class ParallelEnumShapeVisitor: CrossFileVisitorBase, CrossFilePatternVisi
             clusters[info.cases.sorted().joined(separator: "|"), default: []].append(info)
         }
 
-        for cluster in clusters.values where cluster.count >= Self.minClusterSize {
+        // Ordered by key so the walk is a fact about the code — see `AggregationDeterminismTests`.
+        for (_, cluster) in clusters.sorted(by: { $0.key < $1.key })
+        where cluster.count >= Self.minClusterSize {
             // Suppress when every member already shares a domain protocol — they are
             // unified, so there is nothing to suggest.
             let sharedProtocols = cluster.dropFirst().reduce(domainConformances(of: cluster[0])) {

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/PrimitiveNamedForDomainTypeVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/PrimitiveNamedForDomainTypeVisitor.swift
@@ -173,29 +173,58 @@ final class PrimitiveNamedForDomainTypeVisitor: CrossFileVisitorBase, CrossFileP
 
     // MARK: - Phase 2: match + emit
 
+    /// Matches each position against the wrappers whose name it echoes, and reports every
+    /// candidate rather than one of them.
+    ///
+    /// **Two wrapper names that differ only in case are two types and collide here**, because the
+    /// match is case-insensitive by design: a position spelled `userId` should be caught whether
+    /// the type is written `UserID` or `UserId`. The index used to be built by walking `wrappers`
+    /// — a `Dictionary` — and assigning into a `[String: …]` keyed on the lowercased name, so a
+    /// collision was resolved last-write-wins **by Swift's per-process hash seed**. Measured over
+    /// `UserID` / `UserId` / `let userId: String`: the finding named `UserId` in 8 of 12 processes
+    /// and `UserID` in the other 4, on identical source. The choice reaches the message, the
+    /// suggestion, and `symbol`, which the `pbt-seeds` manifest carries into `swift-infer`.
+    ///
+    /// Sorting the walk would make it a decision, but it would still be the wrong shape of answer:
+    /// neither spelling is more the domain type than the other, and advising a reader to type
+    /// their property as `UserID` when they meant `UserId` is a worse failure than saying both
+    /// exist. So the index keeps every candidate, and the message names them all — which is
+    /// exactly what the sibling rule in this directory already does when several wrappers share a
+    /// carrier (see `PrimitiveBypassingDomainTypeVisitor`, whose seed likewise takes the smallest
+    /// in sorted order because a manifest names one subject).
     func finalizeAnalysis() {
         guard wrappers.isEmpty == false, positions.isEmpty == false else { return }
 
-        var byLoweredName: [String: (name: String, carrier: String)] = [:]
-        for (name, carrier) in wrappers { byLoweredName[name.lowercased()] = (name, carrier) }
+        // Sorted so the candidate list is in a stated order rather than the walk's, which is what
+        // makes `first` below the lexicographically smallest rather than the hash's choice.
+        var byLoweredName: [String: [(name: String, carrier: String)]] = [:]
+        for name in wrappers.keys.sorted() {
+            guard let carrier = wrappers[name] else { continue }
+            byLoweredName[name.lowercased(), default: []].append((name, carrier))
+        }
 
         for position in positions {
-            guard let wrapper = byLoweredName[position.name.lowercased()],
-                  wrapper.carrier == position.carrier else { continue }
+            let candidates = byLoweredName[position.name.lowercased(), default: []]
+                .filter { $0.carrier == position.carrier }
+            guard let wrapper = candidates.first else { continue }
             // Don't flag the wrapper's own backing field (`struct Percentage { let percentage: Int }`).
+            // Every candidate shares the position's lowercased name, so asking this of `wrapper`
+            // asks it of all of them.
             if position.enclosingType?.lowercased() == wrapper.name.lowercased() { continue }
 
+            let spelled = candidates.map { "'\($0.name)'" }.joined(separator: " / ")
             addIssue(
                 severity: .info,
                 message: "'\(position.name)' is typed '\(position.carrier)' but names the domain "
-                    + "type '\(wrapper.name)', a newtype over '\(position.carrier)'.",
+                    + "type \(spelled), a newtype over '\(position.carrier)'.",
                 filePath: position.file,
                 lineNumber: position.line,
-                suggestion: "Type '\(position.name)' as '\(wrapper.name)' so the identity is "
+                suggestion: "Type '\(position.name)' as \(spelled) so the identity is "
                     + "enforced by the type instead of a bare '\(position.carrier)'.",
                 ruleName: .primitiveNamedForItsDomainType,
                 // The domain type, not the mistyped property: it is the type that owes the laws
-                // the raw primitive cannot state. Exported as a `carrier` seed.
+                // the raw primitive cannot state. Exported as a `carrier` seed, which names one
+                // subject — the smallest of the candidates, picked by name rather than by hash.
                 symbol: wrapper.name
             )
         }

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ScatteredEnumMappingVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/ScatteredEnumMappingVisitor.swift
@@ -227,7 +227,8 @@ final class ScatteredEnumMappingVisitor: CrossFileVisitorBase, CrossFilePatternV
             groups[groupKey(for: site), default: []].append(site)
         }
 
-        for group in groups.values {
+        // Ordered by key so the walk is a fact about the code — see `AggregationDeterminismTests`.
+        for (_, group) in groups.sorted(by: { $0.key < $1.key }) {
             let scattered = group.filter { !isCentralized($0) }
             let files = Set(scattered.map(\.file))
             guard scattered.count >= Self.minSites, files.count >= Self.minFiles else { continue }

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/SharedDomainEnumFieldVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/SharedDomainEnumFieldVisitor.swift
@@ -33,6 +33,14 @@ final class SharedDomainEnumFieldVisitor: CrossFileVisitorBase, CrossFilePattern
     private struct FieldSignature: Hashable {
         let propertyName: String
         let typeName: String
+
+        /// A total order over the cluster keys, so the walk that emits findings has a stated one.
+        /// Not a `Comparable` conformance: nothing about these signatures is ordered in the domain,
+        /// and the only thing this ordering owes is being a fact about the code rather than about
+        /// the run.
+        static func precedes(_ lhs: Self, _ rhs: Self) -> Bool {
+            (lhs.propertyName, lhs.typeName) < (rhs.propertyName, rhs.typeName)
+        }
     }
 
     private struct TypeShape {
@@ -135,7 +143,9 @@ final class SharedDomainEnumFieldVisitor: CrossFileVisitorBase, CrossFilePattern
             }
         }
 
-        for (signature, members) in clusters where members.count >= Self.minimumCluster {
+        // Ordered by key so the walk is a fact about the code — see `AggregationDeterminismTests`.
+        for (signature, members) in clusters.sorted(by: { FieldSignature.precedes($0.key, $1.key) })
+        where members.count >= Self.minimumCluster {
             // A type already conforming to a protocol that declares this property is
             // abstracted — drop it before deciding whether a cluster remains.
             let reportable = members.filter {

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/SubclassedForMockingVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/Architecture/Visitors/SubclassedForMockingVisitor.swift
@@ -80,7 +80,8 @@ final class SubclassedForMockingVisitor: CrossFileVisitorBase, CrossFilePatternV
             }
         }
 
-        for (baseName, mockName) in flagged {
+        // Ordered by key so the walk is a fact about the code — see `AggregationDeterminismTests`.
+        for (baseName, mockName) in flagged.sorted(by: { $0.key < $1.key }) {
             guard let base = classByName[baseName] else { continue }
             addIssue(
                 severity: .info,

--- a/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/ProtocolCouldBePrivateVisitor.swift
+++ b/Packages/SwiftProjectLintRules/Sources/SwiftProjectLintRules/CodeQuality/Visitors/ProtocolCouldBePrivateVisitor.swift
@@ -96,7 +96,8 @@ final class ProtocolCouldBePrivateVisitor: CrossFileVisitorBase, CrossFilePatter
     func finalizeAnalysis() {
         // Reverse the inheritance map once: parent → the protocols refining it.
         var protocolChildren: [String: Set<String>] = [:]
-        for (child, parents) in protocolInheritsFrom {
+        // Ordered by key so the walk is a fact about the code — see `AggregationDeterminismTests`.
+        for (child, parents) in protocolInheritsFrom.sorted(by: { $0.key < $1.key }) {
             for parent in parents {
                 protocolChildren[parent, default: []].insert(child)
             }

--- a/Tests/CoreTests/CrossFileAnalysis/AggregationDeterminismTests.swift
+++ b/Tests/CoreTests/CrossFileAnalysis/AggregationDeterminismTests.swift
@@ -1,0 +1,183 @@
+import Foundation
+import SwiftParser
+import SwiftSyntax
+import Testing
+
+/// **Every walk inside a `finalizeAnalysis` has a stated order.**
+///
+/// This is the law `DetectorRobustnessPropertyTests.detection_isDeterministic` claimed and could
+/// not reach (SwiftProjectLint#203). That one calls `detectPatterns(in:filePath:)`, which never
+/// invokes `finalizeAnalysis`, and it compares two calls **in one process** — where Swift's hash
+/// seed is fixed, so a rule whose output depends on the seed is perfectly self-consistent within a
+/// run and differs between runs. Calling the detector twice cannot vary the thing that varies.
+///
+/// ## Why this is a source check rather than a run
+///
+/// The two runtime shapes the issue proposed both fail for the same reason: the variable is the
+/// per-process hash seed, and no assertion made inside one process can move it. Shuffling the file
+/// order reaches insertion-order dependence and not this; spawning the binary twice reaches it only
+/// when the corpus happens to contain a colliding pair, and even then it is a coin flip per run —
+/// #202's own kill rates were 5/10 and 6/10 for exactly that reason. A test whose subject is a hash
+/// seed cannot be a decision on one run. A test about the *source* can.
+///
+/// ## What the survey found, which is why the rule is blanket rather than targeted
+///
+/// All 29 cross-file visitors were read. One had a live defect —
+/// `PrimitiveNamedForDomainType` resolved a case-insensitive collision last-write-wins from a
+/// `Dictionary` walk, naming `UserId` in 8 of 12 processes and `UserID` in the other 4. Five had
+/// already handled the hazard by hand, each with its own comment: `CircularDependency` (#202),
+/// `ParallelListDrift`, `PrimitiveBypassingDomainType`, `HoistableConformerMember`,
+/// `MissingEquatableOnStateType`. The rest were safe, but safe *by argument* — each one needed a
+/// reader to establish that its unordered walk could not leak.
+///
+/// One author in six got that argument wrong. This check removes the argument: the walk has an
+/// order, so nothing downstream of it has to be reasoned about. The cost is nil — these maps hold
+/// tens of entries — and the shape it forecloses is real and recurring: state carried across the
+/// loop, like `CircularDependency`'s `reported` set, makes the *first* iteration decide which of
+/// two equally-valid findings is suppressed.
+///
+/// ## What it does not claim
+///
+/// It reads the sequence expression of each `for`-in and nothing else. A `Dictionary` reached
+/// through a local alias, through a function call, or through `Dictionary(grouping:)` assigned to a
+/// `let` is outside it — so this narrows the surface rather than closing it, and the doc comments
+/// on the five hand-handled visitors are still the record for why their *selections* are stable.
+@Suite("Cross-file aggregation walks are ordered")
+struct AggregationDeterminismTests {
+
+    // MARK: - Fixtures
+
+    private static var packagesDirectory: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // CrossFileAnalysis
+            .deletingLastPathComponent()   // CoreTests
+            .deletingLastPathComponent()   // Tests
+            .deletingLastPathComponent()   // repository root
+            .appendingPathComponent("Packages")
+    }
+
+    /// Every Swift file under `Packages/` that declares a `finalizeAnalysis`, excluding the
+    /// checkouts SwiftPM drops inside those package directories.
+    private static func aggregatingSources() throws -> [(url: URL, text: String)] {
+        let enumerator = FileManager.default.enumerator(
+            at: packagesDirectory, includingPropertiesForKeys: nil
+        )
+        var found: [(URL, String)] = []
+        while let url = enumerator?.nextObject() as? URL {
+            guard url.pathExtension == "swift" else { continue }
+            guard url.path.contains("/.build/") == false else { continue }
+            let text = try String(contentsOf: url, encoding: .utf8)
+            guard text.contains("func finalizeAnalysis") else { continue }
+            found.append((url, text))
+        }
+        return found.sorted { $0.0.path < $1.0.path }
+    }
+
+    // MARK: - The law
+
+    @Test("no finalizeAnalysis walks a Dictionary or Set without ordering it")
+    func aggregationWalksAreOrdered() throws {
+        let sources = try Self.aggregatingSources()
+        // A guard on the guard: a path typo would make every assertion below pass on nothing.
+        #expect(sources.count >= 25)
+
+        var offenders: [String] = []
+        for (url, text) in sources {
+            let tree = Parser.parse(source: text)
+            let finder = UnorderedWalkFinder(unordered: UnorderedNames.declared(in: tree))
+            finder.walk(tree)
+            for walk in finder.unorderedWalks {
+                offenders.append("\(url.lastPathComponent): for … in \(walk)")
+            }
+        }
+
+        #expect(offenders.isEmpty, "\(offenders.joined(separator: "\n"))")
+    }
+}
+
+// MARK: - Syntax
+
+/// The names declared as a `Dictionary` or `Set` anywhere in a file.
+///
+/// File-wide rather than scope-aware, and deliberately so: a visitor's aggregation state is a
+/// stored property of the type, and the locals a `finalizeAnalysis` builds are named distinctly
+/// from it. Over-collecting costs a `.sorted()` nobody needed; under-collecting costs the finding.
+private enum UnorderedNames {
+
+    static func declared(in tree: SourceFileSyntax) -> Set<String> {
+        let collector = Collector(viewMode: .sourceAccurate)
+        collector.walk(tree)
+        return collector.names
+    }
+
+    private final class Collector: SyntaxVisitor {
+        var names: Set<String> = []
+
+        override func visit(_ node: PatternBindingSyntax) -> SyntaxVisitorContinueKind {
+            guard let name = node.pattern.as(IdentifierPatternSyntax.self)?.identifier.text
+            else { return .visitChildren }
+            if let annotation = node.typeAnnotation?.type, Self.isUnordered(annotation) {
+                names.insert(name)
+            }
+            return .visitChildren
+        }
+
+        /// `[K: V]` and `Set<E>`, in either spelling. An array literal type is ordered and a
+        /// `Dictionary`'s *values* are not, which is why `[V]` is absent here.
+        private static func isUnordered(_ type: TypeSyntax) -> Bool {
+            if type.is(DictionaryTypeSyntax.self) { return true }
+            if let identifier = type.as(IdentifierTypeSyntax.self) {
+                return identifier.name.text == "Set" || identifier.name.text == "Dictionary"
+            }
+            return false
+        }
+    }
+}
+
+/// The `for`-in sequences inside a `finalizeAnalysis` that are rooted at an unordered name and do
+/// not go through `sorted`.
+private final class UnorderedWalkFinder: SyntaxVisitor {
+    private let unordered: Set<String>
+    private var depth = 0
+    var unorderedWalks: [String] = []
+
+    init(unordered: Set<String>) {
+        self.unordered = unordered
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+        if node.name.text == "finalizeAnalysis" { depth += 1 }
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: FunctionDeclSyntax) {
+        if node.name.text == "finalizeAnalysis" { depth -= 1 }
+    }
+
+    override func visit(_ node: ForStmtSyntax) -> SyntaxVisitorContinueKind {
+        guard depth > 0 else { return .visitChildren }
+        let sequence = node.sequence
+        let text = sequence.trimmedDescription
+        if let root = Self.rootName(of: sequence), unordered.contains(root),
+           text.contains("sorted") == false {
+            unorderedWalks.append(text)
+        }
+        return .visitChildren
+    }
+
+    /// The bare identifier a member chain is rooted at — `groups` for `groups.values`.
+    ///
+    /// A call stops the walk: `candidatePairs()` is a function, and what it returns is its own
+    /// business (`ParallelListDrift`'s sorts before returning). Subscripts stop it too, because
+    /// `typeReferences[typeA] ?? []` yields the *value*, which is an array.
+    private static func rootName(of expression: ExprSyntax) -> String? {
+        if let reference = expression.as(DeclReferenceExprSyntax.self) {
+            return reference.baseName.text
+        }
+        if let member = expression.as(MemberAccessExprSyntax.self) {
+            return member.base.flatMap(rootName(of:))
+        }
+        return nil
+    }
+}

--- a/Tests/CoreTests/CrossFileAnalysis/PrimitiveNamedForDomainTypeVisitorTests.swift
+++ b/Tests/CoreTests/CrossFileAnalysis/PrimitiveNamedForDomainTypeVisitorTests.swift
@@ -39,6 +39,42 @@ struct PrimitiveNamedForDomainTypeVisitorTests {
         #expect(issue.message.contains("idempotencyKey"))
     }
 
+    /// **Two wrapper names differing only in case are two types, and the finding used to name
+    /// whichever the hash seed offered last** — `UserId` in 8 of 12 processes and `UserID` in the
+    /// other 4, on this exact source (SwiftProjectLint#203). A single run cannot catch that, so
+    /// this test does not try: it asserts the answer the rule now owes on *every* run, which is
+    /// that both spellings are named and the seed takes the smaller.
+    @Test
+    func namesEveryWrapperSpellingWhenTwoDifferOnlyInCase() throws {
+        let issues = analyze(files: [
+            "A.swift": "struct UserID { let value: String }",
+            "B.swift": "struct UserId { let value: String }",
+            "C.swift": "struct Session { let userId: String }"
+        ])
+
+        #expect(issues.count == 1)
+        let issue = try #require(issues.first)
+        #expect(issue.message.contains("'UserID' / 'UserId'"))
+        #expect(issue.suggestion?.contains("'UserID' / 'UserId'") == true)
+        // A manifest names one subject, and it is the smaller name rather than the hash's pick.
+        #expect(issue.symbol == "UserID")
+    }
+
+    /// The ordinary case still reads as one name — the candidate list is a list of one, and the
+    /// message must not start rendering `'UserID' / ` for it.
+    @Test
+    func aSingleWrapperIsStillNamedAlone() throws {
+        let issues = analyze(files: [
+            "ID.swift": "struct UserID { let raw: UUID }",
+            "Session.swift": "struct Session { let userID: UUID }"
+        ])
+
+        let issue = try #require(issues.first)
+        #expect(issue.message.contains("'UserID',"))
+        #expect(issue.message.contains("/") == false)
+        #expect(issue.symbol == "UserID")
+    }
+
     /// A stored property named for the wrapper, cross-file, typed as the carrier.
     @Test
     func propertyNamedForWrapperFlags() {

--- a/Tests/CoreTests/SourceSyntaxPattern/DetectorRobustnessPropertyTests.swift
+++ b/Tests/CoreTests/SourceSyntaxPattern/DetectorRobustnessPropertyTests.swift
@@ -72,8 +72,21 @@ private enum RobustnessFixtures {
 /// must satisfy for *any* input, which fixed-snippet example tests can't span.
 ///
 /// 1. **Determinism** — analyzing the same source twice yields identical issues,
-///    in the same order. Guards nondeterministic aggregation (set/dict iteration
-///    leaking into output) and AST-cache staleness.
+///    in the same order. Guards a detector that carries state between runs: a
+///    visitor that accumulates instead of resetting, or a stale AST cache.
+///
+///    **It does not guard nondeterministic aggregation, which its own wording
+///    used to claim** (*"set/dict iteration leaking into output"*). Two reasons,
+///    and the second holds however far the law is widened. It calls
+///    `detectPatterns(in:filePath:)`, which never reaches `finalizeAnalysis()`,
+///    so every cross-file rule is outside it. And both halves run in one
+///    process, where Swift's hash seed is fixed — a rule whose output depends on
+///    that seed is perfectly self-consistent within a run and differs between
+///    runs, which is exactly how SwiftProjectLint#202 behaved. Calling the
+///    detector twice cannot vary the thing that varies.
+///
+///    `AggregationDeterminismTests` covers that class instead, and covers it
+///    statically, because no in-process comparison can.
 /// 2. **In-bounds locations** — every issue's line number lies within the file
 ///    (`1 ... lineCount`). Guards off-by-one / past-EOF location reporting.
 /// 3. **No crash on malformed input** — truncated or adversarial source must


### PR DESCRIPTION
Closes #203. Three commits: a live defect, the check that makes the class a decision, and the law whose claim was wider than what it checked.

## The measurement #203 asked for first

> *"The fix is a test-architecture change across every cross-file registrar, not a tweak to one law, and it deserves a measurement of how many rules are actually exposed before a shape is chosen."*

**Instrument validated before it was trusted.** Ten runs of the CLI over `MacCloud_client_iOS` with #202's fix reverted gave **4 distinct answers**; with the fix in place, 1. So separate-process re-runs do reach this class.

**Run against the current tree — 8 processes × 4 repos — nothing varies.** So the empirical instrument finds zero today, which means the exposure question has to be answered from the sources.

All 29 cross-file visitors were read:

| | count |
|---|---|
| live defect | **1** |
| already handled by hand, each with its own comment | 5 |
| safe, but safe *by argument* — an unordered walk a reader had to clear | 8 |
| ordered or array-walking by construction | 15 |

The five that got it right: `CircularDependency` (#202), `ParallelListDrift`, `PrimitiveBypassingDomainType`, `HoistableConformerMember`, `MissingEquatableOnStateType`.

**And one fact that narrows the whole problem: iteration order cannot reach the report at all.** `LintIssue.precedes` is a total order over every field any formatter renders, applied once at the end of analysis. So the residual class is not *ordering*, it is **selection** — a rule picking one representative out of an unordered collection. That is what #202 was, and it is what the live defect is.

## 1. The live defect

`PrimitiveNamedForDomainType` matches property names against wrapper type names case-insensitively by design. Its index was built by walking a `Dictionary` and assigning into a map keyed on the lowercased name:

```swift
for (name, carrier) in wrappers { byLoweredName[name.lowercased()] = (name, carrier) }
```

`UserID` and `UserId` are two types that collide on that key. Last write wins, and the walk deciding which is last is ordered by the per-process hash seed. **Measured over `UserID` / `UserId` / `let userId: String`, twelve processes on identical source: `UserId` eight times, `UserID` four.** The choice reaches the message, the suggestion, and `symbol` — which the `pbt-seeds` manifest carries into `swift-infer`.

Sorting the walk would make it a decision and still be the wrong *shape* of answer: neither spelling is more the domain type, and advising `UserID` when the reader meant `UserId` is worse than saying both exist. So the index keeps every candidate and the message names them all — which is what the sibling rule in the same directory already does (`PrimitiveBypassingDomainType`: names them all, seed takes the smallest, with a comment saying picking deterministically beats picking by hash). **The sibling had the answer; this rule had not been asked.**

## 2. `AggregationDeterminismTests`

A source check, because the variable is a hash seed and nothing inside one process can move it. #203's two runtime proposals both fail for that reason — shuffling file order reaches insertion-order dependence and not this, and spawning the binary twice is a coin flip per run (#202's own kill rates were 5/10 and 6/10).

It asserts no `finalizeAnalysis` walks a Dictionary or Set without ordering it. Eight walks did; they are ordered by key now.

**Blanket rather than targeted, and the survey is why.** Those eight were safe — but safe by an argument a reader had to make each time, and one author in six made it wrong. The shape it forecloses is recurring: state carried across the loop, like `CircularDependency`'s `reported` set, lets the *first* iteration decide which of two equally-valid findings is suppressed.

## What a reviewer should scrutinise

- **Whether blanket is over-reach.** The eight walks were not broken. The claim is that "ordered" is cheaper to maintain than "safe because of X", on maps holding tens of entries. Disagree with that and the check should be narrowed to selection patterns only.
- **What the check does not catch.** It reads the sequence expression of each `for`-in and nothing else. A Dictionary reached through a local alias, a function call, or a `Dictionary(grouping:)` bound to a `let` is outside it — `HoistableSequenceOperation` is exactly that and is *not* flagged. It narrows the surface; it does not close it. The doc comments on the five hand-handled visitors remain the record for why their **selections** are stable.
- **`FieldSignature.precedes` is a static, not a `Comparable` conformance.** Nothing about these signatures is ordered in the domain.
- **The spelling.** `dict.sorted(by: { $0.key < $1.key })` rather than `dict.keys.sorted()` plus a lookup — the second form added a `guard` per site and pushed two visitors over the cyclomatic-complexity limit for nothing. That first attempt is recorded in the commit message.
- **The law that was narrowed, not deleted.** `detection_isDeterministic` still guards a detector carrying state between runs. Only the sentence claiming aggregation is gone.

## Verification

- `swift test` — 3,774 tests in 450 suites, green. The new tests fail on `main`.
- `swiftlint` on the changed files — exit 0, no new warnings.
- Corpus, 13 repos: **9,869 findings before and after.** Two message-level differences, both accounted for: a suppression directive retired in another repository, and one new `Pure Function Property-Test Candidate` — `FieldSignature.precedes`, which this project's own rule is right about. `Primitive Named For Its Domain Type` fires 0 times across the corpus, so its defect was latent there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015C8BjaXXCA5DGkQCARErGL