### PR TITLE
extension String extends a value type, and the analyzer knew

### DIFF
--- a/Docs/rules/pure-function-candidate.md
+++ b/Docs/rules/pure-function-candidate.md
@@ -99,6 +99,21 @@ tied to a parameter, a local, or a type is assumed to be instance state — even
 Under-suggesting costs a missed test; over-suggesting costs a generated test that runs impure code
 and lies about the result.
 
+**A stdlib carrier is a value type, and the analyzer says so.** `extension String { … }` extends a
+`struct`, so reading the string it extends is a read of a value and the table above applies. This
+used to be decided from the set of *project* declarations alone, so every stdlib carrier answered
+"not a value type" and the reference-type path refused any member touching `self`. Measured before
+the fix: **0 of 88** parameterless members of extensions on foreign carriers were seeds, across 23
+repositories, against 51.4% for extensions on carriers the project declares. Restoring the answer
+recovered **7 seeds of 4,947, none lost** — mostly `switch self` over `extension Optional where
+Wrapped == …`, plus `String.globPatternToRegex()`.
+
+Only `self` *as a whole value* is admitted. A member reached through it — `self.count` on a
+`String` — still refuses, because the project declares no stored properties for a type it does not
+own, and admitting an arbitrary member of a foreign type would be a general relaxation rather than
+an answer the analyzer already had. A carrier that is neither a project declaration nor a known
+stdlib value type — `extension NSTextView` — refuses as before.
+
 **Swift 5.7's shorthand optional binding is a read, not a binding.** `if let tagFilter` — with no
 `=` — introduces nothing; it takes its value from whatever `tagFilter` already meant. So the name is
 resolved rather than assumed local, and the table above applies to it: a shorthand-bound stored

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/PropertyTestCandidacy.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/PropertyTestCandidacy.swift
@@ -407,12 +407,20 @@ public enum PropertyTestCandidacy {
             if let extensionDecl = current.as(ExtensionDeclSyntax.self) {
                 // The extended type's kind is not in the extension's syntax; the cross-file index
                 // is what says whether `extension OrderedSet` extends a value type.
+                //
+                // A stdlib carrier answers the same question without the index. `knownValueTypes`
+                // holds *project* declarations, so `extension String` used to report "not a value
+                // type" — and the bare-`self` branch then refused every member that reads the
+                // string it extends. That is not conservatism about something unknown; `String`
+                // is a struct, and the analyzer was answering a question it had the answer to
+                // (SwiftProjectLint#214).
                 let extendedBase = baseTypeName(extensionDecl.extendedType)
                     ?? extensionDecl.extendedType.trimmedDescription
                 return container(
                     named: extensionDecl.extendedType.trimmedDescription,
                     isActor: false,
-                    isValueType: knownValueTypes.contains(extendedBase),
+                    isValueType: knownValueTypes.contains(extendedBase)
+                        || StdlibTypeNames.valueTypes.contains(extendedBase),
                     from: function
                 )
             }

--- a/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/StdlibTypeNames.swift
+++ b/Packages/SwiftProjectLintVisitors/Sources/SwiftProjectLintVisitors/StdlibTypeNames.swift
@@ -35,4 +35,16 @@ enum StdlibTypeNames {
 
     /// Every stdlib name whose values a test can compare.
     static let equatable: Set<String> = valueLeaves.union(equatableContainers)
+
+    /// The names above that are `struct`s or `enum`s — types whose `self` **is** the value.
+    ///
+    /// A third question, close enough to the other two to live here and different enough to be
+    /// stated: *"when an `extension` names a type this project does not declare, is reading `self`
+    /// a read of a value or a reach into a shared object?"* `PropertyTestCandidacy` asked it of
+    /// `knownValueTypes`, which holds project declarations only, so every stdlib carrier answered
+    /// "no" and a member reading bare `self` was refused (SwiftProjectLint#214).
+    ///
+    /// `Optional` is here and not above because it is not a *leaf* — its equatability is its
+    /// wrapped type's — but it is an `enum`, which is the only thing this question asks.
+    static let valueTypes: Set<String> = equatable.union(["Optional"])
 }

--- a/Tests/CoreTests/Testability/ForeignExtensionCarrierTests.swift
+++ b/Tests/CoreTests/Testability/ForeignExtensionCarrierTests.swift
@@ -1,0 +1,181 @@
+@testable import Core
+import Foundation
+import SwiftParser
+import SwiftProjectLintVisitors
+import SwiftSyntax
+import Testing
+
+/// **`extension String` extends a value type, and the analyzer had the answer all along**
+/// (SwiftProjectLint#214).
+///
+/// `enclosingTypeContainer` decided `isValueType` from `knownValueTypes`, which holds *project*
+/// declarations — so a stdlib carrier answered "not a value type", and `SelfAccessAnalyzer`'s
+/// bare-`self` branch took the reference-type path and refused every member that reads the string
+/// it extends. That is not conservatism about something unknown: `String` is a struct.
+///
+/// Measured before the fix: **0 of 88** parameterless foreign-extension members were seeded across
+/// 23 repositories, against 51.4% for extensions on project-declared carriers. The issue
+/// recommended documenting rather than fixing, on the grounds that only ~12 of the population were
+/// real candidates. Reusing `StdlibTypeNames` recovers **7** of them for one condition, which is
+/// what reversed the recommendation.
+///
+/// The A/B/C fixture below is the issue's own, and its point is causal rather than statistical: A
+/// and B differ only in the carrier, A and C only in the relationship to `self`.
+@Suite("A foreign extension on a stdlib value type")
+struct ForeignExtensionCarrierTests {
+
+    private func shape(_ source: String, method: String) -> PropertyTestShape? {
+        let tree = Parser.parse(source: source)
+        let finder = FunctionFinder(viewMode: .sourceAccurate)
+        finder.walk(tree)
+        guard let declaration = finder.found[method] else { return nil }
+        return PropertyTestCandidacy.shape(
+            of: declaration,
+            knownEquatableTypes: ["String", "Int", "Bool"],
+            knownValueTypes: ["Markup"]
+        )
+    }
+
+    // MARK: - The issue's A/B/C fixture
+
+    /// **Arm A.** The same escaping body, on a carrier the project does not declare, reading the
+    /// value it extends. This is the arm that was dropped.
+    @Test func aMemberOfAStdlibExtensionReadingSelfIsACandidate() {
+        let source = """
+        extension String {
+            func escaped() -> String {
+                var out = ""
+                for character in self { out.append(character == "<" ? "_" : character) }
+                return out
+            }
+        }
+        """
+        #expect(shape(source, method: "escaped") == .ofSelfAndInputs)
+    }
+
+    /// **Arm B.** The same body on a carrier the project declares. Already correct, and it is what
+    /// arm A now agrees with.
+    @Test func theSameBodyOnAProjectStructIsACandidate() {
+        let source = """
+        struct Markup {
+            let text: String
+            func escaped() -> String {
+                var out = ""
+                for character in text { out.append(character == "<" ? "_" : character) }
+                return out
+            }
+        }
+        """
+        #expect(shape(source, method: "escaped") == .ofSelfAndInputs)
+    }
+
+    /// **Arm C.** The same carrier, with the input taken as a parameter instead of read from
+    /// `self`. Already correct — and before the fix it was the *only* foreign-extension shape that
+    /// survived, which is why the corpus measured 0 of 88 for the parameterless ones.
+    @Test func aStaticMemberTakingItsInputIsACandidate() {
+        let source = """
+        extension String {
+            static func escaped(_ text: String) -> String {
+                var out = ""
+                for character in text { out.append(character == "<" ? "_" : character) }
+                return out
+            }
+        }
+        """
+        #expect(shape(source, method: "escaped") == .ofInputs)
+    }
+
+    // MARK: - The conservatism that is kept
+
+    /// A carrier that is neither a project declaration nor a known stdlib value type is still
+    /// refused. `NSTextView` is a class, reading `self` reaches a shared object, and nothing in
+    /// this change was meant to reach it.
+    @Test func anExtensionOnAnUnknownForeignCarrierStillRefuses() {
+        let source = """
+        extension NSTextView {
+            func summary() -> String { describe(self) }
+        }
+        """
+        #expect(shape(source, method: "summary") == nil)
+    }
+
+    /// **Only `self` as a whole value is admitted, and the fix is exactly that one condition.**
+    /// A member *of* the carrier is still unresolvable — the project declares no stored properties
+    /// for `String` — so `self.count` refuses. That is the remaining half of #214's mechanism, and
+    /// it is deliberately left in place: admitting an arbitrary member of a foreign type would be
+    /// a general relaxation rather than answering a question the analyzer already knew.
+    @Test func aMemberReadThroughSelfOnAStdlibCarrierStillRefuses() {
+        let source = """
+        extension String {
+            func widened() -> Int { self.count + 1 }
+        }
+        """
+        #expect(shape(source, method: "widened") == nil)
+    }
+
+    // MARK: - Computed properties, which is where most of the recovery landed
+
+    /// `Optional` is a value type too, and `switch self` over it is the corpus's most common shape
+    /// of recovery — four of the seven seeds this change restored are computed properties on
+    /// `extension Optional where Wrapped == …`.
+    ///
+    /// Routed through `candidate(of:…)` rather than `shape(of:…)`: a computed property is not a
+    /// `FunctionDeclSyntax`, and an earlier version of this test asked the method finder for
+    /// `strength`, got nothing, and passed by asserting `nil` — the answer it would have given
+    /// before the fix, for a reason unrelated to it.
+    @Test func aComputedPropertyOnAnOptionalExtensionIsACandidate() throws {
+        let source = """
+        extension Optional where Wrapped == Int {
+            var strength: Int {
+                switch self {
+                case let .some(value): return value
+                case .none: return 0
+                }
+            }
+        }
+        """
+        let candidate = try #require(self.candidate(source, property: "strength"))
+        #expect(candidate.shape == .ofSelfAndInputs)
+    }
+
+    /// The control for the one above, on a carrier that is still unknown.
+    @Test func aComputedPropertyOnAnUnknownForeignCarrierStillRefuses() {
+        let source = """
+        extension NSTextView {
+            var summary: String { describe(self) }
+        }
+        """
+        #expect(candidate(source, property: "summary") == nil)
+    }
+
+    private func candidate(_ source: String, property: String) -> PropertyTestCandidate? {
+        let tree = Parser.parse(source: source)
+        let finder = PropertyFinder(viewMode: .sourceAccurate)
+        finder.walk(tree)
+        guard let declaration = finder.found[property] else { return nil }
+        return PropertyTestCandidacy.candidate(
+            of: declaration,
+            knownEquatableTypes: ["String", "Int", "Bool"],
+            knownValueTypes: ["Markup"]
+        )
+    }
+
+    final class PropertyFinder: SyntaxVisitor {
+        var found: [String: VariableDeclSyntax] = [:]
+        override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+            guard let binding = PropertyTestCandidacy.soleBinding(of: node),
+                  let name = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text
+            else { return .visitChildren }
+            found[name] = node
+            return .visitChildren
+        }
+    }
+
+    final class FunctionFinder: SyntaxVisitor {
+        var found: [String: FunctionDeclSyntax] = [:]
+        override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+            found[node.name.text] = node
+            return .visitChildren
+        }
+    }
+}


### PR DESCRIPTION
Closes #214 — by fixing it rather than documenting it. The issue recommended the opposite, and the measurement below is why.

## The defect

`PropertyTestCandidacy.enclosingTypeContainer` decided `isValueType` from `knownValueTypes`, which holds **project** declarations. So `extension String` answered "not a value type", `SelfAccessAnalyzer`'s bare-`self` branch took the reference-type path, and every member reading the string it extends was refused.

That is not conservatism about something unknown. `String` is a struct, and the question — *is `self` a value, or a reach into a shared object?* — already had an answer in `StdlibTypeNames`, which two other rules consult for two neighbouring questions. It gains a third set naming what it already lists.

## Why the recommendation flipped

#214 measured the **gap**: 0 of 88 parameterless foreign-extension members seeded across 23 repositories, against 51.4% for extensions on project-declared carriers. It then declined, on the grounds that only ~12 of the 134-member population were real candidates and that closing it would mean "teaching the scanner a stdlib type table".

It measured the fix instead. There is no new table — `StdlibTypeNames` already holds the names — and across 14 repositories:

**4,947 seeds before, 4,954 after. Seven recovered, none lost.**

| repo | recovered |
|---|---|
| SwiftEffectInference | `Substring.trimmingLeadingWhitespace()` |
| SwiftEffectInference | `Substring.firstWord()` |
| SwiftLintRuleStudioTeam | `Optional<RuleSeverity>.strength` |
| SwiftLintRuleStudioTeam | `Optional<RuleSeverity>.auditLabel` |
| SwiftUMLStudio | `String.globPatternToRegex()` |
| SwiftUMLStudio | `Optional<ExtensionVisualization>.safelyUnwrap` |
| SwiftUMLStudio | `Optional<ElementAccessibility>.indicator` |

All seven were read by hand and every one is a pure function of its carrier. `globPatternToRegex` is the one #214 called *"the best of them"*; `trimmingLeadingWhitespace` is `var slice = self` followed by a loop — arm A of the issue's own A/B/C fixture, verbatim. **Seven of about twelve, for one condition.**

This is also the counter-argument #214 stated against itself: an extension on `String` or `Optional` is the *easiest* possible property subject, and the gate that could not see them was asking whether the project declared the carrier — unrelated to anything that makes it easy.

## What a reviewer should scrutinise

- **Only `self` as a whole value is admitted.** `self.count` on a `String` still refuses, because the project declares no stored properties for a type it does not own. That is the other half of #214's mechanism and it stays deliberately: admitting an arbitrary member of a foreign type would be a general relaxation rather than an answer the analyzer already had. Pinned by `aMemberReadThroughSelfOnAStdlibCarrierStillRefuses`.
- **`extension NSTextView` refuses as before** — a carrier that is neither a project declaration nor a known stdlib value type. Pinned twice, once per entry point.
- **`Optional` goes in `valueTypes` and not `valueLeaves`.** It is not a leaf (its equatability is its wrapped type's) but it is an `enum`, which is the only thing this question asks. Four of the seven recoveries are `extension Optional where Wrapped == …`, so it carries most of the payoff.
- **Whether `valueTypes` should include the containers.** It inherits `Array`/`Set`/`Dictionary` from `equatable`. Reading `self` bare on one of those is still a value read even when the elements are references — the analyzer only runs on non-mutating methods and member reads still refuse — but that is the arm I'd argue with first.

## Verification

- `swift test` — 3,788 tests in 452 suites, green.
- **Both new-behaviour tests fail against the unfixed analyzer, and the five controls pass in both.** Checked by stashing the source change and re-running.
- `swiftlint` on the changed files — exit 0.
- One test was written, found vacuous, and rewritten rather than kept: it asked the *method* finder for a computed property, got nothing, and passed by asserting `nil` — the answer it would have given before the fix, for a reason unrelated to it. Computed properties reach candidacy through `candidate(of:)`, and the test goes there now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015C8BjaXXCA5DGkQCARErGL